### PR TITLE
feat: Stripe Checkout webhook handler and Billing page (#75)

### DIFF
--- a/dev/.env.example
+++ b/dev/.env.example
@@ -14,3 +14,11 @@ BINDERSNAP_DEV_AUTO_LOGIN=true
 GITEA_INTERNAL_URL=http://gitea:3000
 GITEA_ADMIN_USER=alice
 GITEA_ADMIN_PASS=bindersnap-dev
+
+# Stripe — get from Stripe dashboard (leave empty in dev)
+# Payment Link: Dashboard > Payment Links > Create
+# Customer Portal: Dashboard > Settings > Billing > Customer portal
+BUN_PUBLIC_STRIPE_PAYMENT_LINK=
+BUN_PUBLIC_STRIPE_PORTAL_URL=
+# Server-side webhook secret — from Stripe CLI: stripe listen --print-secret
+STRIPE_WEBHOOK_SECRET=

--- a/dev/tests/stripe-webhook.pw.ts
+++ b/dev/tests/stripe-webhook.pw.ts
@@ -1,0 +1,60 @@
+/**
+ * Integration tests for POST /stripe/webhook against the running dev server.
+ *
+ * The dev server runs without STRIPE_WEBHOOK_SECRET by default, so signature
+ * verification is skipped and we get 200 back. The tests also cover the case
+ * where a secret is provided — but since we can't easily inject env vars into
+ * an already-running server, we test the "no secret configured" path here and
+ * rely on unit tests (src/stripe/webhook.test.ts) for the HMAC math.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const APP_BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+const WEBHOOK_URL = `${APP_BASE_URL}/stripe/webhook`;
+
+test.describe('POST /stripe/webhook', () => {
+  test('returns 財 200 for a well-formed checkout.session.completed event', async ({ request }) => {
+    const body = JSON.stringify({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_test_123',
+          customer: 'cus_test',
+          customer_email: 'test@example.com',
+          amount_total: 2900,
+          currency: 'usd',
+          payment_status: 'paid',
+        },
+      },
+    });
+
+    const response = await request.post(WEBHOOK_URL, {
+      data: body,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    // Without STRIPE_WEBHOOK_SECRET configured, signature check is skipped.
+    expect(response.status()).toBe(200);
+  });
+
+  test('returns 200 for an unhandled event type (server logs and acks)', async ({ request }) => {
+    const body = JSON.stringify({ type: 'customer.subscription.updated', data: { object: {} } });
+
+    const response = await request.post(WEBHOOK_URL, {
+      data: body,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(response.status()).toBe(200);
+  });
+
+  test('returns 400 for a non-JSON body', async ({ request }) => {
+    const response = await request.post(WEBHOOK_URL, {
+      data: 'not-json',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+    expect(response.status()).toBe(400);
+  });
+});

--- a/src/app/components/BillingPage.tsx
+++ b/src/app/components/BillingPage.tsx
@@ -1,0 +1,78 @@
+/**
+ * Billing page — shows current plan status and links to Stripe Checkout / Customer Portal.
+ *
+ * The STRIPE_PAYMENT_LINK and STRIPE_PORTAL_URL come from env vars so they
+ * can be set without code changes. Until they're configured, the buttons
+ * show a placeholder state.
+ */
+
+const appEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env;
+const PAYMENT_LINK = appEnv?.BUN_PUBLIC_STRIPE_PAYMENT_LINK ?? "";
+const PORTAL_URL = appEnv?.BUN_PUBLIC_STRIPE_PORTAL_URL ?? "";
+
+interface BillingPageProps {
+  onClose: () => void;
+}
+
+export function BillingPage({ onClose }: BillingPageProps) {
+  return (
+    <section className="app-gate" style={{ alignItems: "flex-start", paddingTop: "var(--brand-space-12)" }}>
+      <div className="app-gate-panel bs-card" style={{ maxWidth: 480, width: "100%" }}>
+        <div className="bs-eyebrow">Billing</div>
+        <h1>Manage your plan</h1>
+
+        <dl style={{ marginBottom: "var(--brand-space-6)" }}>
+          <div>
+            <dt style={{ fontWeight: 600 }}>Current plan</dt>
+            <dd>Free (local dev)</dd>
+          </div>
+        </dl>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--brand-space-3)" }}>
+          {PAYMENT_LINK ? (
+            <a
+              href={PAYMENT_LINK}
+              className="bs-btn bs-btn-primary app-submit"
+              style={{ textAlign: "center", textDecoration: "none" }}
+            >
+              Upgrade — Pay with Stripe
+            </a>
+          ) : (
+            <button
+              className="bs-btn bs-btn-primary app-submit"
+              type="button"
+              disabled
+              title="Set BUN_PUBLIC_STRIPE_PAYMENT_LINK to enable"
+            >
+              Upgrade (Stripe not configured)
+            </button>
+          )}
+
+          {PORTAL_URL ? (
+            <a
+              href={PORTAL_URL}
+              className="bs-btn bs-btn-secondary"
+              style={{ textAlign: "center", textDecoration: "none" }}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Manage subscription →
+            </a>
+          ) : null}
+
+          <button
+            className="bs-btn bs-btn-secondary"
+            type="button"
+            onClick={onClose}
+          >
+            Back
+          </button>
+        </div>
+
+        <p style={{ marginTop: "var(--brand-space-4)", fontSize: "var(--brand-text-sm)", color: "var(--bs-text-secondary)" }}>
+          Payments are processed securely by Stripe. Bindersnap never stores card details.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,44 @@ function isAutoLoginEnabled(): boolean {
   return process.env.NODE_ENV !== "production";
 }
 
+/**
+ * Verify a Stripe webhook signature using HMAC-SHA256.
+ * Stripe sends: stripe-signature: t=<timestamp>,v1=<sig>[,v1=<sig2>...]
+ * We compute HMAC-SHA256(secret, "<timestamp>.<rawBody>") and compare.
+ */
+async function verifyStripeSignature(rawBody: string, signature: string, secret: string): Promise<boolean> {
+  try {
+    const parts = Object.fromEntries(
+      signature.split(",").map((part) => {
+        const eq = part.indexOf("=");
+        return [part.slice(0, eq), part.slice(eq + 1)];
+      }),
+    );
+
+    const timestamp = parts["t"];
+    const expectedSigs = signature.split(",")
+      .filter((p) => p.startsWith("v1="))
+      .map((p) => p.slice(3));
+
+    if (!timestamp || expectedSigs.length === 0) return false;
+
+    const payload = `${timestamp}.${rawBody}`;
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
+    const computed = Buffer.from(mac).toString("hex");
+
+    return expectedSigs.some((sig) => sig === computed);
+  } catch {
+    return false;
+  }
+}
+
 function jsonResponse(status: number, body: Record<string, unknown>): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -26,6 +64,7 @@ function jsonResponse(status: number, body: Record<string, unknown>): Response {
 }
 
 const devAutoLoginEnabled = isAutoLoginEnabled();
+const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET ?? "";
 const giteaInternalUrl =
   process.env.GITEA_INTERNAL_URL ??
   process.env.VITE_GITEA_URL ??
@@ -91,6 +130,49 @@ const server = serve({
         }
 
         return jsonResponse(200, { token: payload.sha1 });
+      },
+    },
+
+    "/stripe/webhook": {
+      async POST(req) {
+        if (!stripeWebhookSecret) {
+          console.warn("[stripe] STRIPE_WEBHOOK_SECRET is not set — webhook signature verification skipped.");
+        }
+
+        const rawBody = await req.text();
+
+        // Verify Stripe signature when secret is configured.
+        if (stripeWebhookSecret) {
+          const signature = req.headers.get("stripe-signature") ?? "";
+          const isValid = await verifyStripeSignature(rawBody, signature, stripeWebhookSecret);
+          if (!isValid) {
+            console.warn("[stripe] Invalid webhook signature.");
+            return new Response("Forbidden", { status: 403 });
+          }
+        }
+
+        let event: { type?: string; data?: { object?: Record<string, unknown> } };
+        try {
+          event = JSON.parse(rawBody) as typeof event;
+        } catch {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        if (event.type === "checkout.session.completed") {
+          const session = event.data?.object ?? {};
+          console.log("[stripe] checkout.session.completed:", JSON.stringify({
+            id: session.id,
+            customer: session.customer,
+            customer_email: session.customer_email,
+            amount_total: session.amount_total,
+            currency: session.currency,
+            payment_status: session.payment_status,
+          }));
+        } else {
+          console.log(`[stripe] Received unhandled event type: ${event.type ?? "unknown"}`);
+        }
+
+        return new Response("OK", { status: 200 });
       },
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "bun";
 import index from "./index.html";
 import appIndex from "./app/index.html";
+import { verifyStripeSignature } from "./stripe/webhook";
 
 function parseBoolean(value: string | undefined): boolean {
   return value === "1" || value?.toLowerCase() === "true";
@@ -13,44 +14,6 @@ function isAutoLoginEnabled(): boolean {
   }
 
   return process.env.NODE_ENV !== "production";
-}
-
-/**
- * Verify a Stripe webhook signature using HMAC-SHA256.
- * Stripe sends: stripe-signature: t=<timestamp>,v1=<sig>[,v1=<sig2>...]
- * We compute HMAC-SHA256(secret, "<timestamp>.<rawBody>") and compare.
- */
-async function verifyStripeSignature(rawBody: string, signature: string, secret: string): Promise<boolean> {
-  try {
-    const parts = Object.fromEntries(
-      signature.split(",").map((part) => {
-        const eq = part.indexOf("=");
-        return [part.slice(0, eq), part.slice(eq + 1)];
-      }),
-    );
-
-    const timestamp = parts["t"];
-    const expectedSigs = signature.split(",")
-      .filter((p) => p.startsWith("v1="))
-      .map((p) => p.slice(3));
-
-    if (!timestamp || expectedSigs.length === 0) return false;
-
-    const payload = `${timestamp}.${rawBody}`;
-    const key = await crypto.subtle.importKey(
-      "raw",
-      new TextEncoder().encode(secret),
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["sign"],
-    );
-    const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
-    const computed = Buffer.from(mac).toString("hex");
-
-    return expectedSigs.some((sig) => sig === computed);
-  } catch {
-    return false;
-  }
 }
 
 function jsonResponse(status: number, body: Record<string, unknown>): Response {

--- a/src/stripe/webhook.test.ts
+++ b/src/stripe/webhook.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { verifyStripeSignature } from './webhook';
+
+const SECRET = 'whsec_test_secret_key_for_tests';
+
+/** Build a valid Stripe-style signature header for the given payload. */
+async function buildSignature(rawBody: string, timestamp: string, secret: string): Promise<string> {
+  const payload = `${timestamp}.${rawBody}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
+  const sig = Buffer.from(mac).toString('hex');
+  return `t=${timestamp},v1=${sig}`;
+}
+
+describe('verifyStripeSignature', () => {
+  test('accepts a valid signature', async () => {
+    const body = JSON.stringify({ type: 'checkout.session.completed' });
+    const timestamp = '1700000000';
+    const sig = await buildSignature(body, timestamp, SECRET);
+    expect(await verifyStripeSignature(body, sig, SECRET)).toBe(true);
+  });
+
+  test('rejects a tampered body', async () => {
+    const body = JSON.stringify({ type: 'checkout.session.completed' });
+    const timestamp = '1700000000';
+    const sig = await buildSignature(body, timestamp, SECRET);
+    const tampered = JSON.stringify({ type: 'charge.refunded' });
+    expect(await verifyStripeSignature(tampered, sig, SECRET)).toBe(false);
+  });
+
+  test('rejects a wrong secret', async () => {
+    const body = JSON.stringify({ type: 'checkout.session.completed' });
+    const timestamp = '1700000000';
+    const sig = await buildSignature(body, timestamp, SECRET);
+    expect(await verifyStripeSignature(body, sig, 'wrong_secret')).toBe(false);
+  });
+
+  test('rejects a tampered signature hex', async () => {
+    const body = JSON.stringify({ type: 'checkout.session.completed' });
+    const timestamp = '1700000000';
+    const sig = await buildSignature(body, timestamp, SECRET);
+    const tampered = sig.replace(/v1=[0-9a-f]{4}/, 'v1=0000');
+    expect(await verifyStripeSignature(body, tampered, SECRET)).toBe(false);
+  });
+
+  test('accepts when multiple v1 sigs are present and one matches', async () => {
+    const body = '{"type":"test"}';
+    const timestamp = '1700000001';
+    const validSig = await buildSignature(body, timestamp, SECRET);
+    const hex = validSig.split('v1=')[1];
+    const multiSig = `t=${timestamp},v1=deadbeef,v1=${hex}`;
+    expect(await verifyStripeSignature(body, multiSig, SECRET)).toBe(true);
+  });
+
+  test('returns false for missing timestamp', async () => {
+    expect(await verifyStripeSignature('{}', 'v1=abc123', SECRET)).toBe(false);
+  });
+
+  test('returns false for missing v1 sig', async () => {
+    expect(await verifyStripeSignature('{}', 't=1700000000', SECRET)).toBe(false);
+  });
+
+  test('returns false for empty signature string', async () => {
+    expect(await verifyStripeSignature('{}', '', SECRET)).toBe(false);
+  });
+
+  test('returns false for completely malformed header', async () => {
+    expect(await verifyStripeSignature('{}', 'not-a-stripe-header', SECRET)).toBe(false);
+  });
+});

--- a/src/stripe/webhook.ts
+++ b/src/stripe/webhook.ts
@@ -1,0 +1,37 @@
+/**
+ * Stripe webhook signature verification.
+ * Stripe sends: stripe-signature: t=<timestamp>,v1=<sig>[,v1=<sig2>...]
+ * We compute HMAC-SHA256(secret, "<timestamp>.<rawBody>") and compare.
+ */
+export async function verifyStripeSignature(rawBody: string, signature: string, secret: string): Promise<boolean> {
+  try {
+    const parts = Object.fromEntries(
+      signature.split(",").map((part) => {
+        const eq = part.indexOf("=");
+        return [part.slice(0, eq), part.slice(eq + 1)];
+      }),
+    );
+
+    const timestamp = parts["t"];
+    const expectedSigs = signature.split(",")
+      .filter((p) => p.startsWith("v1="))
+      .map((p) => p.slice(3));
+
+    if (!timestamp || expectedSigs.length === 0) return false;
+
+    const payload = `${timestamp}.${rawBody}`;
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
+    const computed = Buffer.from(mac).toString("hex");
+
+    return expectedSigs.some((sig) => sig === computed);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #75

## Summary
- **`POST /stripe/webhook`** route added to `src/index.ts`:
  - Reads raw request body (required for signature verification)
  - Verifies Stripe HMAC-SHA256 signature when `STRIPE_WEBHOOK_SECRET` is set; skips in dev when unset
  - Logs `checkout.session.completed` events to stdout with key session fields
  - Returns `200 OK` to prevent Stripe retries
- **`BillingPage`** component:
  - Shows current plan status
  - "Upgrade" button redirects to `BUN_PUBLIC_STRIPE_PAYMENT_LINK` (Stripe hosted checkout — zero backend code)
  - "Manage subscription" links to `BUN_PUBLIC_STRIPE_PORTAL_URL` (Stripe Customer Portal)
  - Both buttons degrade gracefully when env vars are not configured

## ⚠️ External requirements before Stripe works end-to-end

| Required | How to get it |
|---|---|
| Stripe Payment Link URL | Stripe Dashboard → Payment Links → Create a product + price |
| Stripe Customer Portal URL | Stripe Dashboard → Settings → Billing → Customer portal |
| `STRIPE_WEBHOOK_SECRET` | Stripe CLI: `stripe listen --forward-to localhost:5173/stripe/webhook --print-secret` |

## Local testing with Stripe CLI
```bash
# Install Stripe CLI, then:
stripe listen --forward-to http://localhost:5173/stripe/webhook
stripe trigger checkout.session.completed
# Observe "[stripe] checkout.session.completed: {...}" in server logs
```

## Test plan
- [ ] With `STRIPE_WEBHOOK_SECRET` unset: POST to `/stripe/webhook` with any body → returns 200
- [ ] With `STRIPE_WEBHOOK_SECRET` set: valid signature → 200, tampered body → 403
- [ ] `checkout.session.completed` event logged to stdout
- [ ] Billing page renders with "Upgrade" button disabled when payment link not configured
- [ ] With `BUN_PUBLIC_STRIPE_PAYMENT_LINK` set: clicking "Upgrade" redirects to Stripe

🤖 Generated with [Claude Code](https://claude.com/claude-code)