### PR TITLE
feat: version history sidebar with commit list and restore (#72)

### DIFF
--- a/src/app/components/GiteaVersionHistory.tsx
+++ b/src/app/components/GiteaVersionHistory.tsx
@@ -1,0 +1,198 @@
+/**
+ * Gitea-backed version history sidebar.
+ *
+ * Lists commits for a document file, allows viewing a historical version
+ * in a read-only preview, and restoring any version as a new commit.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import type { JSONContent } from "@tiptap/core";
+import { History, Clock, User, Eye, RotateCcw } from "lucide-react";
+
+import { GiteaApiError, type GiteaClient } from "../../services/gitea/client";
+import { commitDocument, fetchDocumentAtSha, listDocumentCommits, type CommitSummary } from "../../services/gitea/documents";
+
+interface GiteaVersionHistoryProps {
+  client: GiteaClient;
+  owner: string;
+  repo: string;
+  filePath: string;
+  branch?: string;
+  currentFileSha: string;
+  /** Called when "View" is clicked — renders that version read-only in the editor. */
+  onPreview: (content: JSONContent, commitSha: string) => void;
+  /** Called when "Restore" succeeds — passes new file SHA. */
+  onRestore: (newFileSha: string) => void;
+  /** SHA of the commit currently being previewed (if any). */
+  previewingSha?: string | null;
+}
+
+export function GiteaVersionHistory({
+  client,
+  owner,
+  repo,
+  filePath,
+  branch = "main",
+  currentFileSha,
+  onPreview,
+  onRestore,
+  previewingSha,
+}: GiteaVersionHistoryProps) {
+  const [commits, setCommits] = useState<CommitSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [restoringsha, setRestoringSha] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await listDocumentCommits({ client, owner, repo, filePath, limit: 50 });
+        if (!cancelled) setCommits(result);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof GiteaApiError ? err.message : "Failed to load history.");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, owner, repo, filePath]);
+
+  const handleView = useCallback(
+    async (commit: CommitSummary) => {
+      try {
+        const content = await fetchDocumentAtSha({ client, owner, repo, filePath, sha: commit.sha });
+        onPreview(content, commit.sha);
+      } catch (err) {
+        const msg = err instanceof GiteaApiError ? err.message : "Failed to load version.";
+        window.alert(msg);
+      }
+    },
+    [client, owner, repo, filePath, onPreview]
+  );
+
+  const handleRestore = useCallback(
+    async (commit: CommitSummary) => {
+      const confirmed = window.confirm(
+        `Restore to commit ${commit.sha.slice(0, 7)}?\n\n"${commit.message}"\n\nThis will create a new commit — history is preserved.`
+      );
+      if (!confirmed) return;
+
+      setRestoringSha(commit.sha);
+      try {
+        const content = await fetchDocumentAtSha({ client, owner, repo, filePath, sha: commit.sha });
+        const result = await commitDocument({
+          client,
+          owner,
+          repo,
+          filePath,
+          branch,
+          content,
+          message: `Restored to "${commit.message.slice(0, 50)}"`,
+          sha: currentFileSha || undefined,
+        });
+
+        // Refresh commit list
+        const refreshed = await listDocumentCommits({ client, owner, repo, filePath, limit: 50 });
+        setCommits(refreshed);
+        onRestore(result.fileSha ?? currentFileSha);
+      } catch (err) {
+        const msg = err instanceof GiteaApiError ? err.message : "Restore failed.";
+        window.alert(msg);
+      } finally {
+        setRestoringSha(null);
+      }
+    },
+    [client, owner, repo, filePath, branch, currentFileSha, onRestore]
+  );
+
+  return (
+    <div className="vc-panel">
+      <div className="vc-panel-header">
+        <History size={20} />
+        <h2>Version History</h2>
+      </div>
+
+      {loading ? (
+        <div className="vc-section" style={{ padding: "var(--brand-space-4)" }}>
+          <span style={{ color: "var(--bs-text-secondary)", fontSize: "var(--brand-text-sm)" }}>Loading…</span>
+        </div>
+      ) : error ? (
+        <div className="vc-section" style={{ padding: "var(--brand-space-4)", color: "var(--bs-color-error)" }}>
+          {error}
+        </div>
+      ) : (
+        <div className="vc-section flex flex-1 min-h-0 flex-col">
+          <div className="vc-header">
+            <History size={16} />
+            <span className="vc-title">{commits.length} commits</span>
+          </div>
+
+          <div className="vc-content flex-1 overflow-y-auto commit-list">
+            {commits.length === 0 ? (
+              <div className="empty-state">No commits yet</div>
+            ) : (
+              commits.map((commit) => {
+                const isPreviewing = commit.sha === previewingSha;
+                const isRestoring = commit.sha === restoringsha;
+
+                return (
+                  <div
+                    key={commit.sha}
+                    className={`commit-item${isPreviewing ? " selected-head" : ""}`}
+                  >
+                    <div className="commit-message" title={commit.message}>
+                      {commit.message}
+                    </div>
+                    <div className="commit-meta">
+                      <span className="commit-author">
+                        <User size={10} /> {commit.author}
+                      </span>
+                      <span className="commit-date">
+                        <Clock size={10} />
+                        {new Date(commit.timestamp).toLocaleString([], {
+                          month: "short",
+                          day: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </span>
+                    </div>
+                    <div className="commit-id">{commit.sha.slice(0, 7)}</div>
+                    <div style={{ display: "flex", gap: "var(--brand-space-2)", marginTop: "var(--brand-space-2)" }}>
+                      <button
+                        className="bs-btn bs-btn-secondary"
+                        style={{ flex: 1, fontSize: "var(--brand-text-xs)", padding: "2px 6px" }}
+                        onClick={() => void handleView(commit)}
+                        title="View this version (read-only)"
+                      >
+                        <Eye size={12} /> View
+                      </button>
+                      <button
+                        className="bs-btn bs-btn-secondary"
+                        style={{ flex: 1, fontSize: "var(--brand-text-xs)", padding: "2px 6px" }}
+                        onClick={() => void handleRestore(commit)}
+                        disabled={isRestoring}
+                        title="Restore to this version (creates new commit)"
+                      >
+                        <RotateCcw size={12} /> {isRestoring ? "…" : "Restore"}
+                      </button>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -118,6 +118,8 @@ interface EditorProps {
   onSubmitForReview?: () => void;
   onApprove?: () => void;
   onRequestChanges?: () => void;
+  /** Optional Gitea-backed panel to replace the in-memory VC panel. */
+  giteaHistoryPanel?: React.ReactNode;
 }
 
 const sanitizeContentForEditor = (content: Content): Content => {
@@ -1203,6 +1205,7 @@ export const DemoEditor = ({
   onSubmitForReview,
   onApprove,
   onRequestChanges,
+  giteaHistoryPanel,
 }: EditorProps) => {
   const sanitizedInitialContent = useMemo(
     () => sanitizeContentForEditor(initialContent),
@@ -1796,18 +1799,22 @@ export const DemoEditor = ({
               onMouseDown={startResizing}
             />
             {showVcPanel ? (
-              <VersionControlPanel
-                getEditorContent={() =>
-                  isPreviewMode ? originalContent : editor?.getHTML() || ""
-                }
-                onContentChange={(content) => {
-                  editor?.commands.setContent(
-                    sanitizeContentForEditor(content),
-                  );
-                }}
-                onPreviewDiff={handlePreviewDiff}
-                isPreviewMode={isPreviewMode}
-              />
+              giteaHistoryPanel ? (
+                giteaHistoryPanel
+              ) : (
+                <VersionControlPanel
+                  getEditorContent={() =>
+                    isPreviewMode ? originalContent : editor?.getHTML() || ""
+                  }
+                  onContentChange={(content) => {
+                    editor?.commands.setContent(
+                      sanitizeContentForEditor(content),
+                    );
+                  }}
+                  onPreviewDiff={handlePreviewDiff}
+                  isPreviewMode={isPreviewMode}
+                />
+              )
             ) : showCommentsPanel ? (
               <CommentSidebar editor={editor} comments={comments} />
             ) : null}


### PR DESCRIPTION
Closes #72

## Summary
- **`GiteaVersionHistory`** component: fetches up to 50 commits for a file via `listDocumentCommits()`, shows SHA, message, author, timestamp
- **View** button: calls `fetchDocumentAtSha()` and passes content to `onPreview` callback — caller can render it read-only in the editor
- **Restore** button: confirms with user, fetches historical content, commits it as a new commit (preserves full history — no revert/force-push), refreshes the commit list
- **`giteaHistoryPanel` prop** added to `DemoEditor`: when provided, renders the injected panel instead of the in-memory `VersionControlPanel`. Triggered by the existing GitGraph toolbar button — no new toolbar button needed.

## Wiring
The `GiteaVersionHistory` panel is wired into `DocumentEditor` (PR #79 / feat/document-editor-71) — that PR will pass `client`, `owner`, `repo`, `filePath`, and `currentFileSha` as props. This PR is intentionally standalone so it can be reviewed and merged independently.

## Design note
Restore always creates a **new commit**, never a revert or force-push. This is intentional for regulated industry customers where full audit trails are required.

## Test plan
- [ ] Open an editor with `giteaHistoryPanel` prop set, click the GitGraph button — verify history panel appears
- [ ] After auto-save creates commits, verify history list loads and shows correct entries
- [ ] Click "View" — verify editor enters read-only preview of that version
- [ ] Click "Restore" — confirm dialog → verify new commit appears at top of list

🤖 Generated with [Claude Code](https://claude.com/claude-code)