### PR TITLE
feat: GitHub Actions CI/CD for S3+CloudFront production deploy (#74)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,76 @@
+name: Deploy to Production (S3 + CloudFront)
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Only one deploy at a time
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  id-token: write   # Required for OIDC → AWS role assumption
+  contents: read
+
+jobs:
+  build-and-deploy:
+    name: Build SPA and deploy to S3
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build SPA
+        env:
+          # These are public build-time env vars — safe to expose in the bundle.
+          BUN_PUBLIC_GITEA_URL: ${{ vars.VITE_GITEA_URL }}
+          BUN_PUBLIC_GITEA_OAUTH_CLIENT_ID: ${{ vars.VITE_GITEA_CLIENT_ID }}
+          BUN_PUBLIC_GITEA_OAUTH_REDIRECT_URI: https://bindersnap.com/auth/callback
+          BUN_PUBLIC_PANDOC_SERVICE_URL: ${{ vars.VITE_PANDOC_SERVICE_URL }}
+        run: bun run build
+
+      # ── AWS auth via OIDC (no long-lived credentials) ───────────────────────
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      # ── Upload to S3 ─────────────────────────────────────────────────────────
+      - name: Sync dist/ to S3
+        run: |
+          # Upload static assets with long cache (1 year) — they're content-hashed
+          aws s3 sync dist/ s3://${{ vars.S3_BUCKET_NAME }} \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html"
+
+          # Upload index.html with no-cache so deploys take effect immediately
+          aws s3 cp dist/index.html s3://${{ vars.S3_BUCKET_NAME }}/index.html \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+      # ── Invalidate CloudFront ─────────────────────────────────────────────────
+      - name: Invalidate CloudFront distribution
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"
+
+      - name: Deployment summary
+        run: |
+          echo "### Production deployment complete" >> $GITHUB_STEP_SUMMARY
+          echo "- **Bucket:** s3://${{ vars.S3_BUCKET_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **CloudFront:** ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL:** https://bindersnap.com" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Closes #74

## Summary
Adds `.github/workflows/deploy-production.yml` — triggers on push to `main` and manual dispatch.

**What it does:**
1. Builds the SPA with `bun run build` (injects `BUN_PUBLIC_*` env vars from repo variables)
2. Authenticates to AWS via OIDC (no long-lived credentials stored as secrets)
3. Syncs `dist/` to S3: content-hashed assets get 1-year immutable cache; `index.html` gets `no-cache`
4. Invalidates CloudFront so every deploy takes effect immediately

## ⚠️ External infrastructure required before this workflow will succeed

The workflow is ready but the following AWS resources need to be provisioned first:

| Resource | Notes |
|---|---|
| S3 bucket | Private, OAC access only. Set `S3_BUCKET_NAME` in repo variables |
| CloudFront distribution | Origin: S3 via OAC, custom domain `bindersnap.com`, 404→`/index.html` with 200 (SPA routing). Set `CLOUDFRONT_DISTRIBUTION_ID` in repo secrets |
| ACM certificate | `bindersnap.com` + `www.bindersnap.com` in `us-east-1` |
| Route 53 records | A/AAAA alias for `bindersnap.com` → CloudFront, redirect `www` → apex |
| IAM OIDC role | Trust policy for `token.actions.githubusercontent.com`, permissions: `s3:PutObject`, `s3:DeleteObject`, `cloudfront:CreateInvalidation`. Set `AWS_DEPLOY_ROLE_ARN` in repo secrets |
| Gitea URL / OAuth client ID | Set `VITE_GITEA_URL`, `VITE_GITEA_CLIENT_ID`, `VITE_PANDOC_SERVICE_URL` in repo variables |

## Test plan
- [ ] Provision the above AWS resources
- [ ] Add required secrets and variables to the repo
- [ ] Trigger a manual dispatch and verify deploy summary shows expected bucket/distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)