### PR TITLE
Phase 1: Gitea API client setup - install gitea-js + authenticated factory wrapper

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "@types/dompurify": "^3.2.0",
         "diff": "^8.0.3",
         "dompurify": "^3.3.3",
+        "gitea-js": "1.23.0",
         "lucide-react": "^0.574.0",
         "react": "^19",
         "react-dom": "^19",
@@ -198,6 +199,8 @@
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
+
+    "gitea-js": ["gitea-js@1.23.0", "", {}, "sha512-f4+UPoWgDetZeZ+Awo5iI1nVdO5bjxA8+2QCeLo3oYWUYxKyzLfXgbW1EPD635wb8hLgS0DRBu5XhtiuYKEeUA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/dompurify": "^3.2.0",
     "diff": "^8.0.3",
     "dompurify": "^3.3.3",
+    "gitea-js": "1.23.0",
     "lucide-react": "^0.574.0",
     "react": "^19",
     "react-dom": "^19",

--- a/src/services/gitea/client.test.ts
+++ b/src/services/gitea/client.test.ts
@@ -1,55 +1,44 @@
 import { afterEach, expect, mock, test } from 'bun:test';
 
-import { createGiteaClient, GiteaApiError } from './client';
+const mockedClient = {
+  repos: {},
+  issues: {},
+  user: {},
+  orgs: {},
+};
 
-const originalFetch = globalThis.fetch;
+const giteaApiMock = mock(() => mockedClient);
+
+mock.module('gitea-js', () => ({
+  giteaApi: giteaApiMock,
+}));
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  giteaApiMock.mockClear();
 });
 
-test('attaches the Gitea authorization header', async () => {
-  const fetchMock = mock(
-    async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-      const headers = new Headers(init?.headers);
-      expect(headers.get('Authorization')).toBe('token secret-token');
-      return new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    },
-  );
-
-  globalThis.fetch = fetchMock as typeof fetch;
-
-  const client = createGiteaClient('https://gitea.example.com/', 'secret-token');
-  const result = await client.get<{ ok: boolean }>('/api/v1/user');
-
-  expect(result).toEqual({ ok: true });
-  expect(fetchMock).toHaveBeenCalledTimes(1);
-  expect(fetchMock.mock.calls[0]?.[0]).toBe('https://gitea.example.com/api/v1/user');
-});
-
-test('throws a typed GiteaApiError for non-2xx responses', async () => {
-  const fetchMock = mock(async (): Promise<Response> => {
-    return new Response(JSON.stringify({ message: 'repository not found' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  });
-
-  globalThis.fetch = fetchMock as typeof fetch;
+test('creates a thin gitea-js client with the expected namespaces', async () => {
+  const { createGiteaClient } = await import('./client');
 
   const client = createGiteaClient('https://gitea.example.com', 'secret-token');
 
-  try {
-    await client.get('/api/v1/repos/example/missing');
-    throw new Error('Expected request to fail');
-  } catch (error: unknown) {
-    expect(error).toBeInstanceOf(GiteaApiError);
+  expect(giteaApiMock).toHaveBeenCalledTimes(1);
+  expect(giteaApiMock).toHaveBeenCalledWith('https://gitea.example.com', { token: 'secret-token' });
+  expect(client).toBe(mockedClient);
+  expect(client.repos).toBeDefined();
+  expect(client.issues).toBeDefined();
+  expect(client.user).toBeDefined();
+  expect(client.orgs).toBeDefined();
+});
 
-    const apiError = error as GiteaApiError;
-    expect(apiError.status).toBe(404);
-    expect(apiError.message).toBe('repository not found');
-  }
+test('exposes a typed GiteaApiError status property', async () => {
+  const { GiteaApiError } = await import('./client');
+
+  const error = new GiteaApiError(404, 'repository not found');
+
+  expect(error).toBeInstanceOf(Error);
+  expect(error).toBeInstanceOf(GiteaApiError);
+  expect(error.name).toBe('GiteaApiError');
+  expect(error.status).toBe(404);
+  expect(error.message).toBe('repository not found');
 });

--- a/src/services/gitea/client.ts
+++ b/src/services/gitea/client.ts
@@ -1,131 +1,14 @@
-export class GiteaApiError extends Error {
-  public readonly status: number;
+import { giteaApi } from 'gitea-js';
 
-  constructor(status: number, message: string) {
+export function createGiteaClient(baseUrl: string, token: string) {
+  return giteaApi(baseUrl, { token });
+}
+
+export type GiteaClient = ReturnType<typeof createGiteaClient>;
+
+export class GiteaApiError extends Error {
+  constructor(public status: number, message: string) {
     super(message);
     this.name = 'GiteaApiError';
-    this.status = status;
   }
-}
-
-type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE';
-
-type JsonObject = Record<string, unknown>;
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, '');
-}
-
-function joinUrl(baseUrl: string, path: string): string {
-  if (path.startsWith('http://') || path.startsWith('https://')) {
-    return path;
-  }
-
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  return `${baseUrl}${normalizedPath}`;
-}
-
-function encodeBody(body: unknown): BodyInit | undefined {
-  if (body === undefined) {
-    return undefined;
-  }
-
-  return JSON.stringify(body);
-}
-
-async function readErrorMessage(response: Response): Promise<string> {
-  const fallbackMessage = response.statusText.trim() || 'Request failed';
-  const rawBody = await response.text();
-
-  if (!rawBody.trim()) {
-    return fallbackMessage;
-  }
-
-  try {
-    const parsed: unknown = JSON.parse(rawBody);
-
-    if (isJsonObject(parsed)) {
-      const message = parsed.message;
-      if (typeof message === 'string' && message.trim()) {
-        return message;
-      }
-
-      const error = parsed.error;
-      if (typeof error === 'string' && error.trim()) {
-        return error;
-      }
-    }
-  } catch {
-    // Ignore parse failures and fall back to the raw text below.
-  }
-
-  return rawBody.trim() || fallbackMessage;
-}
-
-export class GiteaClient {
-  private readonly baseUrl: string;
-  private readonly token: string;
-
-  constructor(baseUrl: string, token: string) {
-    this.baseUrl = normalizeBaseUrl(baseUrl);
-    this.token = token;
-  }
-
-  public get<T>(path: string): Promise<T> {
-    return this.request<T>('GET', path);
-  }
-
-  public post<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>('POST', path, body);
-  }
-
-  public patch<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>('PATCH', path, body);
-  }
-
-  public delete<T>(path: string): Promise<T> {
-    return this.request<T>('DELETE', path);
-  }
-
-  private async request<T>(method: HttpMethod, path: string, body?: unknown): Promise<T> {
-    const headers = new Headers({
-      Authorization: `token ${this.token}`,
-      Accept: 'application/json',
-    });
-
-    const encodedBody = encodeBody(body);
-    if (encodedBody !== undefined) {
-      headers.set('Content-Type', 'application/json');
-    }
-
-    const response = await fetch(joinUrl(this.baseUrl, path), {
-      method,
-      headers,
-      body: encodedBody,
-    });
-
-    if (!response.ok) {
-      const message = await readErrorMessage(response);
-      throw new GiteaApiError(response.status, message);
-    }
-
-    if (response.status === 204) {
-      return undefined as T;
-    }
-
-    const contentType = response.headers.get('content-type') ?? '';
-    if (contentType.includes('application/json')) {
-      return (await response.json()) as T;
-    }
-
-    return (await response.text()) as T;
-  }
-}
-
-export function createGiteaClient(baseUrl: string, token: string): GiteaClient {
-  return new GiteaClient(baseUrl, token);
 }


### PR DESCRIPTION
Implements the updated Issue #9 by replacing the custom fetch-based client with a thin authenticated `gitea-js` wrapper.

## What changed
- Added `gitea-js@1.23.0` to `package.json`
- Replaced `src/services/gitea/client.ts` custom HTTP logic with `createGiteaClient(baseUrl, token)` backed by `giteaApi(baseUrl, { token })`
- Exported `GiteaClient` as `ReturnType<typeof createGiteaClient>`
- Kept exported `GiteaApiError(status, message)` for downstream typed error handling
- Rewrote `src/services/gitea/client.test.ts` to mock `gitea-js` and assert the wrapper returns a client exposing `repos`, `issues`, `user`, and `orgs`

## Validation
- `bun test src/services/gitea/client.test.ts` -> `2 pass, 0 fail`

Closes #9
