### PR TITLE
Issue #87: add upload new version API endpoint

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -10,10 +10,13 @@ Lightweight Bun auth/BFF service for the authenticated app.
 - `GET /auth/me`
 - `GET /api/app/documents`
 - `GET /api/app/documents/:id`
+- `POST /api/app/documents/:id/versions`
 
 The browser only receives a Bindersnap session cookie. Gitea access tokens stay server-side in memory for this MVP.
 
 `GET /api/app/documents` resolves the authenticated workspace repository from the session token, reads the live `documents/` directory from Gitea, and returns a normalized catalog payload. Each document includes the current published commit metadata, the latest matching pull request state, and last activity timestamps.
+
+`POST /api/app/documents/:id/versions` accepts `multipart/form-data` with `file`, `summary`, and `source_note`, validates upload extension/size, then creates a deterministic upload branch, commits the uploaded file to that branch, and opens or updates the review pull request for the version.
 
 Errors from the catalog routes are normalized as JSON objects with both a machine-readable `error.code` and a human-readable `error.message`, plus a top-level `message` field for the current frontend.
 
@@ -33,6 +36,8 @@ Errors from the catalog routes are normalized as JSON objects with both a machin
 - `BINDERSNAP_AUTH_RATE_LIMIT_ENABLED`: Enable auth endpoint rate limiting. Default `true`.
 - `BINDERSNAP_AUTH_RATE_LIMIT_WINDOW_MS`: Rate-limit window for `/auth/login` and `/auth/signup`. Default `600000` (10 minutes).
 - `BINDERSNAP_AUTH_RATE_LIMIT_MAX`: Max auth attempts per IP per action per window. Default `20`.
+- `BINDERSNAP_UPLOAD_ALLOWED_EXTENSIONS`: Comma-separated extension allowlist for upload endpoint. Default `.json,.txt,.md,.csv,.doc,.docx,.pdf,.xls,.xlsx,.ppt,.pptx`.
+- `BINDERSNAP_UPLOAD_MAX_BYTES`: Max upload payload size in bytes. Default `26214400` (25 MB).
 
 ## Local usage
 

--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
+import { createHash } from "crypto";
 
 import { handleApiRequest, loadDocumentCatalog, uploadDocumentVersion } from "./server.ts";
 
 const originalFetch = globalThis.fetch;
+const UPLOAD_BRANCH_NAME = `bindersnap/upload/main/documents-draft-json-${createHash("sha1")
+  .update("documents/draft.json")
+  .digest("hex")
+  .slice(0, 12)}`;
+const ENCODED_UPLOAD_BRANCH_NAME = encodeURIComponent(UPLOAD_BRANCH_NAME);
 
 type MockResponseBody = Record<string, unknown> | Array<unknown> | string;
 
@@ -280,7 +286,7 @@ function createMockFetchForUploadLifecycle() {
         });
       }
 
-      if (ref === "bindersnap/upload/main/documents-draft-json" && state.branchExists) {
+      if (ref === UPLOAD_BRANCH_NAME && state.branchExists) {
         return jsonResponse({
           sha: state.branchFileSha,
           content: Buffer.from(state.branchContent, "utf8").toString("base64"),
@@ -304,7 +310,7 @@ function createMockFetchForUploadLifecycle() {
         ]);
       }
 
-      if (path === "documents/draft.json" && sha === "bindersnap/upload/main/documents-draft-json" && state.branchExists) {
+      if (path === "documents/draft.json" && sha === UPLOAD_BRANCH_NAME && state.branchExists) {
         return jsonResponse([
           {
             sha: state.branchCommitSha,
@@ -318,10 +324,10 @@ function createMockFetchForUploadLifecycle() {
     }
 
     if (
-      url.pathname === "/api/v1/repos/alice/quarterly-report/branches/bindersnap%2Fupload%2Fmain%2Fdocuments-draft-json" &&
+      url.pathname === `/api/v1/repos/alice/quarterly-report/branches/${ENCODED_UPLOAD_BRANCH_NAME}` &&
       method === "GET"
     ) {
-      return state.branchExists ? jsonResponse({ name: "bindersnap/upload/main/documents-draft-json" }) : new Response("", { status: 404 });
+      return state.branchExists ? jsonResponse({ name: UPLOAD_BRANCH_NAME }) : new Response("", { status: 404 });
     }
 
     if (url.pathname === "/api/v1/repos/alice/quarterly-report/branches" && method === "POST") {
@@ -360,7 +366,7 @@ function createMockFetchForUploadLifecycle() {
       url.searchParams.get("state") === "open"
     ) {
       const head = url.searchParams.get("head");
-      if (head === "alice:bindersnap/upload/main/documents-draft-json" && state.pullRequest) {
+      if (head === `alice:${UPLOAD_BRANCH_NAME}` && state.pullRequest) {
         return jsonResponse([
           {
             number: state.pullRequest.number,
@@ -384,7 +390,7 @@ function createMockFetchForUploadLifecycle() {
         number: 12,
         title: "Upload review: Q2 Compliance Report (updated-draft.json)",
         body: "Upload review for Q2 Compliance Report",
-        head: { ref: "bindersnap/upload/main/documents-draft-json" },
+        head: { ref: UPLOAD_BRANCH_NAME },
         state: "open",
         updated_at: "2026-04-01T15:00:00Z",
         created_at: "2026-04-01T15:00:00Z",
@@ -398,7 +404,7 @@ function createMockFetchForUploadLifecycle() {
       state.pullRequest = {
         ...(state.pullRequest ?? {
           number: 12,
-          head: { ref: "bindersnap/upload/main/documents-draft-json" },
+          head: { ref: UPLOAD_BRANCH_NAME },
           state: "open",
           updated_at: "2026-04-01T15:00:00Z",
           created_at: "2026-04-01T15:00:00Z",
@@ -562,7 +568,7 @@ test("uploadDocumentVersion creates a deterministic branch and reuses it for dup
   );
 
   expect(firstResult.documentId).toBe("documents/draft.json");
-  expect(firstResult.branchName).toBe("bindersnap/upload/main/documents-draft-json");
+  expect(firstResult.branchName).toBe(UPLOAD_BRANCH_NAME);
   expect(firstResult.commitSha).toBe("branch-commit-sha-1");
   expect(firstResult.pullRequestNumber).toBe(12);
   expect(firstResult.pullRequestUrl).toBe("https://gitea.example/alice/quarterly-report/pulls/12");

--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 
-import { handleApiRequest, loadDocumentCatalog } from "./server.ts";
+import { handleApiRequest, loadDocumentCatalog, uploadDocumentVersion } from "./server.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -26,6 +26,30 @@ function createBaseSession() {
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
   } as Parameters<typeof loadDocumentCatalog>[0];
+}
+
+function createUploadSession() {
+  return {
+    id: "session-2",
+    username: "alice",
+    giteaToken: "token-123",
+    giteaTokenName: "bindersnap-session-2",
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  } as Parameters<typeof uploadDocumentVersion>[0];
+}
+
+function createUploadFormData(content: string, fileName = "updated-draft.json") {
+  const formData = new FormData();
+  formData.set(
+    "file",
+    new File([content], fileName, {
+      type: "application/json",
+    }),
+  );
+  formData.set("summary", "Updated wording for review");
+  formData.set("source_note", "Word export from legal");
+  return formData;
 }
 
 function createMockFetchForCatalog(): typeof fetch {
@@ -177,6 +201,228 @@ function createMockFetchForEmptyRepo(): typeof fetch {
   };
 }
 
+function createMockFetchForUploadLifecycle() {
+  const canonicalContent = JSON.stringify({
+    type: "doc",
+    content: [
+      {
+        type: "heading",
+        attrs: { level: 1 },
+        content: [{ type: "text", text: "Q2 Compliance Report" }],
+      },
+    ],
+  });
+
+  const uploadContent = JSON.stringify({
+    type: "doc",
+    content: [
+      {
+        type: "heading",
+        attrs: { level: 1 },
+        content: [{ type: "text", text: "Q2 Compliance Report v2" }],
+      },
+    ],
+  });
+
+  const state = {
+    branchExists: false,
+    branchContent: canonicalContent,
+    branchFileSha: "canonical-file-sha",
+    branchCommitSha: "canonical-commit-sha",
+    branchCommitCount: 0,
+    pullRequest: null as null | {
+      number: number;
+      title: string;
+      body: string;
+      head: { ref: string };
+      state: "open";
+      updated_at: string;
+      created_at: string;
+      html_url: string;
+    },
+    branchCreateCount: 0,
+    fileWriteCount: 0,
+    pullCreateCount: 0,
+    pullPatchCount: 0,
+  };
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(typeof input === "string" || input instanceof URL ? input.toString() : input.url);
+    const method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+
+    if (url.pathname === "/api/v1/user/repos" && method === "GET") {
+      return jsonResponse([
+        {
+          id: 1,
+          name: "quarterly-report",
+          full_name: "alice/quarterly-report",
+          default_branch: "main",
+          owner: { login: "alice" },
+        },
+      ]);
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/contents/documents" && method === "GET") {
+      return jsonResponse([
+        { type: "file", path: "documents/draft.json" },
+      ]);
+    }
+
+    if (
+      url.pathname === "/api/v1/repos/alice/quarterly-report/contents/documents/draft.json" &&
+      method === "GET"
+    ) {
+      const ref = url.searchParams.get("ref");
+      if (ref === "main") {
+        return jsonResponse({
+          sha: "canonical-file-sha",
+          content: Buffer.from(canonicalContent, "utf8").toString("base64"),
+        });
+      }
+
+      if (ref === "bindersnap/upload/main/documents-draft-json" && state.branchExists) {
+        return jsonResponse({
+          sha: state.branchFileSha,
+          content: Buffer.from(state.branchContent, "utf8").toString("base64"),
+        });
+      }
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/commits" && method === "GET") {
+      const path = url.searchParams.get("path");
+      const sha = url.searchParams.get("sha");
+
+      if (path === "documents/draft.json" && sha === "main") {
+        return jsonResponse([
+          {
+            sha: "canonical-commit-sha",
+            commit: {
+              message: "seed: draft document",
+              author: { name: "Alice Author", date: "2026-03-30T12:00:00Z" },
+            },
+          },
+        ]);
+      }
+
+      if (path === "documents/draft.json" && sha === "bindersnap/upload/main/documents-draft-json" && state.branchExists) {
+        return jsonResponse([
+          {
+            sha: state.branchCommitSha,
+            commit: {
+              message: "Upload new version for Q2 Compliance Report",
+              author: { name: "Alice Author", date: "2026-04-01T15:00:00Z" },
+            },
+          },
+        ]);
+      }
+    }
+
+    if (
+      url.pathname === "/api/v1/repos/alice/quarterly-report/branches/bindersnap%2Fupload%2Fmain%2Fdocuments-draft-json" &&
+      method === "GET"
+    ) {
+      return state.branchExists ? jsonResponse({ name: "bindersnap/upload/main/documents-draft-json" }) : new Response("", { status: 404 });
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/branches" && method === "POST") {
+      state.branchExists = true;
+      state.branchCreateCount += 1;
+      state.branchContent = canonicalContent;
+      state.branchFileSha = "canonical-file-sha";
+      state.branchCommitSha = "canonical-commit-sha";
+      return new Response("", { status: 201 });
+    }
+
+    if (
+      url.pathname === "/api/v1/repos/alice/quarterly-report/contents/documents/draft.json" &&
+      (method === "PUT" || method === "POST")
+    ) {
+      state.fileWriteCount += 1;
+      const body = typeof init?.body === "string" ? init.body : "";
+      const parsed = body ? (JSON.parse(body) as { content?: string }) : {};
+      state.branchContent = parsed.content ? Buffer.from(parsed.content, "base64").toString("utf8") : state.branchContent;
+      state.branchCommitCount += 1;
+      state.branchFileSha = `branch-file-sha-${state.branchCommitCount}`;
+      state.branchCommitSha = `branch-commit-sha-${state.branchCommitCount}`;
+      return jsonResponse({
+        commit: {
+          sha: state.branchCommitSha,
+        },
+        content: {
+          sha: state.branchFileSha,
+        },
+      });
+    }
+
+    if (
+      url.pathname === "/api/v1/repos/alice/quarterly-report/pulls" &&
+      method === "GET" &&
+      url.searchParams.get("state") === "open"
+    ) {
+      const head = url.searchParams.get("head");
+      if (head === "alice:bindersnap/upload/main/documents-draft-json" && state.pullRequest) {
+        return jsonResponse([
+          {
+            number: state.pullRequest.number,
+            title: state.pullRequest.title,
+            body: state.pullRequest.body,
+            state: state.pullRequest.state,
+            head: state.pullRequest.head,
+            updated_at: state.pullRequest.updated_at,
+            created_at: state.pullRequest.created_at,
+            html_url: state.pullRequest.html_url,
+          },
+        ]);
+      }
+
+      return jsonResponse([]);
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls" && method === "POST") {
+      state.pullCreateCount += 1;
+      state.pullRequest = {
+        number: 12,
+        title: "Upload review: Q2 Compliance Report (updated-draft.json)",
+        body: "Upload review for Q2 Compliance Report",
+        head: { ref: "bindersnap/upload/main/documents-draft-json" },
+        state: "open",
+        updated_at: "2026-04-01T15:00:00Z",
+        created_at: "2026-04-01T15:00:00Z",
+        html_url: "https://gitea.example/alice/quarterly-report/pulls/12",
+      };
+      return jsonResponse(state.pullRequest, { status: 201 });
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/issues/12" && method === "PATCH") {
+      state.pullPatchCount += 1;
+      state.pullRequest = {
+        ...(state.pullRequest ?? {
+          number: 12,
+          head: { ref: "bindersnap/upload/main/documents-draft-json" },
+          state: "open",
+          updated_at: "2026-04-01T15:00:00Z",
+          created_at: "2026-04-01T15:00:00Z",
+          html_url: "https://gitea.example/alice/quarterly-report/pulls/12",
+        }),
+        ...(typeof init?.body === "string" ? (JSON.parse(init.body) as { title?: string; body?: string }) : {}),
+        updated_at: `2026-04-01T15:0${state.pullPatchCount}:00Z`,
+      };
+      return jsonResponse(state.pullRequest);
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls/12/reviews" && method === "GET") {
+      return jsonResponse([]);
+    }
+
+    throw new Error(`Unexpected request ${method} ${url.pathname}${url.search}`);
+  };
+
+  return {
+    fetchImpl,
+    state,
+  };
+}
+
 beforeEach(() => {
   globalThis.fetch = originalFetch;
 });
@@ -233,4 +479,101 @@ test("loadDocumentCatalog falls back to an empty catalog when the workspace has 
 
   expect(payload.repository).toBe("alice/blank-workspace");
   expect(payload.documents).toEqual([]);
+});
+
+test("handleApiRequest normalizes unauthorized upload access", async () => {
+  const formData = createUploadFormData("uploaded content");
+  const response = await handleApiRequest(
+    new Request("http://localhost/api/app/documents/documents%2Fdraft.json/versions", {
+      method: "POST",
+      headers: {
+        Origin: "http://localhost:5173",
+      },
+      body: formData,
+    }),
+  );
+
+  expect(response.status).toBe(401);
+  const payload = (await response.json()) as {
+    error?: { code?: string; message?: string };
+    message?: string;
+  };
+
+  expect(payload.error?.code).toBe("unauthorized");
+  expect(payload.error?.message).toBe("Unauthorized.");
+  expect(payload.message).toBe("Unauthorized.");
+});
+
+test("uploadDocumentVersion rejects missing multipart file input", async () => {
+  await expect(uploadDocumentVersion(createUploadSession(), "documents/draft.json", new FormData())).rejects.toMatchObject({
+    status: 400,
+    code: "missing_file",
+  });
+});
+
+test("uploadDocumentVersion rejects unsupported file types", async () => {
+  const formData = new FormData();
+  formData.set("file", new File(["binary"], "payload.exe", { type: "application/octet-stream" }));
+
+  await expect(uploadDocumentVersion(createUploadSession(), "documents/draft.json", formData)).rejects.toMatchObject({
+    status: 400,
+    code: "unsupported_file_type",
+  });
+});
+
+test("uploadDocumentVersion rejects oversized files", async () => {
+  const oversized = new Uint8Array(26 * 1024 * 1024);
+  const formData = new FormData();
+  formData.set("file", new File([oversized], "huge.pdf", { type: "application/pdf" }));
+
+  await expect(uploadDocumentVersion(createUploadSession(), "documents/draft.json", formData)).rejects.toMatchObject({
+    status: 413,
+    code: "file_too_large",
+  });
+});
+
+test("uploadDocumentVersion creates a deterministic branch and reuses it for duplicate uploads", async () => {
+  const { fetchImpl, state } = createMockFetchForUploadLifecycle();
+  globalThis.fetch = fetchImpl;
+
+  const formData = createUploadFormData(
+    JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Q2 Compliance Report v2" }],
+        },
+      ],
+    }),
+  );
+
+  const firstResult = await uploadDocumentVersion(
+    createUploadSession(),
+    "documents/draft.json",
+    formData,
+  );
+
+  const secondResult = await uploadDocumentVersion(
+    createUploadSession(),
+    "documents/draft.json",
+    formData,
+  );
+
+  expect(firstResult.documentId).toBe("documents/draft.json");
+  expect(firstResult.branchName).toBe("bindersnap/upload/main/documents-draft-json");
+  expect(firstResult.commitSha).toBe("branch-commit-sha-1");
+  expect(firstResult.pullRequestNumber).toBe(12);
+  expect(firstResult.pullRequestUrl).toBe("https://gitea.example/alice/quarterly-report/pulls/12");
+  expect(firstResult.approvalState).toBe("in_review");
+
+  expect(secondResult.branchName).toBe(firstResult.branchName);
+  expect(secondResult.commitSha).toBe(firstResult.commitSha);
+  expect(secondResult.pullRequestNumber).toBe(firstResult.pullRequestNumber);
+  expect(secondResult.approvalState).toBe(firstResult.approvalState);
+  expect(state.branchCreateCount).toBe(1);
+  expect(state.fileWriteCount).toBe(1);
+  expect(state.pullCreateCount).toBe(1);
+  expect(state.pullPatchCount).toBe(1);
 });

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 
 function parseBoolean(value: string | undefined, fallback: boolean): boolean {
   if (value === undefined) {
@@ -1280,7 +1280,12 @@ function isAllowedUploadFile(file: File): boolean {
 function buildUploadBranchName(baseBranch: string, documentId: string): string {
   const safeBaseBranch = sanitizeBranchSegment(baseBranch) || "main";
   const safeDocumentId = sanitizeBranchSegment(documentId) || "document";
-  return `${UPLOAD_BRANCH_PREFIX}/${safeBaseBranch}/${safeDocumentId}`;
+  const stableIdSuffix = createHash("sha1")
+    .update(documentId)
+    .digest("hex")
+    .slice(0, 12);
+  const shortDocumentSegment = safeDocumentId.slice(0, 48);
+  return `${UPLOAD_BRANCH_PREFIX}/${safeBaseBranch}/${shortDocumentSegment}-${stableIdSuffix}`;
 }
 
 function buildUploadCommitMessage(params: {
@@ -1726,11 +1731,19 @@ export async function uploadDocumentVersion(
     document.path,
     uploadBranchName,
   );
+  const resolvedCommitSha = latestCommit?.sha || commitSha;
+  if (!resolvedCommitSha) {
+    throw createCatalogError(
+      502,
+      "upload_commit_unavailable",
+      "Unable to resolve the uploaded version commit SHA.",
+    );
+  }
 
   return {
     documentId: document.id,
     branchName: uploadBranchName,
-    commitSha: latestCommit?.sha || commitSha || existingBranchFile?.sha || "",
+    commitSha: resolvedCommitSha,
     pullRequestNumber: pullRequestResult.pullRequest.number ?? 0,
     pullRequestUrl: pullRequestResult.pullRequest.html_url ?? null,
     approvalState: pullRequestResult.approvalState,

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -73,9 +73,23 @@ const configuredAllowedOrigins = (
 
 const DOCUMENTS_DIRECTORY = "documents";
 const DOCUMENTS_ROUTE_PREFIX = "/api/app/documents";
+const DOCUMENTS_VERSIONS_ROUTE_SUFFIX = "/versions";
+const UPLOAD_BRANCH_PREFIX = "bindersnap/upload";
 const GITEA_REPOS_PAGE_LIMIT = 100;
 const GITEA_PULLS_PAGE_LIMIT = 100;
 const GITEA_COMMENTS_PAGE_LIMIT = 100;
+const DEFAULT_UPLOAD_ALLOWED_EXTENSIONS =
+  ".json,.txt,.md,.csv,.doc,.docx,.pdf,.xls,.xlsx,.ppt,.pptx";
+const uploadAllowedExtensions = new Set(
+  (process.env.BINDERSNAP_UPLOAD_ALLOWED_EXTENSIONS ?? DEFAULT_UPLOAD_ALLOWED_EXTENSIONS)
+    .split(",")
+    .map((extension) => extension.trim().toLowerCase())
+    .filter((extension) => extension.startsWith(".")),
+);
+const uploadMaxBytes = parsePositiveInt(
+  process.env.BINDERSNAP_UPLOAD_MAX_BYTES,
+  25 * 1024 * 1024,
+);
 
 interface SessionRecord {
   id: string;
@@ -115,6 +129,7 @@ interface GiteaContentSummary {
 interface GiteaPullSummary {
   number?: number;
   title?: string;
+  body?: string;
   state?: string;
   head?: { ref?: string };
   updated_at?: string;
@@ -135,6 +150,20 @@ interface GiteaPullReviewSummary {
 
 interface GiteaPullFileSummary {
   filename?: string;
+}
+
+interface GiteaBranchSummary {
+  name?: string;
+  commit?: {
+    id?: string;
+    sha?: string;
+  };
+}
+
+interface GiteaContentFileResponse {
+  sha?: string;
+  content?: string;
+  encoding?: string;
 }
 
 interface DocumentVersionMetadata extends CommitSummary {}
@@ -166,6 +195,15 @@ export interface CatalogPendingPullRequest {
   branch: string;
   updatedAt: string;
   htmlUrl: string | null;
+}
+
+export interface DocumentUploadResult {
+  documentId: string;
+  branchName: string;
+  commitSha: string;
+  pullRequestNumber: number;
+  pullRequestUrl: string | null;
+  approvalState: CatalogApprovalState;
 }
 
 export type CatalogApprovalState =
@@ -1065,8 +1103,10 @@ async function selectWorkspaceRepository(session: SessionRecord): Promise<Worksp
   return ordered[0] ?? repositories[0];
 }
 
-export async function loadDocumentCatalog(session: SessionRecord): Promise<CatalogPayload> {
-  const repository = await selectWorkspaceRepository(session);
+async function loadWorkspaceDocumentCatalog(
+  session: SessionRecord,
+  repository: WorkspaceRepository,
+): Promise<CatalogPayload> {
   const documentPaths = await listDocumentFiles(
     session.giteaToken,
     repository.owner,
@@ -1183,8 +1223,23 @@ export async function loadDocumentCatalog(session: SessionRecord): Promise<Catal
   };
 }
 
+async function loadWorkspaceCatalog(session: SessionRecord): Promise<{
+  repository: WorkspaceRepository;
+  catalog: CatalogPayload;
+}> {
+  const repository = await selectWorkspaceRepository(session);
+  const catalog = await loadWorkspaceDocumentCatalog(session, repository);
+
+  return { repository, catalog };
+}
+
+export async function loadDocumentCatalog(session: SessionRecord): Promise<CatalogPayload> {
+  const { catalog } = await loadWorkspaceCatalog(session);
+  return catalog;
+}
+
 export async function loadDocumentCatalogItem(session: SessionRecord, documentId: string): Promise<{ repository: string; document: DocumentCatalogItem }> {
-  const catalog = await loadDocumentCatalog(session);
+  const { catalog } = await loadWorkspaceCatalog(session);
   const document = catalog.documents.find((item) => item.id === documentId);
   if (!document) {
     throw createCatalogError(404, "document_not_found", "Document not found.");
@@ -1193,6 +1248,492 @@ export async function loadDocumentCatalogItem(session: SessionRecord, documentId
   return {
     repository: catalog.repository,
     document,
+  };
+}
+
+function sanitizeBranchSegment(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+function extractLowercaseExtension(fileName: string): string {
+  const trimmed = fileName.trim();
+  const lastDot = trimmed.lastIndexOf(".");
+  if (lastDot <= 0 || lastDot === trimmed.length - 1) {
+    return "";
+  }
+  return trimmed.slice(lastDot).toLowerCase();
+}
+
+function isAllowedUploadFile(file: File): boolean {
+  const extension = extractLowercaseExtension(file.name);
+  if (!extension) {
+    return false;
+  }
+  return uploadAllowedExtensions.has(extension);
+}
+
+function buildUploadBranchName(baseBranch: string, documentId: string): string {
+  const safeBaseBranch = sanitizeBranchSegment(baseBranch) || "main";
+  const safeDocumentId = sanitizeBranchSegment(documentId) || "document";
+  return `${UPLOAD_BRANCH_PREFIX}/${safeBaseBranch}/${safeDocumentId}`;
+}
+
+function buildUploadCommitMessage(params: {
+  document: DocumentCatalogItem;
+  branchName: string;
+  fileName: string;
+  summary: string;
+  sourceNote: string;
+}): string {
+  const lines = [
+    `Upload new version for ${params.document.displayName}`,
+    "",
+    `Document: ${params.document.id}`,
+    `Branch: ${params.branchName}`,
+    `Uploaded file: ${params.fileName}`,
+    `Summary: ${params.summary || "None provided"}`,
+    `Source note: ${params.sourceNote || "None provided"}`,
+  ];
+
+  return lines.join("\n");
+}
+
+function buildUploadPullRequestTitle(params: {
+  document: DocumentCatalogItem;
+  fileName: string;
+}): string {
+  return `Upload review: ${params.document.displayName} (${params.fileName})`;
+}
+
+function buildUploadPullRequestBody(params: {
+  document: DocumentCatalogItem;
+  repository: WorkspaceRepository;
+  branchName: string;
+  fileName: string;
+  summary: string;
+  sourceNote: string;
+}): string {
+  const lines = [
+    `Upload review for ${params.document.displayName}`,
+    "",
+    `Document ID: ${params.document.id}`,
+    `Repository: ${params.repository.fullName}`,
+    `Canonical branch: ${params.repository.defaultBranch}`,
+    `Upload branch: ${params.branchName}`,
+    `Uploaded file: ${params.fileName}`,
+    `Summary: ${params.summary || "None provided"}`,
+    `Source note: ${params.sourceNote || "None provided"}`,
+  ];
+
+  return lines.join("\n");
+}
+
+function decodeGiteaContent(encoded: string | undefined): Buffer {
+  const normalized = encoded ? encoded.replace(/\s+/g, "") : "";
+  return Buffer.from(normalized, "base64");
+}
+
+async function readGiteaFileAtRef(
+  token: string,
+  owner: string,
+  repo: string,
+  filePath: string,
+  ref: string,
+): Promise<{ sha: string; content: Buffer } | null> {
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${filePath}?ref=${encodeURIComponent(ref)}`,
+    {
+      method: "GET",
+      headers: buildGiteaHeaders(token),
+    },
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw upstreamStatusToCatalogError(
+      response.status,
+      "upload_source_unavailable",
+      "Unable to load document source.",
+    );
+  }
+
+  const payload = (await response.json()) as GiteaContentFileResponse | string;
+  if (typeof payload === "string") {
+    return {
+      sha: "",
+      content: Buffer.from(payload, "utf8"),
+    };
+  }
+
+  return {
+    sha: typeof payload.sha === "string" ? payload.sha : "",
+    content: decodeGiteaContent(payload.content),
+  };
+}
+
+async function branchExists(
+  token: string,
+  owner: string,
+  repo: string,
+  branchName: string,
+): Promise<boolean> {
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/branches/${encodeURIComponent(branchName)}`,
+    {
+      method: "GET",
+      headers: buildGiteaHeaders(token),
+    },
+  );
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (!response.ok) {
+    throw upstreamStatusToCatalogError(
+      response.status,
+      "upload_branch_unavailable",
+      "Unable to prepare the review branch.",
+    );
+  }
+
+  return true;
+}
+
+async function createUploadBranch(
+  token: string,
+  owner: string,
+  repo: string,
+  branchName: string,
+  baseBranch: string,
+): Promise<void> {
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/branches`,
+    {
+      method: "POST",
+      headers: buildGiteaHeaders(token, {
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({
+        new_branch_name: branchName,
+        old_ref_name: baseBranch,
+      }),
+    },
+  );
+
+  if (response.ok || response.status === 201 || response.status === 409 || response.status === 422) {
+    return;
+  }
+
+  throw upstreamStatusToCatalogError(
+    response.status,
+    "upload_branch_unavailable",
+    "Unable to prepare the review branch.",
+  );
+}
+
+async function writeUploadFile(
+  token: string,
+  owner: string,
+  repo: string,
+  filePath: string,
+  branchName: string,
+  content: Buffer,
+  message: string,
+): Promise<{ commitSha: string; fileSha: string | null }> {
+  const existingFile = await readGiteaFileAtRef(token, owner, repo, filePath, branchName);
+  const body: Record<string, string> = {
+    content: content.toString("base64"),
+    message,
+    branch: branchName,
+  };
+
+  if (existingFile?.sha) {
+    body.sha = existingFile.sha;
+  }
+
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${filePath}`,
+    {
+      method: existingFile?.sha ? "PUT" : "POST",
+      headers: buildGiteaHeaders(token, {
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) {
+    throw upstreamStatusToCatalogError(
+      response.status,
+      "upload_write_failed",
+      "Unable to save the uploaded file version.",
+    );
+  }
+
+  const payload = (await response.json()) as {
+    commit?: { sha?: string };
+    content?: { sha?: string };
+  };
+
+  return {
+    commitSha: payload.commit?.sha ?? "",
+    fileSha: payload.content?.sha ?? existingFile?.sha ?? null,
+  };
+}
+
+async function listOpenPullRequestsForBranch(
+  token: string,
+  owner: string,
+  repo: string,
+  branchName: string,
+): Promise<GiteaPullSummary[]> {
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls?state=open&head=${encodeURIComponent(`${owner}:${branchName}`)}&limit=${GITEA_PULLS_PAGE_LIMIT}`,
+    {
+      method: "GET",
+      headers: buildGiteaHeaders(token),
+    },
+  );
+
+  if (!response.ok) {
+    throw upstreamStatusToCatalogError(
+      response.status,
+      "upload_pull_request_unavailable",
+      "Unable to load the upload review request.",
+    );
+  }
+
+  const payload = (await response.json()) as GiteaPullSummary[];
+  return Array.isArray(payload) ? payload : [];
+}
+
+function selectLatestUploadPullRequest(
+  pullRequests: GiteaPullSummary[],
+  branchName: string,
+): GiteaPullSummary | null {
+  const candidates = pullRequests.filter((pullRequest) => pullRequest.head?.ref === branchName);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  candidates.sort((left, right) => {
+    const leftRank = (left.number ?? 0) + (parseTimestamp(left.updated_at) || parseTimestamp(left.created_at));
+    const rightRank = (right.number ?? 0) + (parseTimestamp(right.updated_at) || parseTimestamp(right.created_at));
+    return rightRank - leftRank;
+  });
+
+  return candidates[0] ?? null;
+}
+
+async function createOrUpdateUploadPullRequest(
+  token: string,
+  repository: WorkspaceRepository,
+  document: DocumentCatalogItem,
+  branchName: string,
+  fileName: string,
+  summary: string,
+  sourceNote: string,
+): Promise<{
+  pullRequest: GiteaPullSummary;
+  approvalState: CatalogApprovalState;
+}> {
+  const title = buildUploadPullRequestTitle({ document, fileName });
+  const body = buildUploadPullRequestBody({
+    document,
+    repository,
+    branchName,
+    fileName,
+    summary,
+    sourceNote,
+  });
+
+  const existingPullRequest = selectLatestUploadPullRequest(
+    await listOpenPullRequestsForBranch(token, repository.owner, repository.name, branchName),
+    branchName,
+  );
+
+  if (existingPullRequest?.number) {
+    const response = await giteaFetch(
+      `/api/v1/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}/issues/${existingPullRequest.number}`,
+      {
+        method: "PATCH",
+        headers: buildGiteaHeaders(token, {
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          title,
+          body,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      throw upstreamStatusToCatalogError(
+        response.status,
+        "upload_pull_request_unavailable",
+        "Unable to update the upload review request.",
+      );
+    }
+  } else {
+    const response = await giteaFetch(
+      `/api/v1/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}/pulls`,
+      {
+        method: "POST",
+        headers: buildGiteaHeaders(token, {
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          base: repository.defaultBranch,
+          head: branchName,
+          title,
+          body,
+        }),
+      },
+    );
+
+    if (!response.ok && response.status !== 201) {
+      throw upstreamStatusToCatalogError(
+        response.status,
+        "upload_pull_request_unavailable",
+        "Unable to create the upload review request.",
+      );
+    }
+  }
+
+  const pullRequest = selectLatestUploadPullRequest(
+    await listOpenPullRequestsForBranch(token, repository.owner, repository.name, branchName),
+    branchName,
+  );
+
+  if (!pullRequest || !pullRequest.number) {
+    throw createCatalogError(502, "upload_pull_request_unavailable", "Unable to locate the upload review request.");
+  }
+
+  const reviews = await listPullRequestReviews(token, repository.owner, repository.name, pullRequest.number);
+  return {
+    pullRequest,
+    approvalState: resolvePullRequestState(pullRequest, reviews),
+  };
+}
+
+export async function uploadDocumentVersion(
+  session: SessionRecord,
+  documentId: string,
+  formData: FormData,
+): Promise<DocumentUploadResult> {
+  const fileValue = formData.get("file");
+  if (!(fileValue instanceof File)) {
+    throw createCatalogError(400, "missing_file", "A file is required.");
+  }
+  if (fileValue.size <= 0) {
+    throw createCatalogError(400, "empty_file", "Uploaded file is empty.");
+  }
+  if (!isAllowedUploadFile(fileValue)) {
+    throw createCatalogError(400, "unsupported_file_type", "Unsupported file type.");
+  }
+  if (fileValue.size > uploadMaxBytes) {
+    throw createCatalogError(413, "file_too_large", "Uploaded file exceeds size limit.");
+  }
+
+  const summaryValue = formData.get("summary");
+  const sourceNoteValue = formData.get("source_note");
+  const summary = typeof summaryValue === "string" ? summaryValue.trim() : "";
+  const sourceNote = typeof sourceNoteValue === "string" ? sourceNoteValue.trim() : "";
+
+  const { repository, catalog } = await loadWorkspaceCatalog(session);
+  const document = catalog.documents.find((item) => item.id === documentId);
+  if (!document) {
+    throw createCatalogError(404, "document_not_found", "Document not found.");
+  }
+
+  const uploadBranchName = buildUploadBranchName(repository.defaultBranch, document.id);
+  const uploadContent = Buffer.from(await fileValue.arrayBuffer());
+  const branchAlreadyExists = await branchExists(
+    session.giteaToken,
+    repository.owner,
+    repository.name,
+    uploadBranchName,
+  );
+
+  if (!branchAlreadyExists) {
+    await createUploadBranch(
+      session.giteaToken,
+      repository.owner,
+      repository.name,
+      uploadBranchName,
+      repository.defaultBranch,
+    );
+  }
+
+  const existingBranchFile = branchAlreadyExists
+    ? await readGiteaFileAtRef(
+        session.giteaToken,
+        repository.owner,
+        repository.name,
+        document.path,
+        uploadBranchName,
+      )
+    : null;
+
+  const uploadIsDuplicate =
+    branchAlreadyExists &&
+    existingBranchFile !== null &&
+    existingBranchFile.content.equals(uploadContent);
+
+  let commitSha = "";
+  if (!uploadIsDuplicate) {
+    const commitResult = await writeUploadFile(
+      session.giteaToken,
+      repository.owner,
+      repository.name,
+      document.path,
+      uploadBranchName,
+      uploadContent,
+      buildUploadCommitMessage({
+        document,
+        branchName: uploadBranchName,
+        fileName: fileValue.name || document.id,
+        summary,
+        sourceNote,
+      }),
+    );
+    commitSha = commitResult.commitSha;
+  }
+
+  const pullRequestResult = await createOrUpdateUploadPullRequest(
+    session.giteaToken,
+    repository,
+    document,
+    uploadBranchName,
+    fileValue.name || document.id,
+    summary,
+    sourceNote,
+  );
+
+  const latestCommit = await readCommitSummary(
+    session.giteaToken,
+    repository.owner,
+    repository.name,
+    document.path,
+    uploadBranchName,
+  );
+
+  return {
+    documentId: document.id,
+    branchName: uploadBranchName,
+    commitSha: latestCommit?.sha || commitSha || existingBranchFile?.sha || "",
+    pullRequestNumber: pullRequestResult.pullRequest.number ?? 0,
+    pullRequestUrl: pullRequestResult.pullRequest.html_url ?? null,
+    approvalState: pullRequestResult.approvalState,
   };
 }
 
@@ -1488,6 +2029,34 @@ async function handleDocumentDetail(
   }
 }
 
+async function handleDocumentVersionUpload(
+  req: Request,
+  baseHeaders: Headers,
+  documentId: string,
+): Promise<Response> {
+  const session = getSessionFromRequest(req);
+  if (!session) {
+    return catalogErrorResponse(createCatalogError(401, "unauthorized", "Unauthorized."), baseHeaders);
+  }
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return catalogErrorResponse(
+      createCatalogError(400, "invalid_upload_payload", "A multipart form upload is required."),
+      baseHeaders,
+    );
+  }
+
+  try {
+    const payload = await uploadDocumentVersion(session, documentId, formData);
+    return json(200, payload, baseHeaders);
+  } catch (error) {
+    return catalogErrorResponse(error, baseHeaders);
+  }
+}
+
 async function cleanupExpiredSessions(): Promise<void> {
   const now = Date.now();
   const expiredSessions: SessionRecord[] = [];
@@ -1552,6 +2121,29 @@ export async function handleApiRequest(req: Request): Promise<Response> {
 
   if (pathname === DOCUMENTS_ROUTE_PREFIX && req.method === "GET") {
     return handleDocuments(req, baseHeaders);
+  }
+
+  if (
+    pathname.startsWith(`${DOCUMENTS_ROUTE_PREFIX}/`) &&
+    pathname.endsWith(DOCUMENTS_VERSIONS_ROUTE_SUFFIX) &&
+    req.method === "POST"
+  ) {
+    try {
+      const documentId = decodeURIComponent(
+        pathname.slice(
+          `${DOCUMENTS_ROUTE_PREFIX}/`.length,
+          pathname.length - DOCUMENTS_VERSIONS_ROUTE_SUFFIX.length,
+        ),
+      );
+      if (documentId) {
+        return handleDocumentVersionUpload(req, baseHeaders, documentId);
+      }
+    } catch {
+      return catalogErrorResponse(
+        createCatalogError(400, "invalid_document_id", "Invalid document identifier."),
+        baseHeaders,
+      );
+    }
   }
 
   if (pathname.startsWith(`${DOCUMENTS_ROUTE_PREFIX}/`) && req.method === "GET") {


### PR DESCRIPTION
Implements issue #87 by adding `POST /api/app/documents/:id/versions` to upload external file revisions and create/update review PRs.

Workflow evidence:
- Issue read: `issue_read` (`get`) on #87
- Branch creation: `create_branch` for `codex/issue-87-upload-version-api`
- Commit SHA(s):
  - `a2f96e6` Add document version upload API endpoint
  - `484c105` Fix upload branch uniqueness and commit SHA handling
- PR creation: `create_pull_request`
- Fallback used: none

What changed:
- Added multipart upload endpoint with `file`, optional `summary`, optional `source_note`.
- Deterministic upload branch creation from canonical branch + document id (with stable hash suffix to prevent collisions).
- Create/reuse upload branch, commit file content, create/update open review PR, and return upload metadata including approval state.
- Normalized error envelope for upload route behavior.
- Added/updated focused API tests for unauthorized access, validation failures, and deterministic duplicate upload handling.

Validation:
- `bun test services/api/server.test.ts` ✅
- `bun test apps/app packages/gitea-client` ✅

Closes #87