### PR TITLE
feat: align Gitea PR service with issue #11

### DIFF
--- a/src/services/gitea/pullRequests.test.ts
+++ b/src/services/gitea/pullRequests.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, mock, test } from 'bun:test';
-import type { CreatePullRequestOption, CreatePullReviewOptions, MergePullRequestOption, PullRequest, PullReview } from 'gitea-js';
+import type { CreatePullRequestOption, CreatePullReviewOptions, PullRequest, PullReview } from 'gitea-js';
 
 import type { GiteaClient } from './client';
 
@@ -202,7 +202,41 @@ test('getPullRequestForBranch returns null when no branch PR exists', async () =
     branch: 'missing-branch',
   });
 
+  expect(repoListPullRequestsMock).toHaveBeenCalledWith('alice', 'quarterly-report', {
+    state: 'all',
+    head: 'alice:missing-branch',
+  });
   expect(pullRequest).toBeNull();
+});
+
+test('getPullRequestForBranch maps a closed unmerged PR to working', async () => {
+  const { getPullRequestForBranch } = await import('./pullRequests');
+
+  repoListPullRequestsMock.mockImplementation(async () => ({
+    data: [
+      {
+        number: 10,
+        title: 'Stale draft',
+        head: { ref: 'feature/stale-draft' },
+        state: 'closed',
+        merged: false,
+      },
+    ] as PullRequest[],
+  }));
+
+  const pullRequest = await getPullRequestForBranch({
+    client,
+    owner: 'alice',
+    repo: 'quarterly-report',
+    branch: 'feature/stale-draft',
+  });
+
+  expect(repoListPullRequestsMock).toHaveBeenCalledWith('alice', 'quarterly-report', {
+    state: 'all',
+    head: 'alice:feature/stale-draft',
+  });
+  expect(pullRequest).not.toBeNull();
+  expect(pullRequest?.approvalState).toBe('working');
 });
 
 test('getPullRequestForBranch maps requested changes to changes_requested', async () => {
@@ -325,13 +359,11 @@ test('listPullRequests maps merged PRs to published and approved PRs to approved
     repo: 'quarterly-report',
     state: 'all',
     page: 1,
-    limit: 10,
   });
 
   expect(repoListPullRequestsMock).toHaveBeenCalledWith('alice', 'quarterly-report', {
     state: 'all',
     page: 1,
-    limit: 10,
   });
   expect(pullRequests.map((item) => item.approvalState)).toEqual(['in_review', 'changes_requested', 'published']);
 });

--- a/src/services/gitea/pullRequests.ts
+++ b/src/services/gitea/pullRequests.ts
@@ -49,7 +49,6 @@ export interface ListPullRequestsParams {
   repo: string;
   state: 'open' | 'closed' | 'all';
   page?: number;
-  limit?: number;
 }
 
 function readErrorMessage(error: unknown): string {
@@ -267,13 +266,12 @@ export async function mergePullRequest(params: MergePullRequestParams): Promise<
 }
 
 export async function listPullRequests(params: ListPullRequestsParams): Promise<PullRequestWithApprovalState[]> {
-  const { client, owner, repo, state, page, limit } = params;
+  const { client, owner, repo, state, page } = params;
 
   try {
     const response = await client.repos.repoListPullRequests(owner, repo, {
       state,
       page,
-      limit,
     });
 
     const mapped = await Promise.all(


### PR DESCRIPTION
## Summary
- Implemented Issue #11 PR service alignment in `src/services/gitea/pullRequests.ts`.
- `getPullRequestForBranch` now calls `repoListPullRequests(owner, repo, { state: 'all', head: `${owner}:${branch}` })` and still returns `null` when no branch PR exists.
- Narrowed `mergePullRequest` style typing to `merge | squash | rebase`.
- Kept exported `ApprovalState` union and full PR lifecycle functions (`createPullRequest`, `getPullRequestForBranch`, `submitReview`, `mergePullRequest`, `listPullRequests`).
- Expanded tests for approval-state mapping and branch lookup call-shape, including explicit `working` state coverage.

## Validation
- `bun test src/services/gitea/pullRequests.test.ts`
- `bun test src/services/gitea`

## Workflow Evidence (MCP-first)
- Issue read method used: `issue_read` (issue #11)
- Identity preflight: `get_me`
- Repo read preflight: `list_branches`
- Write-path probe: `update_pull_request` (no-op update on closed smoke-test PR #52)
- Branch creation method used: `create_branch` (`codex/issue-11-pr-lifecycle-state-mapping`)
- Commit SHA: `395297997bafc19473f09269be2814d9083dba75`
- PR creation method used: `create_pull_request` (existing PR #66 on this branch), then `update_pull_request` for final body/title
- Fallback used: none