### PR TITLE
feat: document list view and editor with Gitea auto-save (#71)

### DIFF
--- a/dev/tests/gitea-services.pw.ts
+++ b/dev/tests/gitea-services.pw.ts
@@ -7,6 +7,8 @@ import {
   validateToken,
 } from '../../src/services/gitea/auth';
 import {
+  commitDocument,
+  fetchDocument,
   fetchDocumentAtSha,
   listDocumentCommits,
 } from '../../src/services/gitea/documents';
@@ -138,6 +140,63 @@ test.describe('Gitea service wrappers against the live dev stack', () => {
 
     expect(doc.type).toBe('doc');
     expect(Array.isArray(doc.content)).toBe(true);
+  });
+
+  test('fetchDocument returns content and file sha from main branch', async () => {
+    const client = createAuthenticatedClient(GITEA_URL);
+    const result = await fetchDocument({
+      client,
+      owner: 'alice',
+      repo: 'quarterly-report',
+      filePath: 'documents/draft.json',
+      branch: 'main',
+    });
+
+    expect(result.content.type).toBe('doc');
+    expect(Array.isArray(result.content.content)).toBe(true);
+    expect(typeof result.sha).toBe('string');
+    expect(result.sha.length).toBeGreaterThan(0);
+  });
+
+  test('fetchDocument then commitDocument round-trips via sha tracking', async () => {
+    const client = createAuthenticatedClient(GITEA_URL);
+
+    // Fetch so we have the current SHA.
+    const initial = await fetchDocument({
+      client,
+      owner: 'alice',
+      repo: 'quarterly-report',
+      filePath: 'documents/draft.json',
+      branch: 'main',
+    });
+
+    // Commit an update using the SHA to avoid 409.
+    const updated = { ...initial.content, content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Integration test update' }] }] };
+    const writeResult = await commitDocument({
+      client,
+      owner: 'alice',
+      repo: 'quarterly-report',
+      filePath: 'documents/draft.json',
+      branch: 'main',
+      message: 'test: fetchDocument round-trip',
+      sha: initial.sha,
+      content: updated,
+    });
+
+    expect(typeof writeResult.sha).toBe('string');
+    expect(writeResult.sha.length).toBeGreaterThan(0);
+
+    // Fetch again to confirm content was updated.
+    const refetched = await fetchDocument({
+      client,
+      owner: 'alice',
+      repo: 'quarterly-report',
+      filePath: 'documents/draft.json',
+      branch: 'main',
+    });
+    expect(refetched.content).toEqual(updated);
+    // SHA should now be different (new commit).
+    expect(refetched.sha).not.toBe(initial.sha);
   });
 
   test('getPullRequestForBranch returns approval state for the seeded review workflow', async () => {

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { createGiteaClient, GiteaApiError } from "../../services/gitea/client";
-import { listDocumentCommits, type CommitSummary } from "../../services/gitea/documents";
+import { commitDocument } from "../../services/gitea/documents";
+import { DocumentEditor } from "./DocumentEditor";
 
 interface AppShellProps {
   baseUrl: string;
@@ -9,17 +10,23 @@ interface AppShellProps {
   onSignOut: () => void;
 }
 
-interface DocumentRow {
-  title: string;
-  path: string;
-  latestCommit: CommitSummary | null;
+interface RepoRow {
+  owner: string;
+  name: string;
+  description: string;
+  updatedAt: string;
+  defaultBranch: string;
 }
 
-const SEEDED_DOCUMENTS: Array<Pick<DocumentRow, "title" | "path">> = [
-  { title: "Draft", path: "documents/draft.json" },
-  { title: "In Review", path: "documents/in-review.json" },
-  { title: "Changes Requested", path: "documents/changes-requested.json" },
-];
+interface DocSelection {
+  owner: string;
+  repo: string;
+  filePath: string;
+  branch: string;
+}
+
+const DEFAULT_DOC_PATH = "document.json";
+const EMPTY_DOC = { type: "doc", content: [{ type: "paragraph" }] };
 
 function formatTimestamp(value: string) {
   if (!value) return "Unknown";
@@ -27,62 +34,111 @@ function formatTimestamp(value: string) {
   return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString();
 }
 
-function maskToken(value: string) {
-  if (value.length <= 8) {
-    return "********";
-  }
-
-  return `***${value.slice(-8)}`;
-}
-
 export function AppShell({ baseUrl, token, onSignOut }: AppShellProps) {
   const client = useMemo(() => createGiteaClient(baseUrl, token), [baseUrl, token]);
 
-  const [documents, setDocuments] = useState<DocumentRow[]>([]);
+  const [repos, setRepos] = useState<RepoRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [openDoc, setOpenDoc] = useState<DocSelection | null>(null);
 
-  const loadDocuments = useCallback(async () => {
+  const loadRepos = useCallback(async () => {
     setLoading(true);
     setError(null);
 
     try {
-      const nextRows = await Promise.all(
-        SEEDED_DOCUMENTS.map(async (doc) => {
-          const commits = await listDocumentCommits({
-            client,
-            owner: "alice",
-            repo: "quarterly-report",
-            filePath: doc.path,
-            limit: 1,
-          });
+      const response = await client.repos.repoSearch({
+        limit: 50,
+        sort: "updated",
+        order: "desc",
+      });
 
-          return {
-            ...doc,
-            latestCommit: commits[0] ?? null,
-          };
-        }),
+      setRepos(
+        (response.data.data ?? []).map((repo) => ({
+          owner: repo.owner?.login ?? "",
+          name: repo.name ?? "",
+          description: repo.description ?? "",
+          updatedAt: repo.updated ?? "",
+          defaultBranch: repo.default_branch ?? "main",
+        }))
       );
-
-      setDocuments(nextRows);
     } catch (loadError) {
       const message =
         loadError instanceof GiteaApiError
           ? loadError.message
           : loadError instanceof Error
             ? loadError.message
-            : "Unable to load documents from Gitea.";
-
+            : "Unable to load repositories from Gitea.";
       setError(message);
-      setDocuments([]);
+      setRepos([]);
     } finally {
       setLoading(false);
     }
   }, [client]);
 
   useEffect(() => {
-    void loadDocuments();
-  }, [loadDocuments]);
+    void loadRepos();
+  }, [loadRepos]);
+
+  const handleNewDocument = useCallback(async () => {
+    const name = window.prompt("New document name (will create a new Gitea repo):");
+    if (!name?.trim()) return;
+
+    const repoName = name.trim().toLowerCase().replace(/[^a-z0-9-]/g, "-");
+    setCreating(true);
+
+    try {
+      // Create the repo
+      await client.repos.createCurrentUserRepo({
+        name: repoName,
+        description: name.trim(),
+        auto_init: true,
+        default_branch: "main",
+      });
+
+      // Get the current user to know the owner
+      const { data: user } = await client.user.userGetCurrent();
+      const owner = user.login ?? "";
+
+      // Create the initial document file
+      await commitDocument({
+        client,
+        owner,
+        repo: repoName,
+        filePath: DEFAULT_DOC_PATH,
+        branch: "main",
+        content: EMPTY_DOC,
+        message: "Initial document",
+      });
+
+      // Open the new document
+      setOpenDoc({ owner, repo: repoName, filePath: DEFAULT_DOC_PATH, branch: "main" });
+      void loadRepos();
+    } catch (err) {
+      const msg = err instanceof GiteaApiError ? err.message : err instanceof Error ? err.message : "Failed to create document.";
+      window.alert(`Failed to create document: ${msg}`);
+    } finally {
+      setCreating(false);
+    }
+  }, [client, loadRepos]);
+
+  // Show document editor if a doc is selected
+  if (openDoc) {
+    return (
+      <DocumentEditor
+        client={client}
+        owner={openDoc.owner}
+        repo={openDoc.repo}
+        filePath={openDoc.filePath}
+        branch={openDoc.branch}
+        onBack={() => {
+          setOpenDoc(null);
+          void loadRepos();
+        }}
+      />
+    );
+  }
 
   return (
     <div className="app-shell">
@@ -98,8 +154,21 @@ export function AppShell({ baseUrl, token, onSignOut }: AppShellProps) {
         </div>
 
         <div className="app-topbar-actions">
-          <button className="bs-btn bs-btn-secondary" type="button" onClick={() => void loadDocuments()}>
-            {loading ? "Refreshing..." : "Refresh"}
+          <button
+            className="bs-btn bs-btn-secondary"
+            type="button"
+            onClick={() => void loadRepos()}
+            disabled={loading}
+          >
+            {loading ? "Loading…" : "Refresh"}
+          </button>
+          <button
+            className="bs-btn bs-btn-secondary"
+            type="button"
+            onClick={() => void handleNewDocument()}
+            disabled={creating}
+          >
+            {creating ? "Creating…" : "New Document"}
           </button>
           <button className="bs-btn bs-btn-dark" type="button" onClick={onSignOut}>
             Sign out
@@ -108,63 +177,54 @@ export function AppShell({ baseUrl, token, onSignOut }: AppShellProps) {
       </header>
 
       <main className="app-main">
-        <section className="bs-card app-summary">
-          <div className="bs-eyebrow">Seeded Repository</div>
-          <h1>alice/quarterly-report</h1>
-          <p>Documents are loaded from commit history using <code>listDocumentCommits</code>.</p>
-        </section>
-
         {error ? (
           <section className="bs-card app-error">
-            <div className="bs-eyebrow">Failure State</div>
-            <h2>Could not fetch Gitea documents.</h2>
+            <div className="bs-eyebrow">Error</div>
+            <h2>Could not fetch repositories.</h2>
             <p>{error}</p>
-            <dl>
-              <div>
-                <dt>Gitea URL</dt>
-                <dd>{baseUrl}</dd>
-              </div>
-              <div>
-                <dt>Token</dt>
-                <dd>{maskToken(token)}</dd>
-              </div>
-            </dl>
           </section>
         ) : null}
 
         <section className="app-docs">
           <div className="app-section-heading">
             <div className="bs-eyebrow">Documents</div>
-            <h2>Local dev seed documents</h2>
+            <h2>Your workspaces</h2>
           </div>
 
           <div className="app-doc-grid">
-            {loading ? <div className="bs-card app-doc-empty">Loading documents...</div> : null}
-            {!loading && documents.length === 0 ? (
-              <div className="bs-card app-doc-empty">No documents found in the seeded repository.</div>
+            {loading ? <div className="bs-card app-doc-empty">Loading documents…</div> : null}
+            {!loading && repos.length === 0 ? (
+              <div className="bs-card app-doc-empty">No documents yet. Click "New Document" to create one.</div>
             ) : null}
-            {documents.map((doc) => (
-              <article className="bs-card app-doc-card" key={doc.path}>
-                <h3>{doc.title}</h3>
-                <p className="app-doc-path">{doc.path}</p>
+            {repos.map((repo) => (
+              <article className="bs-card app-doc-card" key={`${repo.owner}/${repo.name}`}>
+                <h3>{repo.description || repo.name}</h3>
+                <p className="app-doc-path">{repo.owner}/{repo.name}</p>
                 <dl>
                   <div>
-                    <dt>Latest Commit</dt>
-                    <dd>{doc.latestCommit?.sha ? doc.latestCommit.sha.slice(0, 7) : "None"}</dd>
+                    <dt>Last updated</dt>
+                    <dd>{formatTimestamp(repo.updatedAt)}</dd>
                   </div>
                   <div>
-                    <dt>Message</dt>
-                    <dd>{doc.latestCommit?.message ?? "No commit found"}</dd>
-                  </div>
-                  <div>
-                    <dt>Author</dt>
-                    <dd>{doc.latestCommit?.author ?? "Unknown"}</dd>
-                  </div>
-                  <div>
-                    <dt>Timestamp</dt>
-                    <dd>{formatTimestamp(doc.latestCommit?.timestamp ?? "")}</dd>
+                    <dt>Branch</dt>
+                    <dd>{repo.defaultBranch}</dd>
                   </div>
                 </dl>
+                <button
+                  className="bs-btn bs-btn-primary"
+                  type="button"
+                  style={{ marginTop: "var(--brand-space-3)", width: "100%" }}
+                  onClick={() =>
+                    setOpenDoc({
+                      owner: repo.owner,
+                      repo: repo.name,
+                      filePath: DEFAULT_DOC_PATH,
+                      branch: repo.defaultBranch,
+                    })
+                  }
+                >
+                  Open
+                </button>
               </article>
             ))}
           </div>

--- a/src/app/components/DocumentEditor.tsx
+++ b/src/app/components/DocumentEditor.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { JSONContent } from "@tiptap/core";
+
+import { DemoEditor } from "../../editor/Editor";
+import { GiteaApiError, type GiteaClient } from "../../services/gitea/client";
+import { commitDocument, fetchDocument } from "../../services/gitea/documents";
+
+const AUTOSAVE_DELAY_MS = 2000;
+
+interface DocumentEditorProps {
+  client: GiteaClient;
+  owner: string;
+  repo: string;
+  filePath: string;
+  branch?: string;
+  onBack: () => void;
+}
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+export function DocumentEditor({ client, owner, repo, filePath, branch = "main", onBack }: DocumentEditorProps) {
+  const [content, setContent] = useState<JSONContent | null>(null);
+  const [fileSha, setFileSha] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [lastSaved, setLastSaved] = useState<Date | null>(null);
+
+  const fileShaRef = useRef(fileSha);
+  fileShaRef.current = fileSha;
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Load document on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        setLoading(true);
+        setLoadError(null);
+        const result = await fetchDocument({ client, owner, repo, filePath, branch });
+        if (!cancelled) {
+          setContent(result.content);
+          setFileSha(result.sha);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setLoadError(err instanceof GiteaApiError ? err.message : err instanceof Error ? err.message : "Failed to load document.");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, owner, repo, filePath, branch]);
+
+  const save = useCallback(
+    async (nextContent: JSONContent, message = "Auto-save") => {
+      setSaveState("saving");
+      try {
+        const result = await commitDocument({
+          client,
+          owner,
+          repo,
+          filePath,
+          branch,
+          content: nextContent,
+          message,
+          sha: fileShaRef.current || undefined,
+        });
+        setFileSha(result.fileSha ?? fileShaRef.current);
+        setSaveState("saved");
+        setLastSaved(new Date());
+      } catch (err) {
+        setSaveState("error");
+        console.error("Auto-save failed:", err);
+      }
+    },
+    [client, owner, repo, filePath, branch]
+  );
+
+  const handleChange = useCallback(
+    (nextContent: JSONContent) => {
+      setContent(nextContent);
+      setSaveState("idle");
+
+      if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+      autosaveTimer.current = setTimeout(() => {
+        void save(nextContent, `Auto-save: ${filePath}`);
+      }, AUTOSAVE_DELAY_MS);
+    },
+    [save, filePath]
+  );
+
+  const handleManualSave = useCallback(() => {
+    if (!content) return;
+    if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    void save(content, `Save: ${filePath}`);
+  }, [content, save, filePath]);
+
+  const docTitle = filePath.split("/").pop()?.replace(".json", "") ?? filePath;
+
+  const saveLabel =
+    saveState === "saving"
+      ? "Saving…"
+      : saveState === "saved"
+        ? `Saved ${lastSaved?.toLocaleTimeString() ?? ""}`
+        : saveState === "error"
+          ? "Save failed"
+          : "Save";
+
+  if (loading) {
+    return (
+      <div className="app-shell">
+        <header className="app-topbar">
+          <button className="bs-btn bs-btn-secondary" type="button" onClick={onBack}>
+            ← Back
+          </button>
+        </header>
+        <main className="app-main">
+          <div className="bs-card app-doc-empty">Loading document…</div>
+        </main>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="app-shell">
+        <header className="app-topbar">
+          <button className="bs-btn bs-btn-secondary" type="button" onClick={onBack}>
+            ← Back
+          </button>
+        </header>
+        <main className="app-main">
+          <section className="bs-card app-error">
+            <div className="bs-eyebrow">Load Error</div>
+            <h2>Could not load document</h2>
+            <p>{loadError}</p>
+          </section>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="app-shell">
+      <header className="app-topbar">
+        <div className="app-logo-wrap">
+          <button className="bs-btn bs-btn-secondary" type="button" onClick={onBack}>
+            ← Documents
+          </button>
+          <span className="app-logo-text" style={{ marginLeft: "var(--brand-space-3)" }}>{docTitle}</span>
+        </div>
+        <div className="app-topbar-actions">
+          <span style={{ fontSize: "var(--brand-text-sm)", color: "var(--bs-text-secondary)" }}>
+            {saveState === "error" ? "⚠ Save failed" : lastSaved ? `Saved ${lastSaved.toLocaleTimeString()}` : ""}
+          </span>
+          <button
+            className="bs-btn bs-btn-secondary"
+            type="button"
+            onClick={handleManualSave}
+            disabled={saveState === "saving"}
+          >
+            {saveLabel}
+          </button>
+        </div>
+      </header>
+
+      <main className="app-main" style={{ padding: 0 }}>
+        {content && (
+          <DemoEditor
+            initialContent={content}
+            onChange={handleChange}
+          />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/services/gitea/documents.test.ts
+++ b/src/services/gitea/documents.test.ts
@@ -1,7 +1,23 @@
 import { afterEach, expect, mock, test } from 'bun:test';
-import type { Commit, FileResponse } from 'gitea-js';
+import type { Commit, ContentsResponse, FileResponse } from 'gitea-js';
 
 import type { GiteaClient } from './client';
+
+const validDoc = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }],
+};
+
+// Base64-encode the valid doc JSON as Gitea would return it.
+const validDocBase64 = Buffer.from(JSON.stringify(validDoc), 'utf8').toString('base64');
+
+const repoGetContentsMock = mock(async () => ({
+  data: {
+    type: 'file',
+    content: validDocBase64,
+    sha: 'contents-file-sha',
+  } as ContentsResponse,
+}));
 
 const repoCreateFileMock = mock(async () => ({
   data: {
@@ -65,6 +81,7 @@ const client = {
     repoUpdateFile: repoUpdateFileMock,
     repoGetRawFileOrLfs: repoGetRawFileOrLfsMock,
     repoGetAllCommits: repoGetAllCommitsMock,
+    repoGetContents: repoGetContentsMock,
   },
 } as unknown as GiteaClient;
 
@@ -73,6 +90,7 @@ afterEach(() => {
   repoUpdateFileMock.mockReset();
   repoGetRawFileOrLfsMock.mockReset();
   repoGetAllCommitsMock.mockReset();
+  repoGetContentsMock.mockReset();
 
   repoCreateFileMock.mockImplementation(async () => ({
     data: {
@@ -114,6 +132,14 @@ afterEach(() => {
         },
       },
     ] as Commit[],
+  }));
+
+  repoGetContentsMock.mockImplementation(async () => ({
+    data: {
+      type: 'file',
+      content: validDocBase64,
+      sha: 'contents-file-sha',
+    } as ContentsResponse,
   }));
 });
 
@@ -341,4 +367,79 @@ test('listDocumentCommits maps API failures to GiteaApiError', async () => {
     status: 404,
     message: 'not found',
   });
+});
+
+// ─── fetchDocument ────────────────────────────────────────────────────────────
+
+test('fetchDocument returns content and sha from repoGetContents', async () => {
+  const { fetchDocument } = await import('./documents');
+
+  const result = await fetchDocument({
+    client,
+    owner: 'alice',
+    repo: 'quarterly-report',
+    filePath: 'documents/draft.json',
+    branch: 'main',
+  });
+
+  expect(repoGetContentsMock).toHaveBeenCalledWith(
+    'alice',
+    'quarterly-report',
+    'documents/draft.json',
+    { ref: 'main' },
+  );
+  expect(result.content).toEqual(validDoc);
+  expect(result.sha).toBe('contents-file-sha');
+});
+
+test('fetchDocument rejects when path is a directory', async () => {
+  const { fetchDocument } = await import('./documents');
+
+  repoGetContentsMock.mockImplementation(async () => ({
+    data: { type: 'dir', sha: 'dir-sha' } as ContentsResponse,
+  }));
+
+  await expect(
+    fetchDocument({ client, owner: 'alice', repo: 'quarterly-report', filePath: 'documents', branch: 'main' }),
+  ).rejects.toMatchObject({ name: 'GiteaApiError' });
+});
+
+test('fetchDocument rejects when content is not valid ProseMirror JSON', async () => {
+  const { fetchDocument } = await import('./documents');
+
+  const badContent = Buffer.from(JSON.stringify({ type: 'paragraph' }), 'utf8').toString('base64');
+  repoGetContentsMock.mockImplementation(async () => ({
+    data: { type: 'file', content: badContent, sha: 'sha' } as ContentsResponse,
+  }));
+
+  await expect(
+    fetchDocument({ client, owner: 'alice', repo: 'quarterly-report', filePath: 'documents/draft.json', branch: 'main' }),
+  ).rejects.toMatchObject({
+    name: 'GiteaApiError',
+    message: expect.stringContaining('documents/draft.json'),
+  });
+});
+
+test('fetchDocument rejects when content is invalid base64/JSON', async () => {
+  const { fetchDocument } = await import('./documents');
+
+  repoGetContentsMock.mockImplementation(async () => ({
+    data: { type: 'file', content: 'not-valid-base64!!!', sha: 'sha' } as ContentsResponse,
+  }));
+
+  await expect(
+    fetchDocument({ client, owner: 'alice', repo: 'quarterly-report', filePath: 'documents/draft.json', branch: 'main' }),
+  ).rejects.toMatchObject({ name: 'GiteaApiError' });
+});
+
+test('fetchDocument propagates API errors as GiteaApiError', async () => {
+  const { fetchDocument } = await import('./documents');
+
+  repoGetContentsMock.mockImplementation(async () => {
+    throw { status: 404, error: { message: 'file not found' } };
+  });
+
+  await expect(
+    fetchDocument({ client, owner: 'alice', repo: 'quarterly-report', filePath: 'documents/missing.json', branch: 'main' }),
+  ).rejects.toMatchObject({ name: 'GiteaApiError', status: 404 });
 });

--- a/src/services/gitea/documents.ts
+++ b/src/services/gitea/documents.ts
@@ -227,6 +227,47 @@ export async function fetchDocumentAtSha(params: FetchDocumentAtShaParams): Prom
   }
 }
 
+export interface FetchDocumentParams {
+  client: GiteaClient;
+  owner: string;
+  repo: string;
+  filePath: string;
+  branch?: string;
+}
+
+export interface FetchDocumentResult {
+  content: ProseMirrorJSON;
+  sha: string;
+}
+
+/**
+ * Fetch a document's current content and its file SHA (needed for subsequent updates).
+ */
+export async function fetchDocument(params: FetchDocumentParams): Promise<FetchDocumentResult> {
+  const { client, owner, repo, filePath, branch } = params;
+
+  try {
+    const response = await client.repos.repoGetContents(owner, repo, filePath, { ref: branch });
+    const file = response.data as { content?: string; sha?: string; type?: string };
+
+    if (file.type !== 'file' || !file.content) {
+      throw new GiteaApiError(0, `Path ${filePath} is not a file.`);
+    }
+
+    const decoded = atob(file.content.replace(/\n/g, ''));
+    const parsed = JSON.parse(decoded) as unknown;
+    return {
+      content: assertProseMirrorDocument(parsed, filePath),
+      sha: file.sha ?? '',
+    };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new GiteaApiError(0, `Unable to parse document JSON at ${filePath}.`);
+    }
+    throw toGiteaApiError(error);
+  }
+}
+
 export async function listDocumentCommits(params: ListDocumentCommitsParams): Promise<CommitSummary[]> {
   const { client, owner, repo, filePath, page, limit } = params;
 


### PR DESCRIPTION
Closes #71

## Summary
- **`fetchDocument()`** added to documents service — fetches file content **and** its SHA in one call. Storing the SHA after every save prevents the `409 Conflict` Gitea returns when you update without the current SHA.
- **`AppShell`** rewritten to dynamically fetch repos via `repoSearch()` (sorted by last updated). Each card shows the repo/description and an "Open" button.
- **`DocumentEditor`** new component:
  - Loads `document.json` from the selected repo on mount
  - 2-second debounced auto-save after any edit
  - Manual "Save" button
  - Last-saved timestamp shown in toolbar
  - SHA is tracked in a ref and updated after each successful save
- **New Document** flow: prompts for a name, creates a Gitea repo, seeds an empty `document.json`

## Design note
Documents are stored as `document.json` in the repo root (one doc per repo). This matches the "one repo per workspace" model in the issue. The seeded `quarterly-report` repo with `documents/*.json` paths won't be reachable by the "Open" button yet — that needs a file browser. Left as a follow-up.

## Test plan
- [ ] Run `bun run up`, open `http://localhost:5173/app`
- [ ] Verify repo list loads from Gitea (shows `quarterly-report`)
- [ ] Click "New Document", enter a name, verify repo is created in Gitea and editor opens
- [ ] Type in editor, wait 2s, verify commit appears in Gitea repo
- [ ] Click "Save" manually, verify commit with message "Save: document.json"
- [ ] Reload page and reopen document — verify content persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)