### PR TITLE
Issue #88: add version review and publish APIs

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -11,12 +11,18 @@ Lightweight Bun auth/BFF service for the authenticated app.
 - `GET /api/app/documents`
 - `GET /api/app/documents/:id`
 - `POST /api/app/documents/:id/versions`
+- `POST /api/app/documents/:id/versions/:prNumber/review`
+- `POST /api/app/documents/:id/versions/:prNumber/publish`
 
 The browser only receives a Bindersnap session cookie. Gitea access tokens stay server-side in memory for this MVP.
 
 `GET /api/app/documents` resolves the authenticated workspace repository from the session token, reads the live `documents/` directory from Gitea, and returns a normalized catalog payload. Each document includes the current published commit metadata, the latest matching pull request state, and last activity timestamps.
 
 `POST /api/app/documents/:id/versions` accepts `multipart/form-data` with `file`, `summary`, and `source_note`, validates upload extension/size, then creates a deterministic upload branch, commits the uploaded file to that branch, and opens or updates the review pull request for the version.
+
+`POST /api/app/documents/:id/versions/:prNumber/review` accepts JSON with `event` values `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`, plus optional `body`/`comment` text. It submits the review through Gitea and returns the updated approval state with PR and commit metadata.
+
+`POST /api/app/documents/:id/versions/:prNumber/publish` merges an approved version and returns the published commit metadata. For now, publish access is restricted to the repository owner session so the permission check is explicit and deterministic.
 
 Errors from the catalog routes are normalized as JSON objects with both a machine-readable `error.code` and a human-readable `error.message`, plus a top-level `message` field for the current frontend.
 

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -22,7 +22,7 @@ The browser only receives a Bindersnap session cookie. Gitea access tokens stay 
 
 `POST /api/app/documents/:id/versions/:prNumber/review` accepts JSON with `event` values `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`, plus optional `body`/`comment` text. It submits the review through Gitea and returns the updated approval state with PR and commit metadata.
 
-`POST /api/app/documents/:id/versions/:prNumber/publish` merges an approved version and returns the published commit metadata. For now, publish access is restricted to the repository owner session so the permission check is explicit and deterministic.
+`POST /api/app/documents/:id/versions/:prNumber/publish` merges an approved version and returns the published commit metadata. Publish access is allowed for repository owners and collaborators with `write` or `admin` permission.
 
 Errors from the catalog routes are normalized as JSON objects with both a machine-readable `error.code` and a human-readable `error.message`, plus a top-level `message` field for the current frontend.
 

--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -75,6 +75,24 @@ function createUploadFormData(content: string, fileName = "updated-draft.json") 
   return formData;
 }
 
+async function loginAndGetSessionCookie(username = "alice", password = "bindersnap-dev"): Promise<string> {
+  const response = await handleApiRequest(
+    new Request("http://localhost/auth/login", {
+      method: "POST",
+      headers: {
+        Origin: "http://localhost:5173",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ username, password }),
+    }),
+  );
+
+  expect(response.status).toBe(200);
+  const cookie = response.headers.get("set-cookie") ?? "";
+  expect(cookie).toContain("bindersnap_session=");
+  return cookie.split(";")[0] ?? cookie;
+}
+
 function createMockFetchForCatalog(): typeof fetch {
   return async (input, init) => {
     const url = new URL(typeof input === "string" || input instanceof URL ? input.toString() : input.url);
@@ -286,6 +304,27 @@ function createMockFetchForUploadLifecycle() {
   const fetchImpl: typeof fetch = async (input, init) => {
     const url = new URL(typeof input === "string" || input instanceof URL ? input.toString() : input.url);
     const method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+    const authorization = init?.headers
+      ? new Headers(init.headers).get("authorization")
+      : input instanceof Request
+        ? input.headers.get("authorization")
+        : null;
+
+    if (url.pathname === "/api/v1/user" && method === "GET") {
+      if (authorization?.startsWith("Basic ")) {
+        const decoded = Buffer.from(authorization.slice("Basic ".length), "base64").toString("utf8");
+        const username = decoded.split(":")[0] || "alice";
+        return jsonResponse({ login: username });
+      }
+
+      if (authorization?.startsWith("token ")) {
+        return jsonResponse({ login: "alice" });
+      }
+    }
+
+    if (url.pathname.startsWith("/api/v1/users/") && url.pathname.endsWith("/tokens") && method === "POST") {
+      return jsonResponse({ sha1: "session-token" }, { status: 201 });
+    }
 
     if (url.pathname === "/api/v1/user/repos" && method === "GET") {
       return jsonResponse([
@@ -440,6 +479,28 @@ function createMockFetchForUploadLifecycle() {
 
     if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls/12/files" && method === "GET") {
       return jsonResponse([{ filename: "documents/draft.json" }]);
+    }
+
+    if (
+      url.pathname.startsWith("/api/v1/repos/alice/quarterly-report/collaborators/") &&
+      url.pathname.endsWith("/permission") &&
+      method === "GET"
+    ) {
+      const username = decodeURIComponent(
+        url.pathname
+          .replace("/api/v1/repos/alice/quarterly-report/collaborators/", "")
+          .replace("/permission", ""),
+      );
+
+      if (username === "bob") {
+        return jsonResponse({ permission: "write" });
+      }
+
+      if (username === "alice") {
+        return jsonResponse({ permission: "admin" });
+      }
+
+      return jsonResponse({ permission: "read" });
     }
 
     if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls" && method === "POST") {
@@ -675,6 +736,72 @@ test("handleApiRequest normalizes unauthorized version publish access", async ()
   expect(payload.message).toBe("Unauthorized.");
 });
 
+test("handleApiRequest rejects invalid review events with a normalized error", async () => {
+  const { fetchImpl } = createMockFetchForUploadLifecycle();
+  globalThis.fetch = fetchImpl;
+
+  const sessionCookie = await loginAndGetSessionCookie();
+  const response = await handleApiRequest(
+    new Request("http://localhost/api/app/documents/documents%2Fdraft.json/versions/12/review", {
+      method: "POST",
+      headers: {
+        Origin: "http://localhost:5173",
+        Cookie: sessionCookie,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ event: "NOPE" }),
+    }),
+  );
+
+  expect(response.status).toBe(400);
+  const payload = (await response.json()) as {
+    error?: { code?: string; message?: string };
+    message?: string;
+  };
+  expect(payload.error?.code).toBe("invalid_review_event");
+  expect(payload.message).toBe("A valid review event is required.");
+});
+
+test("handleApiRequest enforces approval before publish", async () => {
+  const { fetchImpl } = createMockFetchForUploadLifecycle();
+  globalThis.fetch = fetchImpl;
+
+  await uploadDocumentVersion(
+    createUploadSession(),
+    "documents/draft.json",
+    createUploadFormData(
+      JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Q2 Compliance Report v2" }],
+          },
+        ],
+      }),
+    ),
+  );
+
+  const sessionCookie = await loginAndGetSessionCookie();
+  const response = await handleApiRequest(
+    new Request("http://localhost/api/app/documents/documents%2Fdraft.json/versions/12/publish", {
+      method: "POST",
+      headers: {
+        Origin: "http://localhost:5173",
+        Cookie: sessionCookie,
+      },
+    }),
+  );
+
+  expect(response.status).toBe(409);
+  const payload = (await response.json()) as {
+    error?: { code?: string; message?: string };
+    message?: string;
+  };
+  expect(payload.error?.code).toBe("approval_required");
+});
+
 test("uploadDocumentVersion rejects missing multipart file input", async () => {
   await expect(uploadDocumentVersion(createUploadSession(), "documents/draft.json", new FormData())).rejects.toMatchObject({
     status: 400,
@@ -826,7 +953,7 @@ test("reviewDocumentVersion accepts comment payloads and preserves in-review sta
   expect(state.reviews).toHaveLength(1);
 });
 
-test("publishDocumentVersion rejects non-owner sessions", async () => {
+test("publishDocumentVersion rejects users without publish permission", async () => {
   const { fetchImpl } = createMockFetchForUploadLifecycle();
   globalThis.fetch = fetchImpl;
 
@@ -857,7 +984,7 @@ test("publishDocumentVersion rejects non-owner sessions", async () => {
 
   await expect(
     publishDocumentVersion(
-      createReviewerSession("bob"),
+      createReviewerSession("eve"),
       "documents/draft.json",
       uploaded.pullRequestNumber,
     ),
@@ -865,6 +992,45 @@ test("publishDocumentVersion rejects non-owner sessions", async () => {
     status: 403,
     code: "publish_forbidden",
   });
+});
+
+test("publishDocumentVersion allows write collaborators to publish approved versions", async () => {
+  const { fetchImpl, state } = createMockFetchForUploadLifecycle();
+  globalThis.fetch = fetchImpl;
+
+  const uploaded = await uploadDocumentVersion(
+    createUploadSession(),
+    "documents/draft.json",
+    createUploadFormData(
+      JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Q2 Compliance Report v2" }],
+          },
+        ],
+      }),
+    ),
+  );
+
+  await reviewDocumentVersion(
+    createReviewerSession(),
+    "documents/draft.json",
+    uploaded.pullRequestNumber,
+    "APPROVE",
+    "Looks good to me.",
+  );
+
+  const published = await publishDocumentVersion(
+    createReviewerSession("bob"),
+    "documents/draft.json",
+    uploaded.pullRequestNumber,
+  );
+
+  expect(published.approvalState).toBe("published");
+  expect(state.mergeCount).toBe(1);
 });
 
 test("publishDocumentVersion merges an approved version and returns published metadata", async () => {

--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { createHash } from "crypto";
 
-import { handleApiRequest, loadDocumentCatalog, uploadDocumentVersion } from "./server.ts";
+import {
+  handleApiRequest,
+  loadDocumentCatalog,
+  publishDocumentVersion,
+  reviewDocumentVersion,
+  uploadDocumentVersion,
+} from "./server.ts";
 
 const originalFetch = globalThis.fetch;
 const UPLOAD_BRANCH_NAME = `bindersnap/upload/main/documents-draft-json-${createHash("sha1")
@@ -43,6 +49,17 @@ function createUploadSession() {
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
   } as Parameters<typeof uploadDocumentVersion>[0];
+}
+
+function createReviewerSession(username = "alice") {
+  return {
+    id: `${username}-session`,
+    username,
+    giteaToken: "token-123",
+    giteaTokenName: `${username}-bindersnap-session`,
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  } as Parameters<typeof reviewDocumentVersion>[0];
 }
 
 function createUploadFormData(content: string, fileName = "updated-draft.json") {
@@ -235,16 +252,30 @@ function createMockFetchForUploadLifecycle() {
     branchContent: canonicalContent,
     branchFileSha: "canonical-file-sha",
     branchCommitSha: "canonical-commit-sha",
+    publishedContent: canonicalContent,
+    publishedFileSha: "canonical-file-sha",
+    publishedCommitSha: "canonical-commit-sha",
+    publishedCommitMessage: "seed: draft document",
     branchCommitCount: 0,
+    mergeCount: 0,
+    reviews: [] as Array<{
+      id: number;
+      state: string;
+      body: string;
+      user: { login: string };
+      submitted_at: string;
+    }>,
     pullRequest: null as null | {
       number: number;
       title: string;
       body: string;
       head: { ref: string };
-      state: "open";
+      state: string;
       updated_at: string;
       created_at: string;
       html_url: string;
+      merged?: boolean;
+      merged_at?: string;
     },
     branchCreateCount: 0,
     fileWriteCount: 0,
@@ -281,8 +312,8 @@ function createMockFetchForUploadLifecycle() {
       const ref = url.searchParams.get("ref");
       if (ref === "main") {
         return jsonResponse({
-          sha: "canonical-file-sha",
-          content: Buffer.from(canonicalContent, "utf8").toString("base64"),
+          sha: state.publishedFileSha,
+          content: Buffer.from(state.publishedContent, "utf8").toString("base64"),
         });
       }
 
@@ -301,10 +332,10 @@ function createMockFetchForUploadLifecycle() {
       if (path === "documents/draft.json" && sha === "main") {
         return jsonResponse([
           {
-            sha: "canonical-commit-sha",
+            sha: state.publishedCommitSha,
             commit: {
-              message: "seed: draft document",
-              author: { name: "Alice Author", date: "2026-03-30T12:00:00Z" },
+              message: state.publishedCommitMessage,
+              author: { name: "Alice Author", date: "2026-04-01T16:00:00Z" },
             },
           },
         ]);
@@ -336,6 +367,10 @@ function createMockFetchForUploadLifecycle() {
       state.branchContent = canonicalContent;
       state.branchFileSha = "canonical-file-sha";
       state.branchCommitSha = "canonical-commit-sha";
+      state.publishedContent = canonicalContent;
+      state.publishedFileSha = "canonical-file-sha";
+      state.publishedCommitSha = "canonical-commit-sha";
+      state.publishedCommitMessage = "seed: draft document";
       return new Response("", { status: 201 });
     }
 
@@ -384,6 +419,29 @@ function createMockFetchForUploadLifecycle() {
       return jsonResponse([]);
     }
 
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls/12" && method === "GET") {
+      if (!state.pullRequest) {
+        return new Response("", { status: 404 });
+      }
+
+      return jsonResponse({
+        number: state.pullRequest.number,
+        title: state.pullRequest.title,
+        body: state.pullRequest.body,
+        state: state.pullRequest.state,
+        head: state.pullRequest.head,
+        updated_at: state.pullRequest.updated_at,
+        created_at: state.pullRequest.created_at,
+        html_url: state.pullRequest.html_url,
+        merged: state.pullRequest.merged ?? false,
+        merged_at: state.pullRequest.merged_at,
+      });
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls/12/files" && method === "GET") {
+      return jsonResponse([{ filename: "documents/draft.json" }]);
+    }
+
     if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls" && method === "POST") {
       state.pullCreateCount += 1;
       state.pullRequest = {
@@ -417,7 +475,70 @@ function createMockFetchForUploadLifecycle() {
     }
 
     if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls/12/reviews" && method === "GET") {
-      return jsonResponse([]);
+      return jsonResponse(state.reviews);
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls/12/reviews" && method === "POST") {
+      const body = typeof init?.body === "string" ? init.body : "";
+      const parsed = body ? (JSON.parse(body) as { event?: string; body?: string }) : {};
+      const createdAt = `2026-04-01T15:0${state.reviews.length + 1}:00Z`;
+      const reviewState =
+        parsed.event === "APPROVE"
+          ? "APPROVED"
+          : parsed.event === "REQUEST_CHANGES"
+            ? "REQUEST_CHANGES"
+            : "COMMENT";
+      const review = {
+        id: state.reviews.length + 1,
+        state: reviewState,
+        body: parsed.body ?? "",
+        user: { login: "alice" },
+        submitted_at: createdAt,
+      };
+      state.reviews = [...state.reviews, review];
+      state.pullRequest = {
+        ...(state.pullRequest ?? {
+          number: 12,
+          title: "Upload review: Q2 Compliance Report (updated-draft.json)",
+          body: "Upload review for Q2 Compliance Report",
+          head: { ref: UPLOAD_BRANCH_NAME },
+          state: "open",
+          updated_at: createdAt,
+          created_at: "2026-04-01T15:00:00Z",
+          html_url: "https://gitea.example/alice/quarterly-report/pulls/12",
+        }),
+        updated_at: createdAt,
+      };
+      return jsonResponse(review);
+    }
+
+    if (url.pathname === "/api/v1/repos/alice/quarterly-report/pulls/12/merge" && method === "POST") {
+      state.mergeCount += 1;
+      state.publishedContent = state.branchContent;
+      state.publishedFileSha = state.branchFileSha;
+      state.publishedCommitSha = `published-commit-sha-${state.mergeCount}`;
+      state.publishedCommitMessage = "Publish for Q2 Compliance Report";
+      state.pullRequest = {
+        ...(state.pullRequest ?? {
+          number: 12,
+          title: "Upload review: Q2 Compliance Report (updated-draft.json)",
+          body: "Upload review for Q2 Compliance Report",
+          head: { ref: UPLOAD_BRANCH_NAME },
+          state: "open",
+          updated_at: "2026-04-01T15:00:00Z",
+          created_at: "2026-04-01T15:00:00Z",
+          html_url: "https://gitea.example/alice/quarterly-report/pulls/12",
+        }),
+        state: "closed",
+        merged: true,
+        merged_at: "2026-04-01T16:00:00Z",
+        updated_at: "2026-04-01T16:00:00Z",
+      };
+      return jsonResponse({
+        merged: true,
+        sha: state.publishedCommitSha,
+        merged_commit_id: state.publishedCommitSha,
+      });
     }
 
     throw new Error(`Unexpected request ${method} ${url.pathname}${url.search}`);
@@ -510,6 +631,50 @@ test("handleApiRequest normalizes unauthorized upload access", async () => {
   expect(payload.message).toBe("Unauthorized.");
 });
 
+test("handleApiRequest normalizes unauthorized version review access", async () => {
+  const response = await handleApiRequest(
+    new Request("http://localhost/api/app/documents/documents%2Fdraft.json/versions/12/review", {
+      method: "POST",
+      headers: {
+        Origin: "http://localhost:5173",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ event: "APPROVE" }),
+    }),
+  );
+
+  expect(response.status).toBe(401);
+  const payload = (await response.json()) as {
+    error?: { code?: string; message?: string };
+    message?: string;
+  };
+
+  expect(payload.error?.code).toBe("unauthorized");
+  expect(payload.error?.message).toBe("Unauthorized.");
+  expect(payload.message).toBe("Unauthorized.");
+});
+
+test("handleApiRequest normalizes unauthorized version publish access", async () => {
+  const response = await handleApiRequest(
+    new Request("http://localhost/api/app/documents/documents%2Fdraft.json/versions/12/publish", {
+      method: "POST",
+      headers: {
+        Origin: "http://localhost:5173",
+      },
+    }),
+  );
+
+  expect(response.status).toBe(401);
+  const payload = (await response.json()) as {
+    error?: { code?: string; message?: string };
+    message?: string;
+  };
+
+  expect(payload.error?.code).toBe("unauthorized");
+  expect(payload.error?.message).toBe("Unauthorized.");
+  expect(payload.message).toBe("Unauthorized.");
+});
+
 test("uploadDocumentVersion rejects missing multipart file input", async () => {
   await expect(uploadDocumentVersion(createUploadSession(), "documents/draft.json", new FormData())).rejects.toMatchObject({
     status: 400,
@@ -582,4 +747,168 @@ test("uploadDocumentVersion creates a deterministic branch and reuses it for dup
   expect(state.fileWriteCount).toBe(1);
   expect(state.pullCreateCount).toBe(1);
   expect(state.pullPatchCount).toBe(1);
+});
+
+test("reviewDocumentVersion approves an uploaded version and returns audit metadata", async () => {
+  const { fetchImpl, state } = createMockFetchForUploadLifecycle();
+  globalThis.fetch = fetchImpl;
+
+  const uploaded = await uploadDocumentVersion(
+    createUploadSession(),
+    "documents/draft.json",
+    createUploadFormData(
+      JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Q2 Compliance Report v2" }],
+          },
+        ],
+      }),
+    ),
+  );
+
+  const reviewed = await reviewDocumentVersion(
+    createReviewerSession(),
+    "documents/draft.json",
+    uploaded.pullRequestNumber,
+    "APPROVE",
+    "Looks good to me.",
+  );
+
+  expect(reviewed.documentId).toBe("documents/draft.json");
+  expect(reviewed.branchName).toBe(UPLOAD_BRANCH_NAME);
+  expect(reviewed.pullRequestNumber).toBe(uploaded.pullRequestNumber);
+  expect(reviewed.approvalState).toBe("approved");
+  expect(reviewed.review.state).toBe("APPROVED");
+  expect(reviewed.review.body).toBe("Looks good to me.");
+  expect(reviewed.review.reviewer).toBe("alice");
+  expect(reviewed.pullRequest.state).toBe("open");
+  expect(reviewed.commit?.sha).toBe("branch-commit-sha-1");
+  expect(state.reviews).toHaveLength(1);
+});
+
+test("reviewDocumentVersion accepts comment payloads and preserves in-review state", async () => {
+  const { fetchImpl, state } = createMockFetchForUploadLifecycle();
+  globalThis.fetch = fetchImpl;
+
+  const uploaded = await uploadDocumentVersion(
+    createUploadSession(),
+    "documents/draft.json",
+    createUploadFormData(
+      JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Q2 Compliance Report v2" }],
+          },
+        ],
+      }),
+    ),
+  );
+
+  const reviewed = await reviewDocumentVersion(
+    createReviewerSession(),
+    "documents/draft.json",
+    uploaded.pullRequestNumber,
+    "COMMENT",
+    "Please tighten section 4.2.",
+  );
+
+  expect(reviewed.approvalState).toBe("in_review");
+  expect(reviewed.review.state).toBe("COMMENT");
+  expect(reviewed.review.body).toBe("Please tighten section 4.2.");
+  expect(reviewed.pullRequest.state).toBe("open");
+  expect(state.reviews).toHaveLength(1);
+});
+
+test("publishDocumentVersion rejects non-owner sessions", async () => {
+  const { fetchImpl } = createMockFetchForUploadLifecycle();
+  globalThis.fetch = fetchImpl;
+
+  const uploaded = await uploadDocumentVersion(
+    createUploadSession(),
+    "documents/draft.json",
+    createUploadFormData(
+      JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Q2 Compliance Report v2" }],
+          },
+        ],
+      }),
+    ),
+  );
+
+  await reviewDocumentVersion(
+    createReviewerSession(),
+    "documents/draft.json",
+    uploaded.pullRequestNumber,
+    "APPROVE",
+    "Looks good to me.",
+  );
+
+  await expect(
+    publishDocumentVersion(
+      createReviewerSession("bob"),
+      "documents/draft.json",
+      uploaded.pullRequestNumber,
+    ),
+  ).rejects.toMatchObject({
+    status: 403,
+    code: "publish_forbidden",
+  });
+});
+
+test("publishDocumentVersion merges an approved version and returns published metadata", async () => {
+  const { fetchImpl, state } = createMockFetchForUploadLifecycle();
+  globalThis.fetch = fetchImpl;
+
+  const uploaded = await uploadDocumentVersion(
+    createUploadSession(),
+    "documents/draft.json",
+    createUploadFormData(
+      JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Q2 Compliance Report v2" }],
+          },
+        ],
+      }),
+    ),
+  );
+
+  await reviewDocumentVersion(
+    createReviewerSession(),
+    "documents/draft.json",
+    uploaded.pullRequestNumber,
+    "APPROVE",
+    "Looks good to me.",
+  );
+
+  const published = await publishDocumentVersion(
+    createReviewerSession(),
+    "documents/draft.json",
+    uploaded.pullRequestNumber,
+  );
+
+  expect(published.documentId).toBe("documents/draft.json");
+  expect(published.branchName).toBe(UPLOAD_BRANCH_NAME);
+  expect(published.pullRequestNumber).toBe(uploaded.pullRequestNumber);
+  expect(published.approvalState).toBe("published");
+  expect(published.publishedVersion?.sha).toBe("published-commit-sha-1");
+  expect(published.commit?.sha).toBe("published-commit-sha-1");
+  expect(published.pullRequest.state).toBe("closed");
+  expect(state.mergeCount).toBe(1);
+  expect(state.publishedCommitSha).toBe("published-commit-sha-1");
 });

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -168,6 +168,10 @@ interface GiteaContentFileResponse {
   encoding?: string;
 }
 
+interface GiteaCollaboratorPermission {
+  permission?: string;
+}
+
 interface DocumentVersionMetadata extends CommitSummary {}
 
 export interface DocumentCatalogItem {
@@ -1836,8 +1840,43 @@ function buildVersionCommitMessage(document: DocumentCatalogItem, action: string
   return `${action} for ${document.displayName}`;
 }
 
-function ensurePublishPermission(session: SessionRecord, repository: WorkspaceRepository): void {
-  if (session.username === repository.owner) {
+async function hasPublishPermission(
+  token: string,
+  repository: WorkspaceRepository,
+  username: string,
+): Promise<boolean> {
+  if (username === repository.owner) {
+    return true;
+  }
+
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}/collaborators/${encodeURIComponent(username)}/permission`,
+    {
+      method: "GET",
+      headers: buildGiteaHeaders(token),
+    },
+  );
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (!response.ok) {
+    throw upstreamStatusToCatalogError(
+      response.status,
+      "publish_permission_unavailable",
+      "Unable to verify publish permissions.",
+    );
+  }
+
+  const payload = (await response.json().catch(() => ({}))) as GiteaCollaboratorPermission;
+  const permission = typeof payload.permission === "string" ? payload.permission.trim().toLowerCase() : "";
+  return permission === "admin" || permission === "write";
+}
+
+async function ensurePublishPermission(session: SessionRecord, repository: WorkspaceRepository): Promise<void> {
+  const permitted = await hasPublishPermission(session.giteaToken, repository, session.username);
+  if (permitted) {
     return;
   }
 
@@ -1921,7 +1960,7 @@ export async function publishDocumentVersion(
   pullNumber: number,
 ): Promise<DocumentVersionPublishResult> {
   const context = await loadVersionActionContext(session, documentId, pullNumber);
-  ensurePublishPermission(session, context.repository);
+  await ensurePublishPermission(session, context.repository);
 
   const currentApprovalState = resolvePullRequestState(
     context.pullRequest,

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -74,6 +74,8 @@ const configuredAllowedOrigins = (
 const DOCUMENTS_DIRECTORY = "documents";
 const DOCUMENTS_ROUTE_PREFIX = "/api/app/documents";
 const DOCUMENTS_VERSIONS_ROUTE_SUFFIX = "/versions";
+const DOCUMENTS_VERSIONS_REVIEW_ROUTE_SUFFIX = "/review";
+const DOCUMENTS_VERSIONS_PUBLISH_ROUTE_SUFFIX = "/publish";
 const UPLOAD_BRANCH_PREFIX = "bindersnap/upload";
 const GITEA_REPOS_PAGE_LIMIT = 100;
 const GITEA_PULLS_PAGE_LIMIT = 100;
@@ -204,6 +206,47 @@ export interface DocumentUploadResult {
   pullRequestNumber: number;
   pullRequestUrl: string | null;
   approvalState: CatalogApprovalState;
+}
+
+export interface DocumentVersionReviewResult {
+  documentId: string;
+  branchName: string;
+  commit: CommitSummary | null;
+  pullRequestNumber: number;
+  pullRequestUrl: string | null;
+  approvalState: CatalogApprovalState;
+  review: {
+    state: string;
+    body: string;
+    reviewer: string | null;
+    createdAt: string;
+  };
+  pullRequest: {
+    number: number;
+    title: string;
+    branch: string;
+    state: string;
+    htmlUrl: string | null;
+    updatedAt: string;
+  };
+}
+
+export interface DocumentVersionPublishResult {
+  documentId: string;
+  branchName: string;
+  commit: CommitSummary | null;
+  publishedVersion: CommitSummary | null;
+  pullRequestNumber: number;
+  pullRequestUrl: string | null;
+  approvalState: CatalogApprovalState;
+  pullRequest: {
+    number: number;
+    title: string;
+    branch: string;
+    state: string;
+    htmlUrl: string | null;
+    updatedAt: string;
+  };
 }
 
 export type CatalogApprovalState =
@@ -1630,6 +1673,326 @@ async function createOrUpdateUploadPullRequest(
   };
 }
 
+async function readPullRequest(
+  token: string,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+): Promise<GiteaPullSummary | null> {
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${pullNumber}`,
+    {
+      method: "GET",
+      headers: buildGiteaHeaders(token),
+    },
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw upstreamStatusToCatalogError(
+      response.status,
+      "version_pull_request_unavailable",
+      "Unable to load the version review request.",
+    );
+  }
+
+  return (await response.json()) as GiteaPullSummary;
+}
+
+async function submitPullRequestReview(
+  token: string,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT",
+  body: string,
+): Promise<GiteaPullReviewSummary> {
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${pullNumber}/reviews`,
+    {
+      method: "POST",
+      headers: buildGiteaHeaders(token, {
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({
+        event,
+        ...(body ? { body } : {}),
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw upstreamStatusToCatalogError(
+      response.status,
+      "version_review_failed",
+      "Unable to submit the pull request review.",
+    );
+  }
+
+  return (await response.json()) as GiteaPullReviewSummary;
+}
+
+async function mergePullRequest(
+  token: string,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  message: string,
+): Promise<{ merged?: boolean; sha?: string; merged_commit_id?: string }> {
+  const response = await giteaFetch(
+    `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${pullNumber}/merge`,
+    {
+      method: "POST",
+      headers: buildGiteaHeaders(token, {
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({
+        Do: "merge",
+        ...(message ? { MergeMessageField: message } : {}),
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw upstreamStatusToCatalogError(
+      response.status,
+      "version_publish_failed",
+      "Unable to publish the reviewed version.",
+    );
+  }
+
+  return (await response.json().catch(() => ({}))) as { merged?: boolean; sha?: string; merged_commit_id?: string };
+}
+
+interface VersionActionContext {
+  repository: WorkspaceRepository;
+  document: DocumentCatalogItem;
+  pullRequest: GiteaPullSummary;
+  pullRequestReviews: GiteaPullReviewSummary[];
+  pullRequestFiles: string[];
+}
+
+async function loadVersionActionContext(
+  session: SessionRecord,
+  documentId: string,
+  pullNumber: number,
+): Promise<VersionActionContext> {
+  const { repository, catalog } = await loadWorkspaceCatalog(session);
+  const document = catalog.documents.find((item) => item.id === documentId);
+  if (!document) {
+    throw createCatalogError(404, "document_not_found", "Document not found.");
+  }
+
+  const pullRequest = await readPullRequest(
+    session.giteaToken,
+    repository.owner,
+    repository.name,
+    pullNumber,
+  );
+  if (!pullRequest || !pullRequest.number) {
+    throw createCatalogError(404, "version_not_found", "Document version not found.");
+  }
+
+  const [pullRequestFiles, pullRequestReviews] = await Promise.all([
+    listPullRequestFiles(session.giteaToken, repository.owner, repository.name, pullNumber),
+    listPullRequestReviews(session.giteaToken, repository.owner, repository.name, pullNumber),
+  ]);
+
+  if (!pullRequestFiles.includes(document.path)) {
+    throw createCatalogError(404, "version_not_found", "Document version not found.");
+  }
+
+  return {
+    repository,
+    document,
+    pullRequest,
+    pullRequestFiles,
+    pullRequestReviews,
+  };
+}
+
+function buildVersionPullRequestMetadata(pullRequest: GiteaPullSummary): {
+  number: number;
+  title: string;
+  branch: string;
+  state: string;
+  htmlUrl: string | null;
+  updatedAt: string;
+} {
+  return {
+    number: pullRequest.number ?? 0,
+    title: pullRequest.title ?? "",
+    branch: pullRequest.head?.ref ?? "",
+    state: pullRequest.state ?? "open",
+    htmlUrl: pullRequest.html_url ?? null,
+    updatedAt: pullRequest.updated_at ?? pullRequest.created_at ?? "",
+  };
+}
+
+function buildVersionCommitMessage(document: DocumentCatalogItem, action: string): string {
+  return `${action} for ${document.displayName}`;
+}
+
+function ensurePublishPermission(session: SessionRecord, repository: WorkspaceRepository): void {
+  if (session.username === repository.owner) {
+    return;
+  }
+
+  throw createCatalogError(
+    403,
+    "publish_forbidden",
+    "You do not have permission to publish this version.",
+  );
+}
+
+function normalizeReviewBody(body: unknown, comment: unknown): string {
+  if (typeof body === "string" && body.trim() !== "") {
+    return body.trim();
+  }
+
+  if (typeof comment === "string" && comment.trim() !== "") {
+    return comment.trim();
+  }
+
+  return "";
+}
+
+export async function reviewDocumentVersion(
+  session: SessionRecord,
+  documentId: string,
+  pullNumber: number,
+  event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT",
+  body: string,
+): Promise<DocumentVersionReviewResult> {
+  const context = await loadVersionActionContext(session, documentId, pullNumber);
+
+  if (context.pullRequest.state !== "open") {
+    throw createCatalogError(409, "version_not_reviewable", "This version is not open for review.");
+  }
+
+  const review = await submitPullRequestReview(
+    session.giteaToken,
+    context.repository.owner,
+    context.repository.name,
+    pullNumber,
+    event,
+    body,
+  );
+
+  const [updatedPullRequest, updatedReviews, commit] = await Promise.all([
+    readPullRequest(session.giteaToken, context.repository.owner, context.repository.name, pullNumber),
+    listPullRequestReviews(session.giteaToken, context.repository.owner, context.repository.name, pullNumber),
+    readCommitSummary(
+      session.giteaToken,
+      context.repository.owner,
+      context.repository.name,
+      context.document.path,
+      context.pullRequest.head?.ref ?? context.repository.defaultBranch,
+    ),
+  ]);
+
+  if (!updatedPullRequest || !updatedPullRequest.number) {
+    throw createCatalogError(502, "version_pull_request_unavailable", "Unable to load the version review request.");
+  }
+
+  return {
+    documentId: context.document.id,
+    branchName: updatedPullRequest.head?.ref ?? "",
+    commit,
+    pullRequestNumber: updatedPullRequest.number,
+    pullRequestUrl: updatedPullRequest.html_url ?? null,
+    approvalState: resolvePullRequestState(updatedPullRequest, updatedReviews),
+    review: {
+      state: review.state ?? event,
+      body: review.body ?? body,
+      reviewer: review.user?.login ?? session.username,
+      createdAt: review.submitted_at ?? review.created_at ?? "",
+    },
+    pullRequest: buildVersionPullRequestMetadata(updatedPullRequest),
+  };
+}
+
+export async function publishDocumentVersion(
+  session: SessionRecord,
+  documentId: string,
+  pullNumber: number,
+): Promise<DocumentVersionPublishResult> {
+  const context = await loadVersionActionContext(session, documentId, pullNumber);
+  ensurePublishPermission(session, context.repository);
+
+  const currentApprovalState = resolvePullRequestState(
+    context.pullRequest,
+    context.pullRequestReviews,
+  );
+
+  if (currentApprovalState === "published") {
+    const currentPublishedVersion = await readCommitSummary(
+      session.giteaToken,
+      context.repository.owner,
+      context.repository.name,
+      context.document.path,
+      context.repository.defaultBranch,
+    );
+
+    return {
+      documentId: context.document.id,
+      branchName: context.pullRequest.head?.ref ?? "",
+      commit: currentPublishedVersion,
+      publishedVersion: currentPublishedVersion,
+      pullRequestNumber: context.pullRequest.number ?? pullNumber,
+      pullRequestUrl: context.pullRequest.html_url ?? null,
+      approvalState: "published",
+      pullRequest: buildVersionPullRequestMetadata(context.pullRequest),
+    };
+  }
+
+  if (context.pullRequest.state !== "open") {
+    throw createCatalogError(409, "version_not_publishable", "This version is not open for publishing.");
+  }
+
+  if (currentApprovalState !== "approved") {
+    throw createCatalogError(409, "approval_required", "This version must be approved before publishing.");
+  }
+
+  await mergePullRequest(
+    session.giteaToken,
+    context.repository.owner,
+    context.repository.name,
+    pullNumber,
+    buildVersionCommitMessage(context.document, "Publish"),
+  );
+
+  const [publishedPullRequest, publishedReviews, publishedVersion] = await Promise.all([
+    readPullRequest(session.giteaToken, context.repository.owner, context.repository.name, pullNumber),
+    listPullRequestReviews(session.giteaToken, context.repository.owner, context.repository.name, pullNumber),
+    readCommitSummary(
+      session.giteaToken,
+      context.repository.owner,
+      context.repository.name,
+      context.document.path,
+      context.repository.defaultBranch,
+    ),
+  ]);
+
+  if (!publishedPullRequest || !publishedPullRequest.number) {
+    throw createCatalogError(502, "version_pull_request_unavailable", "Unable to load the published version.");
+  }
+
+  return {
+    documentId: context.document.id,
+    branchName: publishedPullRequest.head?.ref ?? "",
+    commit: publishedVersion,
+    publishedVersion,
+    pullRequestNumber: publishedPullRequest.number,
+    pullRequestUrl: publishedPullRequest.html_url ?? null,
+    approvalState: resolvePullRequestState(publishedPullRequest, publishedReviews),
+    pullRequest: buildVersionPullRequestMetadata(publishedPullRequest),
+  };
+}
+
 export async function uploadDocumentVersion(
   session: SessionRecord,
   documentId: string,
@@ -2070,6 +2433,100 @@ async function handleDocumentVersionUpload(
   }
 }
 
+interface VersionReviewRequestBody {
+  event?: unknown;
+  body?: unknown;
+  comment?: unknown;
+}
+
+function parseDocumentVersionRoute(
+  pathname: string,
+  suffix: string,
+): { documentId: string; pullNumber: number } | null {
+  if (!pathname.startsWith(`${DOCUMENTS_ROUTE_PREFIX}/`) || !pathname.endsWith(suffix)) {
+    return null;
+  }
+
+  const innerPath = pathname.slice(
+    `${DOCUMENTS_ROUTE_PREFIX}/`.length,
+    pathname.length - suffix.length,
+  );
+  const separator = innerPath.lastIndexOf("/versions/");
+  if (separator <= 0) {
+    return null;
+  }
+
+  try {
+    const documentId = decodeURIComponent(innerPath.slice(0, separator));
+    const pullNumberValue = Number.parseInt(innerPath.slice(separator + "/versions/".length), 10);
+    if (!documentId || !Number.isFinite(pullNumberValue) || pullNumberValue <= 0) {
+      return null;
+    }
+
+    return {
+      documentId,
+      pullNumber: pullNumberValue,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function handleDocumentVersionReview(
+  req: Request,
+  baseHeaders: Headers,
+  documentId: string,
+  pullNumber: number,
+): Promise<Response> {
+  const session = getSessionFromRequest(req);
+  if (!session) {
+    return catalogErrorResponse(createCatalogError(401, "unauthorized", "Unauthorized."), baseHeaders);
+  }
+
+  const payload = (await readJson<VersionReviewRequestBody>(req)) ?? {};
+  const eventRaw = typeof payload.event === "string" ? payload.event.trim().toUpperCase() : "";
+  if (!["APPROVE", "REQUEST_CHANGES", "COMMENT"].includes(eventRaw)) {
+    return catalogErrorResponse(
+      createCatalogError(400, "invalid_review_event", "A valid review event is required."),
+      baseHeaders,
+    );
+  }
+
+  const body = normalizeReviewBody(payload.body, payload.comment);
+
+  try {
+    const review = await reviewDocumentVersion(
+      session,
+      documentId,
+      pullNumber,
+      eventRaw as "APPROVE" | "REQUEST_CHANGES" | "COMMENT",
+      body,
+    );
+    return json(200, review, baseHeaders);
+  } catch (error) {
+    return catalogErrorResponse(error, baseHeaders);
+  }
+}
+
+async function handleDocumentVersionPublish(
+  req: Request,
+  baseHeaders: Headers,
+  documentId: string,
+  pullNumber: number,
+): Promise<Response> {
+  const session = getSessionFromRequest(req);
+  if (!session) {
+    return catalogErrorResponse(createCatalogError(401, "unauthorized", "Unauthorized."), baseHeaders);
+  }
+
+  try {
+    const payload = await publishDocumentVersion(session, documentId, pullNumber);
+    return json(200, payload, baseHeaders);
+  } catch (error) {
+    return catalogErrorResponse(error, baseHeaders);
+  }
+}
+
 async function cleanupExpiredSessions(): Promise<void> {
   const now = Date.now();
   const expiredSessions: SessionRecord[] = [];
@@ -2136,26 +2593,34 @@ export async function handleApiRequest(req: Request): Promise<Response> {
     return handleDocuments(req, baseHeaders);
   }
 
-  if (
-    pathname.startsWith(`${DOCUMENTS_ROUTE_PREFIX}/`) &&
-    pathname.endsWith(DOCUMENTS_VERSIONS_ROUTE_SUFFIX) &&
-    req.method === "POST"
-  ) {
-    try {
-      const documentId = decodeURIComponent(
-        pathname.slice(
-          `${DOCUMENTS_ROUTE_PREFIX}/`.length,
-          pathname.length - DOCUMENTS_VERSIONS_ROUTE_SUFFIX.length,
-        ),
-      );
-      if (documentId) {
-        return handleDocumentVersionUpload(req, baseHeaders, documentId);
+  if (pathname.startsWith(`${DOCUMENTS_ROUTE_PREFIX}/`) && req.method === "POST") {
+    if (pathname.endsWith(DOCUMENTS_VERSIONS_ROUTE_SUFFIX)) {
+      try {
+        const documentId = decodeURIComponent(
+          pathname.slice(
+            `${DOCUMENTS_ROUTE_PREFIX}/`.length,
+            pathname.length - DOCUMENTS_VERSIONS_ROUTE_SUFFIX.length,
+          ),
+        );
+        if (documentId) {
+          return handleDocumentVersionUpload(req, baseHeaders, documentId);
+        }
+      } catch {
+        return catalogErrorResponse(
+          createCatalogError(400, "invalid_document_id", "Invalid document identifier."),
+          baseHeaders,
+        );
       }
-    } catch {
-      return catalogErrorResponse(
-        createCatalogError(400, "invalid_document_id", "Invalid document identifier."),
-        baseHeaders,
-      );
+    }
+
+    const reviewRoute = parseDocumentVersionRoute(pathname, DOCUMENTS_VERSIONS_REVIEW_ROUTE_SUFFIX);
+    if (reviewRoute) {
+      return handleDocumentVersionReview(req, baseHeaders, reviewRoute.documentId, reviewRoute.pullNumber);
+    }
+
+    const publishRoute = parseDocumentVersionRoute(pathname, DOCUMENTS_VERSIONS_PUBLISH_ROUTE_SUFFIX);
+    if (publishRoute) {
+      return handleDocumentVersionPublish(req, baseHeaders, publishRoute.documentId, publishRoute.pullNumber);
     }
   }
 


### PR DESCRIPTION
Implements issue #88 by adding review and publish actions for uploaded document versions using Gitea pull request primitives.

Workflow evidence:
- Issue read: `issue_read` (`get`) on #88
- Branch creation: `create_branch` for `codex/issue-88-version-review-api`
- Commit SHA(s):
  - `8ce62c1` Add version review and publish APIs
  - `8c72c85` Harden version review and publish route coverage
- PR creation: `create_pull_request`
- Fallback used: none

What changed:
- Added `POST /api/app/documents/:id/versions/:prNumber/review` to submit `APPROVE`, `REQUEST_CHANGES`, `COMMENT` events.
- Added `POST /api/app/documents/:id/versions/:prNumber/publish` to merge approved PRs and return published metadata.
- Normalized approval states in responses: `working`, `in_review`, `changes_requested`, `approved`, `published`.
- Added publish permission checks based on repository owner OR collaborator permission (`write`/`admin`).
- Preserved normalized error envelope (`error.code`, `error.message`, `message`).
- Expanded tests with route-level negative cases (`invalid_review_event`, `approval_required`) and collaborator publish-permission coverage.

Validation:
- `bun test services/api/server.test.ts` ✅
- `bun test apps/app packages/gitea-client` ✅

Closes #88