### PR TITLE
Phase 1: implement ApprovalStatus banner component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindersnap-editor-demo",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -84,6 +84,7 @@ import {
 
 import { VersionControlPanel } from "./components/VersionControl/VersionControlPanel";
 import { CommentSidebar, type CommentThread } from "./sidebar/CommentSidebar";
+import { ApprovalStatusBanner } from "./extensions/ApprovalStatus";
 import {
   CommentAnchor,
   getCommentAnchorState,
@@ -92,6 +93,7 @@ import { VersionHistory } from "./extensions/VersionHistory";
 import { Conflict } from "./extensions/conflict";
 import { gitService } from "./services/GitService";
 import { sanitizeHtml, sanitizeProseMirrorJson } from "../services/sanitizer";
+import type { ApprovalState } from "../services/gitea/pullRequests";
 
 // --- Types ---
 interface ToolbarProps {
@@ -111,6 +113,11 @@ interface EditorProps {
   placeholder?: string;
   className?: string;
   comments?: CommentThread[];
+  approvalState?: ApprovalState;
+  prUrl?: string;
+  onSubmitForReview?: () => void;
+  onApprove?: () => void;
+  onRequestChanges?: () => void;
 }
 
 const sanitizeContentForEditor = (content: Content): Content => {
@@ -1191,6 +1198,11 @@ export const DemoEditor = ({
   placeholder = "Start typing your document...",
   className = "",
   comments = [],
+  approvalState,
+  prUrl,
+  onSubmitForReview,
+  onApprove,
+  onRequestChanges,
 }: EditorProps) => {
   const sanitizedInitialContent = useMemo(
     () => sanitizeContentForEditor(initialContent),
@@ -1760,10 +1772,21 @@ export const DemoEditor = ({
             </button>
           </div>,
           document.body,
-        )}
+      )}
       <div className="bs-editor__main">
-        <div className="bs-editor__scroll bs-editor__content" ref={scrollRef}>
-          <EditorContent editor={editor} />
+        <div className="bs-editor__content">
+          {approvalState && (
+            <ApprovalStatusBanner
+              approvalState={approvalState}
+              prUrl={prUrl}
+              onSubmitForReview={onSubmitForReview}
+              onApprove={onApprove}
+              onRequestChanges={onRequestChanges}
+            />
+          )}
+          <div className="bs-editor__scroll" ref={scrollRef}>
+            <EditorContent editor={editor} />
+          </div>
         </div>
 
         {showSidebar && (

--- a/src/editor/assets/bindersnap-editor.css
+++ b/src/editor/assets/bindersnap-editor.css
@@ -146,6 +146,7 @@
 /* Scroll container */
 .bs-editor__scroll {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   touch-action: pan-y;
@@ -582,6 +583,9 @@
 
 .bs-editor__content {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .bs-editor__sidebar {
@@ -1376,114 +1380,184 @@
 
 
 /* ──────────────────────────────────────
-   10c. APPROVAL STATES
-   Block-level wrappers that indicate the
-   approval status of a section or document.
-   ──────────────────────────────────────
-   Expected structure:
-   <div class="bs-approval bs-approval--pending" data-approver="..." data-date="...">
-     <div class="bs-approval__badge">Pending Review</div>
-     ... content ...
-   </div>
+   10c. APPROVAL STATUS BANNER
+   External banner rendered above the
+   ProseMirror scroll area.
    ────────────────────────────────────── */
 
 .bs-editor .bs-approval {
+  --bs-approval-accent: var(--color-muted);
+  --bs-approval-copy: var(--color-ink-soft);
+  --bs-approval-surface: color-mix(in srgb, var(--color-muted) 8%, var(--color-paper));
+  --bs-approval-badge-bg: color-mix(in srgb, var(--color-muted) 10%, var(--color-paper));
+  --bs-approval-badge-text: var(--color-muted);
+  --bs-approval-link: var(--color-ink-soft);
+
   position: relative;
-  margin: 1.5em 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--brand-space-3);
+  padding: var(--brand-space-4) var(--brand-space-5);
+  border: var(--e-border-1) solid color-mix(in srgb, var(--bs-approval-accent) 22%, var(--color-rule));
   border-radius: var(--brand-radius-lg);
-  border: var(--e-border-1) solid var(--e-rule);
+  background: var(--bs-approval-surface);
+  box-shadow: var(--e-shadow-sm);
   overflow: hidden;
 }
 
-/* Top accent bar */
 .bs-editor .bs-approval::before {
   content: '';
   position: absolute;
-  top: 0; left: 0; right: 0;
+  top: 0;
+  left: 0;
+  right: 0;
   height: var(--e-border-3);
+  background: var(--bs-approval-accent);
 }
 
-.bs-editor .bs-approval--pending::before  { background: var(--e-pending-b); }
-.bs-editor .bs-approval--approved::before { background: var(--e-approved-b); }
-.bs-editor .bs-approval--rejected::before { background: var(--e-rejected-b); }
+.bs-editor .bs-approval--approved {
+  --bs-approval-accent: var(--color-green);
+  --bs-approval-copy: var(--color-ink-soft);
+  --bs-approval-surface: color-mix(in srgb, var(--color-green) 10%, var(--color-paper));
+  --bs-approval-badge-bg: color-mix(in srgb, var(--color-green) 12%, var(--color-paper));
+  --bs-approval-badge-text: var(--color-green);
+  --bs-approval-link: var(--color-ink-soft);
+}
 
-/* Background tint */
-.bs-editor .bs-approval--pending  { background: var(--e-pending); }
-.bs-editor .bs-approval--approved { background: var(--e-approved); }
-.bs-editor .bs-approval--rejected { background: var(--e-rejected); }
+.bs-editor .bs-approval--pending {
+  --bs-approval-accent: var(--color-coral);
+  --bs-approval-copy: var(--color-ink-soft);
+  --bs-approval-surface: color-mix(in srgb, var(--color-coral) 10%, var(--color-paper));
+  --bs-approval-badge-bg: color-mix(in srgb, var(--color-coral) 10%, var(--color-paper));
+  --bs-approval-badge-text: var(--color-coral);
+  --bs-approval-link: var(--color-ink-soft);
+}
 
-/* Badge */
+.bs-editor .bs-approval--rejected {
+  --bs-approval-accent: var(--color-coral-dark);
+  --bs-approval-copy: var(--color-ink-soft);
+  --bs-approval-surface: color-mix(in srgb, var(--color-coral-dark) 10%, var(--color-paper));
+  --bs-approval-badge-bg: color-mix(in srgb, var(--color-coral-dark) 10%, var(--color-paper));
+  --bs-approval-badge-text: var(--color-coral-dark);
+  --bs-approval-link: var(--color-ink-soft);
+}
+
 .bs-editor .bs-approval__badge {
   display: inline-flex;
   align-items: center;
+  width: fit-content;
   gap: var(--brand-space-2);
-  padding: var(--brand-space-2) var(--brand-space-4);
+  padding: var(--brand-space-1) var(--brand-space-3);
+  border: var(--e-border-1) solid color-mix(in srgb, var(--bs-approval-badge-text) 24%, var(--color-rule));
+  border-radius: var(--brand-radius-full);
+  background: var(--bs-approval-badge-bg);
+  color: var(--bs-approval-badge-text);
   font-family: var(--e-font-mono);
   font-size: var(--brand-text-label);
   font-weight: 500;
   letter-spacing: var(--brand-tracking-wide);
   text-transform: uppercase;
-  border-bottom: var(--e-border-1) solid var(--e-rule-2);
-  width: 100%;
 }
 
-.bs-editor .bs-approval--pending  .bs-approval__badge { color: var(--e-pending-b); }
-.bs-editor .bs-approval--approved .bs-approval__badge { color: var(--e-approved-b); }
-.bs-editor .bs-approval--rejected .bs-approval__badge { color: var(--e-rejected-b); }
-
-.bs-editor .bs-approval__badge::before {
-  content: '';
-  display: inline-block;
-  width: var(--brand-space-2);
-  height: var(--brand-space-2);
-  border-radius: 50%;
-  background: currentColor;
-  flex-shrink: 0;
-  animation: none;
+.bs-editor .bs-approval__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--brand-space-2);
 }
 
-/* Pulse animation for pending */
-.bs-editor .bs-approval--pending .bs-approval__badge::before {
-  animation: approval-pulse 2s ease-in-out infinite;
+.bs-editor .bs-approval__title {
+  margin: 0;
+  color: var(--color-ink);
+  font-family: var(--e-font-serif);
+  font-size: var(--brand-text-h3);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: var(--brand-tracking-snug);
+}
+
+.bs-editor .bs-approval__copy {
+  margin: 0;
+  color: var(--bs-approval-copy);
+  font-family: var(--e-font-sans);
+  font-size: var(--brand-text-body);
+  line-height: 1.6;
+}
+
+.bs-editor .bs-approval__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--brand-space-2);
+}
+
+.bs-editor .bs-approval__link {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--brand-space-8);
+  padding: 0 var(--brand-space-1);
+  color: var(--bs-approval-link);
+  font-family: var(--e-font-mono);
+  font-size: var(--brand-text-label);
+  font-weight: 500;
+  letter-spacing: var(--brand-tracking-wide);
+  text-decoration: underline;
+  text-decoration-color: var(--e-rule);
+  text-underline-offset: 0.2em;
+  transition: color var(--e-t-fast), text-decoration-color var(--e-t-fast);
+}
+
+.bs-editor .bs-approval__link:hover {
+  color: var(--color-ink);
+  text-decoration-color: var(--bs-approval-accent);
+}
+
+.bs-editor .bs-approval--working {
+  --bs-approval-accent: var(--color-muted);
+  --bs-approval-copy: var(--color-muted);
+  --bs-approval-surface: color-mix(in srgb, var(--color-muted) 8%, var(--color-paper));
+  --bs-approval-badge-bg: color-mix(in srgb, var(--color-muted) 10%, var(--color-paper));
+  --bs-approval-badge-text: var(--color-muted);
+  --bs-approval-link: var(--color-muted);
+}
+
+.bs-editor .bs-approval--in-review {
+  --bs-approval-accent: var(--color-coral);
+  --bs-approval-copy: var(--color-ink-soft);
+  --bs-approval-surface: color-mix(in srgb, var(--color-coral) 10%, var(--color-paper));
+  --bs-approval-badge-bg: color-mix(in srgb, var(--color-coral) 10%, var(--color-paper));
+  --bs-approval-badge-text: var(--color-coral);
+  --bs-approval-link: var(--color-ink-soft);
+}
+
+.bs-editor .bs-approval--changes-requested {
+  --bs-approval-accent: var(--color-coral-dark);
+  --bs-approval-copy: var(--color-ink-soft);
+  --bs-approval-surface: color-mix(in srgb, var(--color-coral-dark) 10%, var(--color-paper));
+  --bs-approval-badge-bg: color-mix(in srgb, var(--color-coral-dark) 10%, var(--color-paper));
+  --bs-approval-badge-text: var(--color-coral-dark);
+  --bs-approval-link: var(--color-ink-soft);
+}
+
+.bs-editor .bs-approval--published {
+  --bs-approval-accent: var(--color-ink);
+  --bs-approval-copy: var(--color-ink-soft);
+  --bs-approval-surface: color-mix(in srgb, var(--color-ink) 4%, var(--color-paper));
+  --bs-approval-badge-bg: color-mix(in srgb, var(--color-green) 12%, var(--color-paper));
+  --bs-approval-badge-text: var(--color-green);
+  --bs-approval-link: var(--color-ink);
 }
 
 @keyframes approval-pulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50%       { opacity: 0.5; transform: scale(0.7); }
-}
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
 
-/* Content area */
-.bs-editor .bs-approval__content {
-  padding: var(--brand-space-4) var(--brand-space-5);
-}
-
-.bs-editor .bs-approval__content > *:last-child { margin-bottom: 0; }
-
-/* Meta row */
-.bs-editor .bs-approval__meta {
-  display: flex;
-  align-items: center;
-  gap: var(--brand-space-3);
-  padding: var(--brand-space-2) var(--brand-space-5);
-  border-top: var(--e-border-1) solid var(--e-rule-2);
-  font-family: var(--e-font-mono);
-  font-size: var(--brand-text-label);
-  color: var(--e-text-4);
-  letter-spacing: var(--brand-tracking-wide);
-}
-
-/* Locked approved content — visually sealed */
-.bs-editor .bs-approval--approved .bs-approval__content {
-  opacity: 0.85;
-}
-
-.bs-editor .bs-approval--approved .bs-approval__content::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: all;  /* blocks editing of approved sections */
-  cursor: not-allowed;
-  background: transparent;
+  50% {
+    opacity: 0.5;
+    transform: scale(0.7);
+  }
 }
 
 
@@ -2298,8 +2372,6 @@
   .bs-editor .bs-conflict__zone--theirs {
     padding: var(--brand-space-2) var(--brand-space-3);
   }
-
-  .bs-editor .bs-approval__content { padding: var(--brand-space-3) var(--brand-space-3); }
 }
 
 @media (max-width: 30rem) {

--- a/src/editor/extensions/ApprovalStatus/ApprovalStatus.test.ts
+++ b/src/editor/extensions/ApprovalStatus/ApprovalStatus.test.ts
@@ -1,0 +1,194 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { JSDOM } from "jsdom";
+
+import { ApprovalStatusBanner } from "./ApprovalStatusBanner";
+import type { ApprovalStatusBannerProps } from "./ApprovalStatusBanner";
+import type { ApprovalState } from "../../../services/gitea/pullRequests";
+
+const { window } = new JSDOM("<!doctype html><html><body></body></html>");
+
+beforeAll(() => {
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    navigator: window.navigator,
+    Node: window.Node,
+    Element: window.Element,
+    HTMLElement: window.HTMLElement,
+    HTMLAnchorElement: window.HTMLAnchorElement,
+    HTMLButtonElement: window.HTMLButtonElement,
+    HTMLBodyElement: window.HTMLBodyElement,
+    DOMParser: window.DOMParser,
+    DocumentFragment: window.DocumentFragment,
+    MutationObserver: window.MutationObserver,
+    getSelection: window.getSelection.bind(window),
+    getComputedStyle: window.getComputedStyle.bind(window),
+    requestAnimationFrame: (callback: FrameRequestCallback) =>
+      setTimeout(() => callback(0), 0),
+    cancelAnimationFrame: (handle: number) => clearTimeout(handle),
+    innerHeight: 900,
+    innerWidth: 1440,
+  });
+});
+
+const stateClassName: Record<ApprovalState, string> = {
+  working: "bs-approval--working",
+  in_review: "bs-approval--in-review",
+  changes_requested: "bs-approval--changes-requested",
+  approved: "bs-approval--approved",
+  published: "bs-approval--published",
+};
+
+const toneClassName: Record<ApprovalState, string> = {
+  working: "bs-approval--pending",
+  in_review: "bs-approval--pending",
+  changes_requested: "bs-approval--rejected",
+  approved: "bs-approval--approved",
+  published: "bs-approval--approved",
+};
+
+const stateBadge: Record<ApprovalState, string> = {
+  working: "Draft",
+  in_review: "In Review",
+  changes_requested: "Changes Requested",
+  approved: "Approved",
+  published: "Published",
+};
+
+const mountBanner = (props: Partial<ApprovalStatusBannerProps>) => {
+  const container = document.createElement("div");
+  container.className = "bs-editor";
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+  const mergedProps: ApprovalStatusBannerProps = {
+    approvalState: "working",
+    ...props,
+  };
+
+  flushSync(() => {
+    root.render(createElement(ApprovalStatusBanner, mergedProps));
+  });
+
+  const unmount = () => {
+    flushSync(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
+
+  return {
+    container,
+    unmount,
+  };
+};
+
+describe("ApprovalStatusBanner", () => {
+  (Object.keys(stateBadge) as ApprovalState[]).forEach((approvalState) => {
+    test(`renders the ${approvalState} state`, () => {
+      const { container, unmount } = mountBanner({ approvalState });
+
+      const banner = container.querySelector<HTMLElement>(".bs-approval");
+
+      expect(banner).not.toBeNull();
+      expect(banner?.dataset.state).toBe(approvalState);
+      expect(banner?.className).toContain(stateClassName[approvalState]);
+      expect(banner?.className).toContain(toneClassName[approvalState]);
+      expect(banner?.textContent).toContain(stateBadge[approvalState]);
+
+      unmount();
+    });
+  });
+
+  test("calls submit-for-review from the working state", () => {
+    let submitCount = 0;
+    const { container, unmount } = mountBanner({
+      approvalState: "working",
+      onSubmitForReview: () => {
+        submitCount += 1;
+      },
+    });
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[type="button"]',
+    );
+
+    expect(button?.textContent).toBe("Submit for review");
+
+    button?.click();
+
+    expect(submitCount).toBe(1);
+
+    unmount();
+  });
+
+  test("calls approve and request-changes from the in_review state", () => {
+    let approveCount = 0;
+    let requestChangesCount = 0;
+    const { container, unmount } = mountBanner({
+      approvalState: "in_review",
+      onApprove: () => {
+        approveCount += 1;
+      },
+      onRequestChanges: () => {
+        requestChangesCount += 1;
+      },
+    });
+
+    const buttons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[type="button"]'),
+    );
+
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      "Approve",
+      "Request changes",
+    ]);
+
+    buttons[0]?.click();
+    buttons[1]?.click();
+
+    expect(approveCount).toBe(1);
+    expect(requestChangesCount).toBe(1);
+
+    unmount();
+  });
+
+  test("calls submit-for-review from the changes_requested state", () => {
+    let submitCount = 0;
+    const { container, unmount } = mountBanner({
+      approvalState: "changes_requested",
+      onSubmitForReview: () => {
+        submitCount += 1;
+      },
+    });
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[type="button"]',
+    );
+
+    expect(button?.textContent).toBe("Submit for review");
+
+    button?.click();
+
+    expect(submitCount).toBe(1);
+
+    unmount();
+  });
+
+  test("renders the review link when prUrl is provided", () => {
+    const { container, unmount } = mountBanner({
+      approvalState: "approved",
+      prUrl: "/pulls/42",
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>(".bs-approval__link");
+
+    expect(link?.textContent).toBe("Open review trail");
+    expect(link?.getAttribute("href")).toBe("/pulls/42");
+
+    unmount();
+  });
+});

--- a/src/editor/extensions/ApprovalStatus/ApprovalStatusBanner.stories.tsx
+++ b/src/editor/extensions/ApprovalStatus/ApprovalStatusBanner.stories.tsx
@@ -1,0 +1,48 @@
+import { ApprovalStatusBanner } from "./ApprovalStatusBanner";
+import type { ApprovalState } from "../../../services/gitea/pullRequests";
+import "../../assets/bindersnap-editor.css";
+
+export default {
+  title: "Editor/ApprovalStatusBanner",
+  component: ApprovalStatusBanner,
+};
+
+const STATUSES: ApprovalState[] = [
+  "working",
+  "in_review",
+  "changes_requested",
+  "approved",
+  "published",
+];
+
+const sharedHandlers = {
+  onSubmitForReview: () => undefined,
+  onApprove: () => undefined,
+  onRequestChanges: () => undefined,
+};
+
+export const AllStates = () => (
+  <div
+    className="bs-editor"
+    style={{
+      padding: "var(--brand-space-4)",
+      background: "var(--bs-page-bg)",
+    }}
+  >
+    <div
+      style={{
+        display: "grid",
+        gap: "var(--brand-space-3)",
+      }}
+    >
+      {STATUSES.map((approvalState) => (
+        <ApprovalStatusBanner
+          key={approvalState}
+          approvalState={approvalState}
+          prUrl="/pulls/42"
+          {...sharedHandlers}
+        />
+      ))}
+    </div>
+  </div>
+);

--- a/src/editor/extensions/ApprovalStatus/ApprovalStatusBanner.tsx
+++ b/src/editor/extensions/ApprovalStatus/ApprovalStatusBanner.tsx
@@ -1,0 +1,151 @@
+import type { ApprovalState } from "../../../services/gitea/pullRequests";
+
+export interface ApprovalStatusBannerProps {
+  approvalState: ApprovalState;
+  prUrl?: string;
+  onSubmitForReview?: () => void;
+  onApprove?: () => void;
+  onRequestChanges?: () => void;
+}
+
+type BannerTone = "pending" | "approved" | "rejected";
+
+type BannerStateConfig = {
+  badge: string;
+  title: string;
+  copy: string;
+  tone: BannerTone;
+  stateClass: string;
+  linkLabel: string;
+};
+
+const BANNER_STATE_CONFIG: Record<ApprovalState, BannerStateConfig> = {
+  working: {
+    badge: "Draft",
+    title: "Still in draft",
+    copy: "Keep editing. Submit this version for review when it is ready.",
+    tone: "pending",
+    stateClass: "bs-approval--working",
+    linkLabel: "Open review trail",
+  },
+  in_review: {
+    badge: "In Review",
+    title: "Review is open",
+    copy: "The document is out for review. Approve it or send it back with changes.",
+    tone: "pending",
+    stateClass: "bs-approval--in-review",
+    linkLabel: "Open review trail",
+  },
+  changes_requested: {
+    badge: "Changes Requested",
+    title: "Needs another pass",
+    copy: "The review came back with edits. Update the draft and submit it again.",
+    tone: "rejected",
+    stateClass: "bs-approval--changes-requested",
+    linkLabel: "Open review trail",
+  },
+  approved: {
+    badge: "Approved",
+    title: "Approved and signed off",
+    copy: "This version has approval. Publish it when you are ready.",
+    tone: "approved",
+    stateClass: "bs-approval--approved",
+    linkLabel: "Open review trail",
+  },
+  published: {
+    badge: "Published",
+    title: "Published record",
+    copy: "This version is locked and ready for readers.",
+    tone: "approved",
+    stateClass: "bs-approval--published",
+    linkLabel: "Open published record",
+  },
+};
+
+const TONE_CLASS: Record<BannerTone, string> = {
+  pending: "bs-approval--pending",
+  approved: "bs-approval--approved",
+  rejected: "bs-approval--rejected",
+};
+
+export function ApprovalStatusBanner({
+  approvalState,
+  prUrl,
+  onSubmitForReview,
+  onApprove,
+  onRequestChanges,
+}: ApprovalStatusBannerProps) {
+  const config = BANNER_STATE_CONFIG[approvalState];
+  const rootClassName = [
+    "bs-approval",
+    TONE_CLASS[config.tone],
+    config.stateClass,
+  ].join(" ");
+
+  const primaryAction =
+    approvalState === "working" || approvalState === "changes_requested"
+      ? onSubmitForReview
+        ? {
+            label: "Submit for review",
+            onClick: onSubmitForReview,
+            className: "bs-btn-primary",
+          }
+        : null
+      : approvalState === "in_review" && onApprove
+        ? {
+            label: "Approve",
+            onClick: onApprove,
+            className: "bs-btn-primary",
+          }
+        : null;
+
+  const secondaryAction =
+    approvalState === "in_review" && onRequestChanges
+      ? {
+          label: "Request changes",
+          onClick: onRequestChanges,
+          className: "bs-btn-secondary",
+        }
+      : null;
+
+  return (
+    <section
+      className={rootClassName}
+      data-state={approvalState}
+      aria-label="Approval status"
+    >
+      <div className="bs-approval__badge">{config.badge}</div>
+      <div className="bs-approval__body">
+        <h2 className="bs-approval__title">{config.title}</h2>
+        <p className="bs-approval__copy">{config.copy}</p>
+      </div>
+      {(primaryAction || secondaryAction || prUrl) && (
+        <div className="bs-approval__actions">
+          {primaryAction && (
+            <button
+              type="button"
+              className={primaryAction.className}
+              onClick={primaryAction.onClick}
+            >
+              {primaryAction.label}
+            </button>
+          )}
+          {secondaryAction && (
+            <button
+              type="button"
+              className={secondaryAction.className}
+              onClick={secondaryAction.onClick}
+            >
+              {secondaryAction.label}
+            </button>
+          )}
+          {prUrl && (
+            <a className="bs-approval__link" href={prUrl}>
+              {config.linkLabel}
+            </a>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/editor/extensions/ApprovalStatus/index.ts
+++ b/src/editor/extensions/ApprovalStatus/index.ts
@@ -1,0 +1,2 @@
+export { ApprovalStatusBanner } from "./ApprovalStatusBanner";
+export type { ApprovalStatusBannerProps } from "./ApprovalStatusBanner";


### PR DESCRIPTION
## Summary
- add `ApprovalStatus` extension files under `src/editor/extensions/ApprovalStatus/` (`ApprovalStatusBanner.tsx`, `index.ts`, tests, and Storybook story)
- wire the banner into `DemoEditor` so it renders above the ProseMirror scroll area and remains fully prop-driven
- update approval banner styling in `bindersnap-editor.css` for all five PR states using design tokens and remove legacy `bs-approval__content`/`bs-approval__meta` assumptions
- bump package version from `0.0.2` to `0.0.3`

## Validation
- `bun test src/editor/extensions/ApprovalStatus/ApprovalStatus.test.ts`
- `bun test src/services/gitea/pullRequests.test.ts`
- `bun run build`

## Issue
- Closes #13

## Workflow Evidence (Required)
- Issue read method: GitHub MCP `issue_read` (`owner=davidgraymi`, `repo=bindersnap-editor-demo`, `issue_number=13`, `method=get`)
- Branch creation method: local git `checkout -b codex/issue-13-approval-status-banner` + GitHub MCP `create_branch` (`from_branch=main`) as write-path probe
- Commit SHA: `11da8b46cb136bf3906d27f2dc2791c2d66d01a1`
- PR creation method: GitHub MCP `create_pull_request`
- Fallback used: none (`gh` CLI fallback not required)