### PR TITLE
docs: enforce MCP-first workflow and PR evidence template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Workflow Evidence (Required)
+
+- Issue read method used:
+- Branch creation method used:
+- Commit SHA(s):
+- PR creation method used:
+- Fallback used (`none` if not used):
+- If fallback used, reason:
+
+## Scope Check
+
+- [ ] Changes are focused on one issue/task
+- [ ] No unrelated refactors or formatting-only churn included
+
+## Validation
+
+- [ ] Local validation/tests run (list commands below)
+- Commands run:
+
+## Merge Gate
+
+- [ ] This PR includes complete workflow evidence
+- [ ] Any fallback is explicitly documented and justified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,3 +299,66 @@ When generating new pages, components, or templates:
 5. Every new section needs: a `.bs-eyebrow` label, a Lora serif headline, and
    a single clear action — never two competing CTAs
 6. Add `.bs-reveal` to any block-level element introduced below the fold
+
+---
+
+## GitHub Agent Workflow Policy (Required)
+
+This repository uses a strict MCP-first workflow for all GitHub API actions.
+Agents must follow this policy exactly.
+
+### Required default
+
+For GitHub operations, use GitHub MCP tools first:
+
+- Read issues/PRs: `issue_read`, `pull_request_read`, `list_issues`,
+  `list_pull_requests`
+- Create branches/files/PRs: `create_branch`, `create_or_update_file`,
+  `create_pull_request`
+- Update PRs/comments/reviews: `update_pull_request`, `add_issue_comment`,
+  `pull_request_review_write`
+
+### Allowed fallback
+
+`gh` CLI is fallback-only. Use it only if:
+
+- The required MCP tool is unavailable, or
+- The MCP call fails for a non-user-actionable reason
+
+When fallback is used, document:
+
+- The MCP tool name
+- The exact failure message
+- The `gh` command used as fallback
+
+### Git ownership split
+
+- Use local `git` for working tree operations (edit, stage, commit, diff)
+- Use MCP for GitHub API operations (issue, branch, PR, comments, reviews)
+
+### PR evidence is mandatory
+
+Every PR must include workflow evidence:
+
+- Issue read method used
+- Branch creation method used
+- Commit SHA
+- PR creation method used
+- Any fallback used and why
+
+Do not merge PRs that omit workflow evidence or contain unexplained fallback.
+
+## MCP Preflight Checklist (Run Before GitHub Writes)
+
+Before creating branches, updating issues, or opening PRs, verify:
+
+1. MCP identity is healthy (`get_me` succeeds)
+2. Repo read path is healthy (`list_issues` or `list_branches` succeeds)
+3. Write path is healthy (perform one safe write probe in a test branch or
+   update an existing test PR body)
+4. If any write fails, stop and fix auth before continuing feature work
+
+## Deterministic MCP Setup
+
+Use one GitHub MCP server configuration path at a time. Avoid mixed auth paths
+(for example OAuth + PAT at once) to prevent nondeterministic write failures.


### PR DESCRIPTION
## Summary

Add enforceable agent workflow guardrails so all agents use GitHub MCP by default and provide auditable PR workflow evidence.

## Workflow Evidence (Required)

- Issue read method used: `mcp__MCP_DOCKER__list_issues` / `issue_read` used in prior workflow validation
- Branch creation method used: local `git checkout -b codex/mcp-workflow-guardrails`
- Commit SHA(s): `fc4e70b`
- PR creation method used: `mcp__MCP_DOCKER__create_pull_request`
- Fallback used (`none` if not used): `git push -u` partial-failure fallback (remote push succeeded; upstream tracking failed)
- If fallback used, reason: local lock/permission issue writing `.git/refs/remotes` in this environment

## Scope Check

- [x] Changes are focused on one issue/task
- [x] No unrelated refactors or formatting-only churn included

## Validation

- [x] Local validation/tests run (list commands below)
- Commands run:
  - `git status --short --branch`
  - `git diff -- AGENTS.md .github/pull_request_template.md`
  - `git push -u origin codex/mcp-workflow-guardrails`

## Merge Gate

- [x] This PR includes complete workflow evidence
- [x] Any fallback is explicitly documented and justified
