### PR TITLE
docs: MCP-only GitHub smoke workflow update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,8 +315,8 @@ Use this sequence for every agent-run implementation or smoke test:
    - `git add <files>`
    - `git commit -m "chore: <what changed>"`
 6. Push and open PR:
-   - `git push origin <branch>`
-   - Prefer GitHub MCP `create_pull_request` for deterministic agent runs
+    - `git push origin <branch>`
+   - Prefer GitHub MCP `create_pull_request`; if it returns `404`, fall back to `gh pr create --body-file <file>`
 
 ### Anti-clunk guardrails
 

--- a/docs/agent-pr-smoke-checklist.md
+++ b/docs/agent-pr-smoke-checklist.md
@@ -27,6 +27,7 @@ Use this checklist when validating agent GitHub operations in this repository.
 ## 5) Open PR
 
 - Prefer GitHub MCP `create_pull_request`.
+- If MCP `create_pull_request` returns `404`, fall back to `gh pr create`.
 - If using `gh`, prefer `gh pr create --body-file /tmp/pr-body.md` to avoid
   shell quoting bugs.
 - Include:
@@ -44,3 +45,5 @@ Use this checklist when validating agent GitHub operations in this repository.
   writable from the agent sandbox.
 - This is resolved by proceeding from local refs and documenting the limitation
   in the PR.
+- GitHub MCP may be read-capable (issues/branches) while PR create returns 404.
+- This is resolved by falling back to `gh pr create` until MCP write access is fixed.


### PR DESCRIPTION
## What this validates
- Issue read via GitHub MCP works cleanly
- Branch, commit, and push flow still works
- PR workflow re-run after plugin/network changes

## Setup change verified
- GitHub plugin disabled
- GitHub MCP server available
- Networking enabled

## Difference observed
- MCP `create_pull_request` returned `404` for this repo even though issue read and branch listing work.
- Fallback to `gh pr create` succeeded.

## Remaining hurdle
- `git fetch origin main` failed in this worktree because `.git/worktrees/.../FETCH_HEAD` is outside writable sandbox roots.

## Scope
- Docs-only update to workflow guidance.
