### PR TITLE
Issue #89: pivot app shell to file vault UI

### DIFF
--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -8,12 +8,13 @@ This is the authenticated Bindersnap product app.
 - API sets an `HttpOnly` session cookie.
 - Browser never stores or receives upstream Gitea access tokens.
 - App data calls go through API routes (for example `/api/app/documents`).
+- The file-vault shell uses `/api/app/documents` and `/api/app/documents/:id` to keep the list and detail views in sync.
 
 ## Entry points
 
 - `index.html`: HTML entry for the product app.
 - `App.tsx`: Route/auth gate (`/app`, `/login`, `/auth/callback` shell handling).
-- `components/AppShell.tsx`: Authenticated app shell and workspace data fetch.
+- `components/AppShell.tsx`: Authenticated vault shell with document list and detail state.
 
 ## Local dev
 

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -322,7 +322,7 @@ input {
 .app-vault-hero-head h1 {
   margin: 0;
   font-family: var(--font-serif);
-  font-size: clamp(2rem, 3vw, 3rem);
+  font-size: var(--brand-text-h1);
   line-height: var(--brand-leading-tight);
 }
 
@@ -362,8 +362,8 @@ input {
 
 .app-vault-stat strong {
   font-family: var(--font-serif);
-  font-size: 1.5rem;
-  line-height: 1.2;
+  font-size: var(--brand-text-h3);
+  line-height: var(--brand-leading-snug);
 }
 
 .app-vault-stat-label {
@@ -429,6 +429,8 @@ input {
 
 .app-vault-item {
   appearance: none;
+  position: relative;
+  overflow: hidden;
   width: 100%;
   text-align: left;
   border: 1px solid var(--bs-rule);
@@ -443,11 +445,29 @@ input {
   gap: var(--brand-space-4);
 }
 
+.app-vault-item::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--brand-space-1);
+  background: var(--color-coral);
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform var(--transition-base);
+}
+
 .app-vault-item:hover,
 .app-vault-item:focus-visible {
-  transform: translateY(-2px);
+  transform: translateY(calc(-1 * var(--brand-space-1)));
   box-shadow: var(--shadow-lg);
-  border-color: var(--bs-coral-dim);
+  border-color: transparent;
+}
+
+.app-vault-item:hover::before,
+.app-vault-item:focus-visible::before {
+  transform: scaleX(1);
 }
 
 .app-vault-item.is-selected {
@@ -465,7 +485,7 @@ input {
 .app-vault-item-head h3 {
   margin: 0;
   font-family: var(--font-serif);
-  font-size: 1.35rem;
+  font-size: var(--brand-text-h3);
   line-height: var(--brand-leading-tight);
 }
 
@@ -486,7 +506,7 @@ input {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.35rem 0.7rem;
+  padding: var(--brand-space-1) var(--brand-space-2);
   border-radius: var(--brand-radius-full);
   font-family: var(--font-mono);
   font-size: var(--brand-text-label);

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -299,3 +299,376 @@ input {
     flex-direction: column;
   }
 }
+
+.app-vault-shell .app-main {
+  gap: var(--brand-space-4);
+}
+
+.app-vault-hero {
+  display: grid;
+  gap: var(--brand-space-5);
+  background:
+    radial-gradient(circle at top right, var(--bs-coral-glow), transparent 24%),
+    linear-gradient(180deg, var(--bs-surface-2), var(--bs-surface-1));
+}
+
+.app-vault-hero-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--brand-space-5);
+}
+
+.app-vault-hero-head h1 {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(2rem, 3vw, 3rem);
+  line-height: var(--brand-leading-tight);
+}
+
+.app-vault-hero-head p {
+  max-width: 58ch;
+}
+
+.app-vault-hero-note {
+  display: grid;
+  justify-items: end;
+  gap: var(--brand-space-2);
+  text-align: right;
+}
+
+.app-vault-hero-meta {
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+}
+
+.app-vault-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--brand-space-4);
+}
+
+.app-vault-stat {
+  display: grid;
+  gap: var(--brand-space-2);
+  padding: var(--brand-space-4);
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-xl);
+}
+
+.app-vault-stat strong {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.app-vault-stat-label {
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+}
+
+.app-vault-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: var(--brand-space-5);
+  align-items: start;
+}
+
+.app-vault-list-panel,
+.app-vault-detail-panel {
+  padding: var(--brand-space-5);
+}
+
+.app-vault-list-panel {
+  display: grid;
+  gap: var(--brand-space-4);
+}
+
+.app-vault-list-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--brand-space-4);
+  align-items: flex-start;
+}
+
+.app-vault-list-heading h2,
+.app-vault-detail-head h2,
+.app-vault-detail-empty h2,
+.app-vault-detail-error h2 {
+  margin: var(--brand-space-2) 0 0;
+  font-family: var(--font-serif);
+  line-height: var(--brand-leading-tight);
+}
+
+.app-vault-list-meta,
+.app-vault-detail-meta {
+  display: grid;
+  gap: var(--brand-space-2);
+  justify-items: end;
+}
+
+.app-vault-list-count {
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+}
+
+.app-vault-list {
+  display: grid;
+  gap: var(--brand-space-4);
+}
+
+.app-vault-item {
+  appearance: none;
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--bs-rule);
+  background: var(--bs-surface-1);
+  color: inherit;
+  cursor: pointer;
+  transition:
+    transform var(--transition-base),
+    box-shadow var(--transition-base),
+    border-color var(--transition-base);
+  display: grid;
+  gap: var(--brand-space-4);
+}
+
+.app-vault-item:hover,
+.app-vault-item:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--bs-coral-dim);
+}
+
+.app-vault-item.is-selected {
+  border-color: var(--color-coral);
+  box-shadow: var(--shadow-coral);
+}
+
+.app-vault-item-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--brand-space-4);
+}
+
+.app-vault-item-head h3 {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 1.35rem;
+  line-height: var(--brand-leading-tight);
+}
+
+.app-vault-item-grid {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--brand-space-4);
+}
+
+.app-vault-item-grid div,
+.app-vault-detail-block dl div {
+  display: grid;
+  gap: var(--brand-space-2);
+}
+
+.app-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: var(--brand-radius-full);
+  font-family: var(--font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.app-status-badge--good {
+  color: var(--brand-green);
+  background: var(--bs-green-dim);
+  border-color: var(--bs-rule);
+}
+
+.app-status-badge--alert {
+  color: var(--color-coral-dark);
+  background: var(--bs-coral-dim);
+  border-color: var(--bs-rule);
+}
+
+.app-status-badge--pending {
+  color: var(--color-ink);
+  background: var(--bs-surface-2);
+  border-color: var(--bs-rule);
+}
+
+.app-status-badge--idle {
+  color: var(--color-muted);
+  background: var(--bs-surface-2);
+  border-color: var(--bs-rule);
+}
+
+.app-vault-detail-panel {
+  display: grid;
+  gap: var(--brand-space-4);
+  position: sticky;
+  top: var(--brand-space-5);
+}
+
+.app-vault-detail-empty,
+.app-vault-detail-error {
+  display: grid;
+  gap: var(--brand-space-3);
+}
+
+.app-vault-detail-head {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--brand-space-4);
+  align-items: flex-start;
+}
+
+.app-vault-detail-stack {
+  display: grid;
+  gap: var(--brand-space-4);
+}
+
+.app-vault-detail-block {
+  display: grid;
+  gap: var(--brand-space-3);
+  padding: var(--brand-space-4);
+  border-radius: var(--brand-radius-xl);
+  border: 1px solid var(--bs-rule);
+  background: var(--bs-surface-2);
+}
+
+.app-vault-detail-block h3 {
+  margin: 0;
+  font-family: var(--font-serif);
+  line-height: var(--brand-leading-tight);
+}
+
+.app-vault-detail-block dl {
+  margin: 0;
+  display: grid;
+  gap: var(--brand-space-3);
+}
+
+.app-vault-detail-block dt {
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+}
+
+.app-vault-detail-block dd {
+  margin: 0;
+  color: var(--color-ink-soft);
+  word-break: break-word;
+}
+
+.app-vault-block-empty {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.app-detail-link {
+  color: var(--color-coral);
+  font-family: var(--font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+  text-decoration: none;
+}
+
+.app-detail-link:hover,
+.app-detail-link:focus-visible {
+  color: var(--color-coral-dark);
+}
+
+.app-vault-timeline {
+  margin: 0;
+  padding-left: var(--brand-space-5);
+  display: grid;
+  gap: var(--brand-space-3);
+}
+
+.app-vault-timeline li {
+  display: grid;
+  gap: var(--brand-space-1);
+}
+
+.app-vault-timeline strong {
+  font-family: var(--font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+}
+
+.app-vault-timeline span {
+  color: var(--color-ink-soft);
+}
+
+.app-vault-detail-loading {
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+}
+
+@media (max-width: 960px) {
+  .app-vault-hero-head,
+  .app-vault-list-heading,
+  .app-vault-detail-head {
+    flex-direction: column;
+  }
+
+  .app-vault-hero-note,
+  .app-vault-list-meta,
+  .app-vault-detail-meta {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .app-vault-stats,
+  .app-vault-item-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .app-vault-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .app-vault-detail-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-vault-list-panel,
+  .app-vault-detail-panel {
+    padding: var(--brand-space-4);
+  }
+
+  .app-vault-hero {
+    padding: var(--brand-space-4);
+  }
+
+  .app-vault-stat {
+    padding: var(--brand-space-3);
+  }
+}

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { CommitSummary } from "../../../packages/gitea-client/documents";
 
@@ -18,6 +18,8 @@ const API_BASE_URL = (
   (isLocalHost ? devDefaultApiBaseUrl : "")
 ).replace(/\/$/, "");
 
+type ApprovalState = "none" | "working" | "in_review" | "changes_requested" | "approved" | "published";
+
 interface AppShellProps {
   user: {
     username: string;
@@ -26,15 +28,38 @@ interface AppShellProps {
   onSignOut: () => void | Promise<void>;
 }
 
-interface DocumentRow {
+interface DocumentPendingPullRequest {
+  number: number;
   title: string;
+  state: ApprovalState;
+  branch: string;
+  updatedAt: string;
+  htmlUrl: string | null;
+}
+
+interface DocumentVaultItem {
+  id: string;
+  title: string;
+  displayName: string;
   path: string;
+  repository: string;
+  publishedVersion: CommitSummary | null;
+  currentPublishedVersion: CommitSummary | null;
+  latestPendingVersionStatus: ApprovalState | null;
+  latestPendingPullRequest: DocumentPendingPullRequest | null;
   latestCommit: CommitSummary | null;
+  lastActivityTimestamp: string;
+  lastActivityAt: string;
 }
 
 interface DocumentsPayload {
   repository: string;
-  documents: DocumentRow[];
+  documents: DocumentVaultItem[];
+}
+
+interface DocumentDetailPayload {
+  repository: string;
+  document: DocumentVaultItem;
 }
 
 function formatTimestamp(value: string) {
@@ -56,58 +81,226 @@ function readErrorMessage(payload: unknown, fallback: string): string {
     if (typeof (payload as { message?: unknown }).message === "string") {
       return (payload as { message: string }).message;
     }
+
+    if (
+      typeof (payload as { error?: unknown }).error === "object" &&
+      (payload as { error?: unknown }).error !== null &&
+      typeof ((payload as { error?: { message?: unknown } }).error?.message) === "string"
+    ) {
+      return (payload as { error: { message: string } }).error.message;
+    }
   }
 
   return fallback;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readCommitSummary(value: unknown): CommitSummary | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const sha = typeof value.sha === "string" ? value.sha.trim() : "";
+  const message = typeof value.message === "string" ? value.message.trim() : "";
+  const author = typeof value.author === "string" ? value.author.trim() : "";
+  const timestamp = typeof value.timestamp === "string" ? value.timestamp.trim() : "";
+
+  if (!sha && !message && !author && !timestamp) {
+    return null;
+  }
+
+  return { sha, message, author, timestamp };
+}
+
+function readApprovalState(value: unknown): ApprovalState | null {
+  if (
+    value === "none" ||
+    value === "working" ||
+    value === "in_review" ||
+    value === "changes_requested" ||
+    value === "approved" ||
+    value === "published"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function readPendingPullRequest(value: unknown): DocumentPendingPullRequest | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const number = typeof value.number === "number" && Number.isFinite(value.number) ? value.number : 0;
+  const title = typeof value.title === "string" ? value.title.trim() : "";
+  const state = readApprovalState(value.state) ?? null;
+  const branch = typeof value.branch === "string" ? value.branch.trim() : "";
+  const updatedAt = typeof value.updatedAt === "string" ? value.updatedAt.trim() : "";
+  const htmlUrl = typeof value.htmlUrl === "string" && value.htmlUrl.trim() !== "" ? value.htmlUrl.trim() : null;
+
+  if (!number && !title && !state && !branch && !updatedAt && !htmlUrl) {
+    return null;
+  }
+
+  return {
+    number,
+    title,
+    state: state ?? "none",
+    branch,
+    updatedAt,
+    htmlUrl,
+  };
+}
+
+function readDocument(value: unknown): DocumentVaultItem | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const path = typeof value.path === "string" ? value.path.trim() : "";
+  if (!path) {
+    return null;
+  }
+
+  const displayName =
+    typeof value.displayName === "string" && value.displayName.trim() !== ""
+      ? value.displayName.trim()
+      : typeof value.title === "string" && value.title.trim() !== ""
+        ? value.title.trim()
+        : path;
+
+  const currentPublishedVersion =
+    readCommitSummary(value.currentPublishedVersion) ??
+    readCommitSummary(value.publishedVersion) ??
+    readCommitSummary(value.latestCommit);
+  const publishedVersion =
+    readCommitSummary(value.publishedVersion) ?? currentPublishedVersion;
+  const latestCommit = readCommitSummary(value.latestCommit) ?? currentPublishedVersion;
+  const latestPendingPullRequest = readPendingPullRequest(value.latestPendingPullRequest);
+  const latestPendingVersionStatus =
+    readApprovalState(value.latestPendingVersionStatus) ?? latestPendingPullRequest?.state ?? null;
+  const lastActivityTimestamp =
+    typeof value.lastActivityTimestamp === "string" && value.lastActivityTimestamp.trim() !== ""
+      ? value.lastActivityTimestamp.trim()
+      : typeof value.lastActivityAt === "string" && value.lastActivityAt.trim() !== ""
+        ? value.lastActivityAt.trim()
+        : latestPendingPullRequest?.updatedAt ?? latestCommit?.timestamp ?? "";
+  const lastActivityAt =
+    typeof value.lastActivityAt === "string" && value.lastActivityAt.trim() !== ""
+      ? value.lastActivityAt.trim()
+      : lastActivityTimestamp;
+
+  return {
+    id: typeof value.id === "string" && value.id.trim() !== "" ? value.id.trim() : path,
+    title: displayName,
+    displayName,
+    path,
+    repository: typeof value.repository === "string" && value.repository.trim() !== "" ? value.repository.trim() : "your workspace",
+    publishedVersion,
+    currentPublishedVersion,
+    latestPendingVersionStatus,
+    latestPendingPullRequest,
+    latestCommit,
+    lastActivityTimestamp,
+    lastActivityAt,
+  };
+}
+
 function parseDocuments(payload: unknown): DocumentsPayload {
-  const rows =
-    Array.isArray(payload)
-      ? payload
-      : typeof payload === "object" &&
-          payload !== null &&
-          Array.isArray((payload as { documents?: unknown }).documents)
-        ? ((payload as { documents: unknown[] }).documents as unknown[])
-        : [];
   const repository =
-    typeof payload === "object" && payload !== null && typeof (payload as { repository?: unknown }).repository === "string"
-      ? (payload as { repository: string }).repository
+    isRecord(payload) && typeof payload.repository === "string" && payload.repository.trim() !== ""
+      ? payload.repository.trim()
       : "your workspace";
 
+  const rows = Array.isArray(payload)
+    ? payload
+    : isRecord(payload) && Array.isArray(payload.documents)
+      ? payload.documents
+      : isRecord(payload) && isRecord(payload.document)
+        ? [payload.document]
+        : [];
+
   const documents = rows.flatMap((row) => {
-    if (typeof row !== "object" || row === null) {
-      return [];
-    }
-
-    const candidate = row as {
-      title?: unknown;
-      path?: unknown;
-      latestCommit?: unknown;
-      latest_commit?: unknown;
-    };
-
-    if (typeof candidate.title !== "string" || typeof candidate.path !== "string") {
-      return [];
-    }
-
-    const latestCommit =
-      typeof candidate.latestCommit === "object" && candidate.latestCommit !== null
-        ? (candidate.latestCommit as CommitSummary)
-        : typeof candidate.latest_commit === "object" && candidate.latest_commit !== null
-          ? (candidate.latest_commit as CommitSummary)
-        : null;
-
-    return [
-      {
-        title: candidate.title,
-        path: candidate.path,
-        latestCommit,
-      },
-    ];
+    const document = readDocument(row);
+    return document ? [document] : [];
   });
 
   return { repository, documents };
+}
+
+function parseDocumentDetail(payload: unknown): DocumentDetailPayload {
+  if (isRecord(payload) && isRecord(payload.document)) {
+    const document = readDocument(payload.document);
+    if (document) {
+      return {
+        repository:
+          typeof payload.repository === "string" && payload.repository.trim() !== ""
+            ? payload.repository.trim()
+            : document.repository,
+        document,
+      };
+    }
+  }
+
+  const { repository, documents } = parseDocuments(payload);
+  const document = documents[0];
+  if (!document) {
+    throw new Error("Document details were not returned.");
+  }
+
+  return { repository, document };
+}
+
+function formatCommitSummary(commit: CommitSummary | null | undefined): string {
+  if (!commit) {
+    return "No published version";
+  }
+
+  const parts = [commit.sha ? commit.sha.slice(0, 7) : "No SHA"];
+  if (commit.message) {
+    parts.push(commit.message);
+  }
+  return parts.join(" - ");
+}
+
+function formatPendingState(state: ApprovalState | null | undefined): string {
+  switch (state) {
+    case "changes_requested":
+      return "Changes requested";
+    case "approved":
+      return "Approved";
+    case "published":
+      return "Published";
+    case "in_review":
+      return "In review";
+    case "working":
+      return "Working";
+    default:
+      return "No pending review";
+  }
+}
+
+function approvalTone(state: ApprovalState | null | undefined): string {
+  switch (state) {
+    case "published":
+    case "approved":
+      return "good";
+    case "changes_requested":
+      return "alert";
+    case "in_review":
+    case "working":
+      return "pending";
+    default:
+      return "idle";
+  }
+}
+
+function pendingCountProxy(document: DocumentVaultItem | null): number {
+  return document?.latestPendingPullRequest ? 1 : 0;
 }
 
 async function fetchDocuments(): Promise<DocumentsPayload> {
@@ -127,20 +320,84 @@ async function fetchDocuments(): Promise<DocumentsPayload> {
   return parseDocuments(payload);
 }
 
+async function fetchDocumentDetail(documentId: string): Promise<DocumentDetailPayload> {
+  const response = await fetch(resolveApiUrl(`/api/app/documents/${encodeURIComponent(documentId)}`), {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  const payload = (await response.json().catch(() => null)) as unknown;
+  if (!response.ok) {
+    throw new Error(readErrorMessage(payload, "Unable to load document details."));
+  }
+
+  return parseDocumentDetail(payload);
+}
+
 export function AppShell({ user, onSignOut }: AppShellProps) {
-  const [documents, setDocuments] = useState<DocumentRow[]>([]);
+  const [documents, setDocuments] = useState<DocumentVaultItem[]>([]);
   const [repository, setRepository] = useState("your workspace");
+  const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(null);
+  const [detailDocument, setDetailDocument] = useState<DocumentVaultItem | null>(null);
   const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const selectedDocumentIdRef = useRef<string | null>(null);
+
+  const selectedDocument = useMemo(() => {
+    if (detailDocument && detailDocument.id === selectedDocumentId) {
+      return detailDocument;
+    }
+
+    return documents.find((document) => document.id === selectedDocumentId) ?? null;
+  }, [detailDocument, documents, selectedDocumentId]);
+
+  const loadDocumentDetail = useCallback(async (documentId: string) => {
+    setDetailLoading(true);
+    setDetailError(null);
+
+    try {
+      const payload = await fetchDocumentDetail(documentId);
+      setDetailDocument(payload.document);
+      setRepository(payload.repository);
+    } catch (loadError) {
+      const message =
+        loadError instanceof Error
+          ? loadError.message
+          : "Unable to load document details.";
+      setDetailError(message);
+      setDetailDocument(null);
+    } finally {
+      setDetailLoading(false);
+    }
+  }, []);
 
   const loadDocuments = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setDetailError(null);
 
     try {
       const payload = await fetchDocuments();
       setDocuments(payload.documents);
       setRepository(payload.repository);
+
+      const nextSelectedDocumentId =
+        payload.documents.some((document) => document.id === selectedDocumentIdRef.current)
+          ? selectedDocumentIdRef.current
+          : payload.documents[0]?.id ?? null;
+
+      setSelectedDocumentId(nextSelectedDocumentId);
+
+      if (nextSelectedDocumentId) {
+        void loadDocumentDetail(nextSelectedDocumentId);
+      } else {
+        setDetailDocument(null);
+      }
     } catch (loadError) {
       const message =
         loadError instanceof Error
@@ -150,17 +407,29 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
       setError(message);
       setDocuments([]);
       setRepository("your workspace");
+      setSelectedDocumentId(null);
+      setDetailDocument(null);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [loadDocumentDetail]);
 
   useEffect(() => {
     void loadDocuments();
   }, [loadDocuments]);
 
+  useEffect(() => {
+    selectedDocumentIdRef.current = selectedDocumentId;
+  }, [selectedDocumentId]);
+
+  const totalPendingCount = documents.reduce(
+    (count, document) => count + (document.latestPendingPullRequest ? 1 : 0),
+    0,
+  );
+  const latestWorkspaceActivity = documents[0]?.lastActivityTimestamp || documents[0]?.lastActivityAt || "";
+
   return (
-    <div className="app-shell">
+    <div className="app-shell app-vault-shell">
       <header className="app-topbar">
         <div className="app-logo-wrap">
           <div className="app-logo-mark" aria-hidden="true">
@@ -177,7 +446,7 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
 
         <div className="app-topbar-actions">
           <button className="bs-btn bs-btn-secondary" type="button" onClick={() => void loadDocuments()}>
-            {loading ? "Refreshing..." : "Refresh"}
+            {loading ? "Refreshing..." : "Refresh vault"}
           </button>
           <button className="bs-btn bs-btn-dark" type="button" onClick={() => void onSignOut()}>
             Sign out
@@ -185,60 +454,227 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
         </div>
       </header>
 
-      <main className="app-main">
-        <section className="bs-card app-summary">
-          <div className="bs-eyebrow">Workspace</div>
-          <h1>{repository}</h1>
-          <p>
-            Signed in as {user?.fullName ?? user?.username ?? "your account"}. Documents load through the
-            Bindersnap session API, not from a browser-held upstream token.
-          </p>
+      <main className="app-main app-vault-main">
+        <section className="bs-card app-summary app-vault-hero">
+          <div className="bs-eyebrow">File Vault</div>
+          <div className="app-vault-hero-head">
+            <div>
+              <h1>{repository}</h1>
+              <p>
+                Keep the published file, the pending review branch, and the audit trail in one place.
+                No editor canvas required for the core workflow.
+              </p>
+            </div>
+            <div className="app-vault-hero-note">
+              <span className="app-status-badge app-status-badge--good">Live catalog</span>
+              <span className="app-vault-hero-meta">Session-backed access</span>
+            </div>
+          </div>
+
+          <div className="app-vault-stats">
+            <div className="app-vault-stat">
+              <span className="app-vault-stat-label">Documents</span>
+              <strong>{documents.length}</strong>
+            </div>
+            <div className="app-vault-stat">
+              <span className="app-vault-stat-label">Pending reviews</span>
+              <strong>{totalPendingCount}</strong>
+            </div>
+            <div className="app-vault-stat">
+              <span className="app-vault-stat-label">Latest activity</span>
+              <strong>{formatTimestamp(latestWorkspaceActivity)}</strong>
+            </div>
+          </div>
         </section>
 
         {error ? (
           <section className="bs-card app-error">
             <div className="bs-eyebrow">Failure State</div>
-            <h2>Could not fetch workspace documents.</h2>
+            <h2>Could not load the vault.</h2>
             <p>{error}</p>
           </section>
         ) : null}
 
-        <section className="app-docs">
-          <div className="app-section-heading">
-            <div className="bs-eyebrow">Documents</div>
-            <h2>Local dev seed documents</h2>
-          </div>
+        <section className="app-vault-layout">
+          <section className="bs-card app-vault-list-panel">
+            <div className="app-section-heading app-vault-list-heading">
+              <div>
+                <div className="bs-eyebrow">Documents</div>
+                <h2>Published files and reviewable versions</h2>
+              </div>
+              <div className="app-vault-list-meta">
+                <span className="app-vault-list-count">{documents.length} records</span>
+                <span className="app-vault-list-count">{totalPendingCount} pending</span>
+              </div>
+            </div>
 
-          <div className="app-doc-grid">
-            {loading ? <div className="bs-card app-doc-empty">Loading documents...</div> : null}
-            {!loading && documents.length === 0 ? (
-              <div className="bs-card app-doc-empty">No documents were returned for this workspace.</div>
+            <div className="app-vault-list">
+              {loading ? <div className="bs-card app-doc-empty">Loading documents...</div> : null}
+              {!loading && documents.length === 0 ? (
+                <div className="bs-card app-doc-empty">
+                  No documents were returned for this workspace.
+                </div>
+              ) : null}
+
+              {documents.map((document) => {
+                const isSelected = document.id === selectedDocumentId;
+                const pendingCount = pendingCountProxy(document);
+                return (
+                  <button
+                    key={document.id}
+                    className={`bs-card app-vault-item ${isSelected ? "is-selected" : ""}`}
+                    type="button"
+                    onClick={() => {
+                      setSelectedDocumentId(document.id);
+                      void loadDocumentDetail(document.id);
+                    }}
+                    aria-pressed={isSelected}
+                  >
+                    <div className="app-vault-item-head">
+                      <div>
+                        <h3>{document.title}</h3>
+                        <p className="app-doc-path">{document.path}</p>
+                      </div>
+                      <span className={`app-status-badge app-status-badge--${approvalTone(document.latestPendingVersionStatus)}`}>
+                        {formatPendingState(document.latestPendingVersionStatus)}
+                      </span>
+                    </div>
+
+                    <dl className="app-vault-item-grid">
+                      <div>
+                        <dt>Published</dt>
+                        <dd>{formatCommitSummary(document.currentPublishedVersion ?? document.publishedVersion ?? document.latestCommit)}</dd>
+                      </div>
+                      <div>
+                        <dt>Pending proxy</dt>
+                        <dd>{pendingCount > 0 ? `1 pending version` : "No pending versions"}</dd>
+                      </div>
+                      <div>
+                        <dt>Latest activity</dt>
+                        <dd>{formatTimestamp(document.lastActivityTimestamp || document.lastActivityAt)}</dd>
+                      </div>
+                    </dl>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="bs-card app-vault-detail-panel">
+            {detailError ? (
+              <div className="app-vault-detail-error">
+                <div className="bs-eyebrow">Detail State</div>
+                <h2>Could not load this document.</h2>
+                <p>{detailError}</p>
+              </div>
             ) : null}
-            {documents.map((doc) => (
-              <article className="bs-card app-doc-card" key={doc.path}>
-                <h3>{doc.title}</h3>
-                <p className="app-doc-path">{doc.path}</p>
-                <dl>
+
+            {!selectedDocument ? (
+              <div className="app-vault-detail-empty">
+                <div className="bs-eyebrow">Document Detail</div>
+                <h2>Select a file to inspect its review trail.</h2>
+                <p>
+                  The detail pane shows the published version, the latest pending review branch, and a short timeline.
+                </p>
+              </div>
+            ) : (
+              <>
+                <div className="app-vault-detail-head">
                   <div>
-                    <dt>Latest Commit</dt>
-                    <dd>{doc.latestCommit?.sha ? doc.latestCommit.sha.slice(0, 7) : "None"}</dd>
+                    <div className="bs-eyebrow">Document Detail</div>
+                    <h2>{selectedDocument.title}</h2>
+                    <p className="app-doc-path">{selectedDocument.path}</p>
                   </div>
-                  <div>
-                    <dt>Message</dt>
-                    <dd>{doc.latestCommit?.message ?? "No commit found"}</dd>
+                  <div className="app-vault-detail-meta">
+                    <span className={`app-status-badge app-status-badge--${approvalTone(selectedDocument.latestPendingVersionStatus)}`}>
+                      {formatPendingState(selectedDocument.latestPendingVersionStatus)}
+                    </span>
+                    <span className="app-vault-hero-meta">
+                      {pendingCountProxy(selectedDocument)} pending version proxy
+                    </span>
                   </div>
-                  <div>
-                    <dt>Author</dt>
-                    <dd>{doc.latestCommit?.author ?? "Unknown"}</dd>
-                  </div>
-                  <div>
-                    <dt>Timestamp</dt>
-                    <dd>{formatTimestamp(doc.latestCommit?.timestamp ?? "")}</dd>
-                  </div>
-                </dl>
-              </article>
-            ))}
-          </div>
+                </div>
+
+                <div className="app-vault-detail-stack">
+                  <article className="app-vault-detail-block">
+                    <div className="bs-eyebrow">Current Published Version</div>
+                    <h3>{formatCommitSummary(selectedDocument.currentPublishedVersion ?? selectedDocument.publishedVersion ?? selectedDocument.latestCommit)}</h3>
+                    <dl>
+                      <div>
+                        <dt>Author</dt>
+                        <dd>{selectedDocument.currentPublishedVersion?.author ?? selectedDocument.latestCommit?.author ?? "Unknown"}</dd>
+                      </div>
+                      <div>
+                        <dt>Timestamp</dt>
+                        <dd>{formatTimestamp(selectedDocument.currentPublishedVersion?.timestamp ?? selectedDocument.latestCommit?.timestamp ?? "")}</dd>
+                      </div>
+                    </dl>
+                  </article>
+
+                  <article className="app-vault-detail-block">
+                    <div className="bs-eyebrow">Latest Pending Review</div>
+                    {selectedDocument.latestPendingPullRequest ? (
+                      <>
+                        <h3>
+                          #{selectedDocument.latestPendingPullRequest.number} {selectedDocument.latestPendingPullRequest.title || "Review request"}
+                        </h3>
+                        <dl>
+                          <div>
+                            <dt>State</dt>
+                            <dd>{formatPendingState(selectedDocument.latestPendingPullRequest.state)}</dd>
+                          </div>
+                          <div>
+                            <dt>Branch</dt>
+                            <dd>{selectedDocument.latestPendingPullRequest.branch || "Unknown"}</dd>
+                          </div>
+                          <div>
+                            <dt>Updated</dt>
+                            <dd>{formatTimestamp(selectedDocument.latestPendingPullRequest.updatedAt)}</dd>
+                          </div>
+                        </dl>
+                        {selectedDocument.latestPendingPullRequest.htmlUrl ? (
+                          <a
+                            className="app-detail-link"
+                            href={selectedDocument.latestPendingPullRequest.htmlUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Open review request
+                          </a>
+                        ) : null}
+                      </>
+                    ) : (
+                      <p className="app-vault-block-empty">No pending review versions are open for this document.</p>
+                    )}
+                  </article>
+
+                  <article className="app-vault-detail-block">
+                    <div className="bs-eyebrow">Version Timeline</div>
+                    <ol className="app-vault-timeline">
+                      <li>
+                        <strong>Published record</strong>
+                        <span>{formatCommitSummary(selectedDocument.currentPublishedVersion ?? selectedDocument.publishedVersion ?? selectedDocument.latestCommit)}</span>
+                      </li>
+                      <li>
+                        <strong>Pending review</strong>
+                        <span>
+                          {selectedDocument.latestPendingPullRequest
+                            ? `#${selectedDocument.latestPendingPullRequest.number} ${formatPendingState(selectedDocument.latestPendingPullRequest.state)}`
+                            : "None open right now"}
+                        </span>
+                      </li>
+                      <li>
+                        <strong>Latest activity</strong>
+                        <span>{formatTimestamp(selectedDocument.lastActivityTimestamp || selectedDocument.lastActivityAt)}</span>
+                      </li>
+                    </ol>
+                  </article>
+                </div>
+
+                {detailLoading ? <div className="app-vault-detail-loading">Refreshing detail...</div> : null}
+              </>
+            )}
+          </section>
         </section>
       </main>
     </div>

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -347,6 +347,7 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
   const [error, setError] = useState<string | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
   const selectedDocumentIdRef = useRef<string | null>(null);
+  const detailRequestIdRef = useRef(0);
 
   const selectedDocument = useMemo(() => {
     if (detailDocument && detailDocument.id === selectedDocumentId) {
@@ -357,14 +358,22 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
   }, [detailDocument, documents, selectedDocumentId]);
 
   const loadDocumentDetail = useCallback(async (documentId: string) => {
+    const requestId = detailRequestIdRef.current + 1;
+    detailRequestIdRef.current = requestId;
     setDetailLoading(true);
     setDetailError(null);
 
     try {
       const payload = await fetchDocumentDetail(documentId);
+      if (detailRequestIdRef.current !== requestId || selectedDocumentIdRef.current !== documentId) {
+        return;
+      }
       setDetailDocument(payload.document);
       setRepository(payload.repository);
     } catch (loadError) {
+      if (detailRequestIdRef.current !== requestId || selectedDocumentIdRef.current !== documentId) {
+        return;
+      }
       const message =
         loadError instanceof Error
           ? loadError.message
@@ -372,7 +381,9 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
       setDetailError(message);
       setDetailDocument(null);
     } finally {
-      setDetailLoading(false);
+      if (detailRequestIdRef.current === requestId) {
+        setDetailLoading(false);
+      }
     }
   }, []);
 
@@ -391,11 +402,14 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
           ? selectedDocumentIdRef.current
           : payload.documents[0]?.id ?? null;
 
+      selectedDocumentIdRef.current = nextSelectedDocumentId;
       setSelectedDocumentId(nextSelectedDocumentId);
 
       if (nextSelectedDocumentId) {
         void loadDocumentDetail(nextSelectedDocumentId);
       } else {
+        detailRequestIdRef.current += 1;
+        setDetailLoading(false);
         setDetailDocument(null);
       }
     } catch (loadError) {
@@ -407,6 +421,8 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
       setError(message);
       setDocuments([]);
       setRepository("your workspace");
+      detailRequestIdRef.current += 1;
+      setDetailLoading(false);
       setSelectedDocumentId(null);
       setDetailDocument(null);
     } finally {
@@ -525,6 +541,7 @@ export function AppShell({ user, onSignOut }: AppShellProps) {
                     className={`bs-card app-vault-item ${isSelected ? "is-selected" : ""}`}
                     type="button"
                     onClick={() => {
+                      selectedDocumentIdRef.current = document.id;
                       setSelectedDocumentId(document.id);
                       void loadDocumentDetail(document.id);
                     }}


### PR DESCRIPTION
Implements issue #89 by reworking `/app` into a file-vault workflow with list + detail states driven by live catalog endpoints.

Workflow evidence:
- Issue read: `issue_read` (`get`) on #89
- Branch creation: `create_branch` for `codex/issue-89-file-vault-ui`
- Commit SHA(s):
  - `683229b` Rework app shell into file vault view
  - `8072a3a` Fix vault detail race and align tokenized card styles
- PR creation: `create_pull_request`
- Fallback used: none

What changed:
- Updated app shell UX to vault list/detail view (no inline editor dependency for core flow).
- List pane now shows published metadata, pending-review proxy/state, latest activity, and status badges.
- Detail pane fetches `/api/app/documents/:id` and displays current published metadata, latest pending review details, and a timeline summary.
- Added stale-request protection to prevent out-of-order detail fetch responses from overwriting active selection.
- Aligned updated vault card interactions/styles to tokenized system patterns.
- Updated app README for the new shell behavior.

Validation:
- `bun test apps/app packages/gitea-client` ✅
- `bun run build:app` ✅

Closes #89