### PR TITLE
Codex/new document upload flow

### DIFF
--- a/apps/app/App.test.ts
+++ b/apps/app/App.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+
+import { resolveGiteaTokenScopes } from "./giteaTokenScopes";
+
+test("resolveGiteaTokenScopes includes all required write scopes by default", () => {
+  expect(resolveGiteaTokenScopes()).toEqual([
+    "write:user",
+    "write:repository",
+    "write:issue",
+  ]);
+});
+
+test("resolveGiteaTokenScopes preserves configured scopes and adds missing required scopes", () => {
+  const scopes = resolveGiteaTokenScopes("read:user,write:repository");
+
+  expect(scopes).toContain("read:user");
+  expect(scopes).toContain("write:user");
+  expect(scopes).toContain("write:repository");
+  expect(scopes).toContain("write:issue");
+});
+
+test("resolveGiteaTokenScopes de-duplicates repeated scopes", () => {
+  const scopes = resolveGiteaTokenScopes(
+    "write:issue,write:user,write:repository,write:issue",
+  );
+
+  expect(scopes.filter((scope) => scope === "write:issue")).toHaveLength(1);
+  expect(scopes.filter((scope) => scope === "write:user")).toHaveLength(1);
+  expect(scopes.filter((scope) => scope === "write:repository")).toHaveLength(
+    1,
+  );
+});

--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -9,6 +9,7 @@ import {
 import "./app.css";
 
 import { AppShell } from "./components/AppShell";
+import { resolveGiteaTokenScopes } from "./giteaTokenScopes";
 import {
   clearToken,
   createAuthenticatedClient,
@@ -204,11 +205,8 @@ async function createGiteaSessionToken(
   const tokenScopesRaw =
     appEnv?.BUN_PUBLIC_GITEA_TOKEN_SCOPES ??
     appEnv?.VITE_GITEA_TOKEN_SCOPES ??
-    "write:repository,write:issue";
-  const tokenScopes = tokenScopesRaw
-    .split(",")
-    .map((scope) => scope.trim())
-    .filter((scope) => scope.length > 0);
+    "";
+  const tokenScopes = resolveGiteaTokenScopes(tokenScopesRaw);
   const credentials = btoa(`${username}:${password}`);
   const response = await fetch(
     `${baseUrl}/api/v1/users/${encodeURIComponent(username)}/tokens`,
@@ -221,7 +219,7 @@ async function createGiteaSessionToken(
       },
       body: JSON.stringify({
         name: tokenName,
-        scopes: tokenScopes.length > 0 ? tokenScopes : ["read:repository"],
+        scopes: tokenScopes,
       }),
     },
   );

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -714,25 +714,6 @@ input {
   outline-offset: 1px;
 }
 
-.create-document-preview {
-  display: grid;
-  gap: var(--brand-space-3);
-  padding: var(--brand-space-4);
-  background: var(--bs-surface-2);
-  border-radius: var(--brand-radius-lg);
-}
-
-.create-document-preview-label {
-  display: block;
-  margin-bottom: var(--brand-space-1);
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-label);
-  color: var(--bs-text-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--brand-tracking-wide);
-}
-
-.create-document-preview-value,
 .create-document-file-summary {
   margin: 0;
   color: var(--bs-text-secondary);

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -322,6 +322,13 @@ input {
   gap: var(--brand-space-3);
 }
 
+.vault-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--brand-space-4);
+}
+
 .vault-section h1 {
   margin: 0;
   font-family: var(--brand-font-serif);
@@ -477,6 +484,12 @@ input {
 .vault-error-state {
   padding: var(--brand-space-8);
   text-align: center;
+}
+
+.vault-empty-state-actions {
+  margin-top: var(--brand-space-5);
+  display: flex;
+  justify-content: center;
 }
 
 .vault-empty-state h2,
@@ -668,6 +681,66 @@ input {
   margin: 0;
   font-family: var(--font-serif);
   line-height: var(--brand-leading-tight);
+}
+
+.create-document-modal {
+  width: min(100%, 620px);
+}
+
+.create-document-form {
+  display: grid;
+  gap: var(--brand-space-4);
+}
+
+.create-document-field {
+  display: grid;
+  gap: var(--brand-space-2);
+}
+
+.create-document-input {
+  padding: var(--brand-space-3);
+  background: var(--bs-surface-1);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--brand-radius-md);
+  color: var(--bs-text-primary);
+  font-family: var(--brand-font-sans);
+  font-size: var(--brand-text-body);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.create-document-input:focus {
+  outline: 2px solid var(--color-coral);
+  outline-offset: 1px;
+}
+
+.create-document-preview {
+  display: grid;
+  gap: var(--brand-space-3);
+  padding: var(--brand-space-4);
+  background: var(--bs-surface-2);
+  border-radius: var(--brand-radius-lg);
+}
+
+.create-document-preview-label {
+  display: block;
+  margin-bottom: var(--brand-space-1);
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-label);
+  color: var(--bs-text-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--brand-tracking-wide);
+}
+
+.create-document-preview-value,
+.create-document-file-summary {
+  margin: 0;
+  color: var(--bs-text-secondary);
+  word-break: break-word;
+}
+
+.create-document-file-summary strong {
+  color: var(--bs-text-primary);
 }
 
 .upload-modal-actions {

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -84,6 +84,7 @@ export function AppShell({ user, giteaClient, onSignOut }: AppShellProps) {
         {view === "workspace" ? (
           <FileVaultWorkspace
             giteaClient={giteaClient}
+            currentUsername={user?.username ?? ""}
             onSelectDocument={handleSelectDocument}
           />
         ) : selectedDocument ? (

--- a/apps/app/components/CreateDocumentModal.tsx
+++ b/apps/app/components/CreateDocumentModal.tsx
@@ -1,0 +1,563 @@
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  GiteaApiError,
+  unwrap,
+  type GiteaClient,
+} from "../../../packages/gitea-client/client";
+import { createPullRequest } from "../../../packages/gitea-client/pullRequests";
+import {
+  buildUploadBranchName,
+  buildUploadCommitMessage,
+  commitBinaryFile,
+  computeFileHash,
+  createUploadBranch,
+  validateUploadFile,
+} from "../../../packages/gitea-client/uploads";
+
+interface CreateDocumentModalProps {
+  giteaClient: GiteaClient;
+  owner: string;
+  onClose: () => void;
+  onSuccess: (owner: string, repo: string) => void;
+}
+
+type CreateDocumentStatus =
+  | "idle"
+  | "checking-repo"
+  | "hashing"
+  | "creating-repo"
+  | "bootstrapping"
+  | "protecting"
+  | "creating-branch"
+  | "committing"
+  | "opening-pr"
+  | "done"
+  | "error";
+
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.split(",")[1] ?? "");
+    };
+    reader.onerror = () => {
+      reject(new Error("Failed to read file as base64."));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function stripExtension(fileName: string): string {
+  const cleanName = fileName.split(/[\\/]/).pop() ?? fileName;
+  const lastDot = cleanName.lastIndexOf(".");
+  if (lastDot <= 0) return cleanName;
+  return cleanName.slice(0, lastDot);
+}
+
+function getOriginalExtension(fileName: string): string {
+  const cleanName = fileName.split(/[\\/]/).pop() ?? fileName;
+  const lastDot = cleanName.lastIndexOf(".");
+  if (lastDot <= 0 || lastDot === cleanName.length - 1) return "";
+  return cleanName.slice(lastDot + 1).toLowerCase();
+}
+
+function makeFriendlyDocumentName(fileName: string): string {
+  return stripExtension(fileName)
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function slugifyRepoName(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function formatFileSize(bytes: number): string {
+  const mebibytes = bytes / (1024 * 1024);
+  if (mebibytes >= 1) {
+    return `${mebibytes.toFixed(2)} MiB`;
+  }
+  const kibibytes = bytes / 1024;
+  return `${kibibytes.toFixed(0)} KiB`;
+}
+
+async function repoExists(
+  client: GiteaClient,
+  owner: string,
+  repo: string,
+): Promise<boolean> {
+  try {
+    await unwrap(
+      client.GET("/repos/{owner}/{repo}", {
+        params: { path: { owner, repo } },
+      }),
+    );
+    return true;
+  } catch (err) {
+    if (err instanceof GiteaApiError && err.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+async function deleteReadmeIfPresent(
+  client: GiteaClient,
+  owner: string,
+  repo: string,
+): Promise<void> {
+  try {
+    const readme = await unwrap(
+      client.GET("/repos/{owner}/{repo}/contents/{filepath}", {
+        params: {
+          path: { owner, repo, filepath: "README.md" },
+          query: { ref: "main" },
+        },
+      }),
+    );
+
+    const sha =
+      !Array.isArray(readme) && typeof readme.sha === "string"
+        ? readme.sha
+        : "";
+
+    if (!sha) return;
+
+    await unwrap(
+      client.DELETE("/repos/{owner}/{repo}/contents/{filepath}", {
+        params: {
+          path: { owner, repo, filepath: "README.md" },
+        },
+        body: {
+          branch: "main",
+          message: "Bootstrap empty repository",
+          sha,
+        },
+      }),
+    );
+  } catch (err) {
+    if (err instanceof GiteaApiError && err.status === 404) {
+      return;
+    }
+    throw err;
+  }
+}
+
+async function createMainBranchProtection(
+  client: GiteaClient,
+  owner: string,
+  repo: string,
+): Promise<void> {
+  await unwrap(
+    client.POST("/repos/{owner}/{repo}/branch_protections", {
+      params: { path: { owner, repo } },
+      body: {
+        rule_name: "main",
+        required_approvals: 1,
+        block_on_official_review_requests: true,
+        block_on_outdated_branch: true,
+        block_on_rejected_reviews: true,
+        dismiss_stale_approvals: true,
+        enable_approvals_whitelist: false,
+        enable_merge_whitelist: false,
+        enable_push: false,
+      },
+    }),
+  );
+}
+
+export function CreateDocumentModal({
+  giteaClient,
+  owner,
+  onClose,
+  onSuccess,
+}: CreateDocumentModalProps) {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [documentName, setDocumentName] = useState("");
+  const [status, setStatus] = useState<CreateDocumentStatus>("idle");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const repoSlug = useMemo(() => slugifyRepoName(documentName), [documentName]);
+  const repoSlugValid = repoSlug.length > 0;
+  const originalExtension = selectedFile
+    ? getOriginalExtension(selectedFile.name)
+    : "";
+  const canonicalFileName = originalExtension
+    ? `document.${originalExtension}`
+    : "document";
+  const friendlyDocumentName = documentName.trim();
+  const displayDocumentName = titleCase(
+    (friendlyDocumentName || repoSlug.replace(/-/g, " ")).trim(),
+  );
+  const isBusy = status !== "idle" && status !== "error" && status !== "done";
+
+  useEffect(() => {
+    if (!selectedFile) return;
+    const nextName = makeFriendlyDocumentName(selectedFile.name);
+    setDocumentName(nextName);
+    setValidationError(null);
+    setError(null);
+  }, [selectedFile]);
+
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget && !isBusy) {
+      onClose();
+    }
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    if (!file) {
+      setSelectedFile(null);
+      setValidationError(null);
+      return;
+    }
+
+    const validation = validateUploadFile(file);
+    if (!validation.valid) {
+      setSelectedFile(null);
+      setValidationError(validation.reason ?? "Invalid file.");
+      return;
+    }
+
+    setSelectedFile(file);
+    setValidationError(null);
+    setError(null);
+  };
+
+  const handleCreateDocument = async () => {
+    if (!selectedFile) {
+      setValidationError("Choose a file before creating the document.");
+      return;
+    }
+
+    const trimmedName = documentName.trim();
+    if (!trimmedName) {
+      setValidationError("Enter a document name.");
+      return;
+    }
+
+    if (!repoSlugValid) {
+      setValidationError(
+        "The document name must produce a valid repository name.",
+      );
+      return;
+    }
+
+    if (!owner) {
+      setError("Missing repository owner. Sign in again and retry.");
+      setStatus("error");
+      return;
+    }
+
+    try {
+      setError(null);
+      setValidationError(null);
+      setStatus("checking-repo");
+
+      const exists = await repoExists(giteaClient, owner, repoSlug);
+      if (exists) {
+        setStatus("error");
+        setError(
+          `A document named "${trimmedName}" already exists. Choose a different name.`,
+        );
+        return;
+      }
+
+      setStatus("hashing");
+      const fileHashSha256 = await computeFileHash(selectedFile);
+      const contentHash8 = fileHashSha256.slice(0, 8);
+
+      const base64Content = await readFileAsBase64(selectedFile);
+
+      setStatus("creating-repo");
+      await unwrap(
+        giteaClient.POST("/user/repos", {
+          body: {
+            name: repoSlug,
+            private: true,
+            auto_init: true,
+            default_branch: "main",
+          },
+        }),
+      );
+
+      setStatus("bootstrapping");
+      await deleteReadmeIfPresent(giteaClient, owner, repoSlug);
+
+      setStatus("protecting");
+      await createMainBranchProtection(giteaClient, owner, repoSlug);
+
+      setStatus("creating-branch");
+      const branchName = buildUploadBranchName(repoSlug, owner, contentHash8);
+      await createUploadBranch({
+        client: giteaClient,
+        owner,
+        repo: repoSlug,
+        branchName,
+        from: "main",
+      });
+
+      setStatus("committing");
+      const commitMessage = buildUploadCommitMessage({
+        docSlug: repoSlug,
+        canonicalFile: canonicalFileName,
+        sourceFilename: selectedFile.name,
+        uploadBranch: branchName,
+        uploaderSlug: owner,
+        fileHashSha256,
+      });
+
+      await commitBinaryFile({
+        client: giteaClient,
+        owner,
+        repo: repoSlug,
+        branch: branchName,
+        filePath: canonicalFileName,
+        base64Content,
+        message: commitMessage,
+      });
+
+      setStatus("opening-pr");
+      const prTitle = `Upload v1: ${displayDocumentName}`;
+      const prBody = [
+        "Automated upload from Bindersnap file vault.",
+        "",
+        `Source file: ${selectedFile.name}`,
+        `Document: ${trimmedName}`,
+        `Uploaded by: ${owner}`,
+        `File hash (SHA-256): ${fileHashSha256}`,
+      ].join("\n");
+
+      await createPullRequest({
+        client: giteaClient,
+        owner,
+        repo: repoSlug,
+        title: prTitle,
+        head: branchName,
+        base: "main",
+        body: prBody,
+      });
+
+      setStatus("done");
+      onSuccess(owner, repoSlug);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Unable to create document.";
+      setStatus("error");
+      setError(message);
+    }
+  };
+
+  const canSubmit =
+    Boolean(selectedFile) &&
+    friendlyDocumentName.length > 0 &&
+    repoSlugValid &&
+    status !== "creating-repo" &&
+    status !== "bootstrapping" &&
+    status !== "protecting" &&
+    status !== "creating-branch" &&
+    status !== "committing" &&
+    status !== "opening-pr";
+
+  return (
+    <div className="upload-modal-backdrop" onClick={handleBackdropClick}>
+      <div
+        className="upload-modal create-document-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="bs-eyebrow">New Document</div>
+        <h2>Create workspace document</h2>
+
+        {status === "idle" || status === "error" || status === "done" ? (
+          <div className="create-document-form">
+            <label
+              htmlFor="create-document-file"
+              className="upload-file-input-label"
+            >
+              <span className="bs-eyebrow">Choose File</span>
+              <input
+                id="create-document-file"
+                type="file"
+                onChange={handleFileChange}
+                className="upload-file-input"
+              />
+            </label>
+
+            {selectedFile ? (
+              <p className="create-document-file-summary">
+                <strong>Selected:</strong> {selectedFile.name} (
+                {formatFileSize(selectedFile.size)})
+              </p>
+            ) : null}
+
+            <label
+              htmlFor="create-document-name"
+              className="create-document-field"
+            >
+              <span className="bs-eyebrow">Document Name</span>
+              <input
+                id="create-document-name"
+                className="create-document-input"
+                type="text"
+                value={documentName}
+                onChange={(event) => {
+                  setDocumentName(event.target.value);
+                  setError(null);
+                  setValidationError(null);
+                }}
+                placeholder="Quarterly Report"
+              />
+            </label>
+
+            <div className="create-document-preview">
+              <div>
+                <span className="create-document-preview-label">
+                  Repository Slug
+                </span>
+                <p className="create-document-preview-value">
+                  {repoSlugValid
+                    ? repoSlug
+                    : "Enter a name to generate the repo slug"}
+                </p>
+              </div>
+              <div>
+                <span className="create-document-preview-label">
+                  Canonical File
+                </span>
+                <p className="create-document-preview-value">
+                  {canonicalFileName}
+                </p>
+              </div>
+            </div>
+
+            {validationError ? (
+              <p className="upload-validation-error">{validationError}</p>
+            ) : null}
+
+            {error ? (
+              <p className="upload-error-message" role="alert">
+                {error}
+              </p>
+            ) : null}
+
+            <div className="upload-modal-actions">
+              <button
+                className="bs-btn bs-btn-primary"
+                type="button"
+                onClick={() => void handleCreateDocument()}
+                disabled={!canSubmit}
+              >
+                Create Document
+              </button>
+              <button
+                className="bs-btn bs-btn-secondary"
+                type="button"
+                onClick={onClose}
+                disabled={isBusy}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="upload-success-pr">
+            <p>Creating your workspace document...</p>
+            <ul className="upload-step-list">
+              <li
+                className={
+                  status === "checking-repo"
+                    ? "upload-step upload-step-active"
+                    : "upload-step"
+                }
+              >
+                Checking repository name...
+              </li>
+              <li
+                className={
+                  status === "hashing"
+                    ? "upload-step upload-step-active"
+                    : "upload-step"
+                }
+              >
+                Hashing file...
+              </li>
+              <li
+                className={
+                  status === "creating-repo"
+                    ? "upload-step upload-step-active"
+                    : "upload-step"
+                }
+              >
+                Creating private repository...
+              </li>
+              <li
+                className={
+                  status === "bootstrapping"
+                    ? "upload-step upload-step-active"
+                    : "upload-step"
+                }
+              >
+                Removing bootstrap README...
+              </li>
+              <li
+                className={
+                  status === "protecting"
+                    ? "upload-step upload-step-active"
+                    : "upload-step"
+                }
+              >
+                Protecting main branch...
+              </li>
+              <li
+                className={
+                  status === "creating-branch"
+                    ? "upload-step upload-step-active"
+                    : "upload-step"
+                }
+              >
+                Creating upload branch...
+              </li>
+              <li
+                className={
+                  status === "committing"
+                    ? "upload-step upload-step-active"
+                    : "upload-step"
+                }
+              >
+                Committing document...
+              </li>
+              <li
+                className={
+                  status === "opening-pr"
+                    ? "upload-step upload-step-active"
+                    : "upload-step"
+                }
+              >
+                Opening pull request...
+              </li>
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/components/CreateDocumentModal.tsx
+++ b/apps/app/components/CreateDocumentModal.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import {
-  buildCanonicalDocumentFileName,
   createInitialDocumentUpload,
-  getFileExtension,
   type InitialDocumentUploadStep,
   validateUploadFile,
 } from "../../../packages/gitea-client/uploads";
@@ -72,9 +70,6 @@ export function CreateDocumentModal({
 
   const repoSlug = useMemo(() => slugifyRepoName(documentName), [documentName]);
   const repoSlugValid = repoSlug.length > 0;
-  const canonicalFileName = selectedFile
-    ? buildCanonicalDocumentFileName(getFileExtension(selectedFile.name))
-    : "document";
   const friendlyDocumentName = documentName.trim();
   const isBusy = status !== "idle" && status !== "error" && status !== "done";
 
@@ -125,14 +120,12 @@ export function CreateDocumentModal({
     }
 
     if (!repoSlugValid) {
-      setValidationError(
-        "The document name must produce a valid repository name.",
-      );
+      setValidationError("Enter a document name with at least one letter or number.");
       return;
     }
 
     if (!owner) {
-      setError("Missing repository owner. Sign in again and retry.");
+      setError("Your session is missing account details. Sign in again and retry.");
       setStatus("error");
       return;
     }
@@ -230,27 +223,6 @@ export function CreateDocumentModal({
               />
             </label>
 
-            <div className="create-document-preview">
-              <div>
-                <span className="create-document-preview-label">
-                  Repository Slug
-                </span>
-                <p className="create-document-preview-value">
-                  {repoSlugValid
-                    ? repoSlug
-                    : "Enter a name to generate the repo slug"}
-                </p>
-              </div>
-              <div>
-                <span className="create-document-preview-label">
-                  Canonical File
-                </span>
-                <p className="create-document-preview-value">
-                  {canonicalFileName}
-                </p>
-              </div>
-            </div>
-
             {validationError ? (
               <p className="upload-validation-error">{validationError}</p>
             ) : null}
@@ -291,7 +263,7 @@ export function CreateDocumentModal({
                     : "upload-step"
                 }
               >
-                Checking repository name...
+                Checking document name...
               </li>
               <li
                 className={
@@ -309,7 +281,7 @@ export function CreateDocumentModal({
                     : "upload-step"
                 }
               >
-                Creating private repository...
+                Setting up your document...
               </li>
               <li
                 className={
@@ -318,7 +290,7 @@ export function CreateDocumentModal({
                     : "upload-step"
                 }
               >
-                Removing bootstrap README...
+                Preparing the first draft...
               </li>
               <li
                 className={
@@ -327,7 +299,7 @@ export function CreateDocumentModal({
                     : "upload-step"
                 }
               >
-                Protecting main branch...
+                Locking review rules...
               </li>
               <li
                 className={
@@ -336,7 +308,7 @@ export function CreateDocumentModal({
                     : "upload-step"
                 }
               >
-                Creating upload branch...
+                Creating the review draft...
               </li>
               <li
                 className={
@@ -354,7 +326,7 @@ export function CreateDocumentModal({
                     : "upload-step"
                 }
               >
-                Opening pull request...
+                Opening the first review...
               </li>
             </ul>
           </div>

--- a/apps/app/components/CreateDocumentModal.tsx
+++ b/apps/app/components/CreateDocumentModal.tsx
@@ -1,19 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
 
 import {
-  GiteaApiError,
-  unwrap,
-  type GiteaClient,
-} from "../../../packages/gitea-client/client";
-import { createPullRequest } from "../../../packages/gitea-client/pullRequests";
-import {
-  buildUploadBranchName,
-  buildUploadCommitMessage,
-  commitBinaryFile,
-  computeFileHash,
-  createUploadBranch,
+  buildCanonicalDocumentFileName,
+  createInitialDocumentUpload,
+  getFileExtension,
+  type InitialDocumentUploadStep,
   validateUploadFile,
 } from "../../../packages/gitea-client/uploads";
+import type { GiteaClient } from "../../../packages/gitea-client/client";
+import { repoExists } from "../../../packages/gitea-client/repos";
 
 interface CreateDocumentModalProps {
   giteaClient: GiteaClient;
@@ -25,42 +20,15 @@ interface CreateDocumentModalProps {
 type CreateDocumentStatus =
   | "idle"
   | "checking-repo"
-  | "hashing"
-  | "creating-repo"
-  | "bootstrapping"
-  | "protecting"
-  | "creating-branch"
-  | "committing"
-  | "opening-pr"
+  | InitialDocumentUploadStep
   | "done"
   | "error";
-
-function readFileAsBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result as string;
-      resolve(result.split(",")[1] ?? "");
-    };
-    reader.onerror = () => {
-      reject(new Error("Failed to read file as base64."));
-    };
-    reader.readAsDataURL(file);
-  });
-}
 
 function stripExtension(fileName: string): string {
   const cleanName = fileName.split(/[\\/]/).pop() ?? fileName;
   const lastDot = cleanName.lastIndexOf(".");
   if (lastDot <= 0) return cleanName;
   return cleanName.slice(0, lastDot);
-}
-
-function getOriginalExtension(fileName: string): string {
-  const cleanName = fileName.split(/[\\/]/).pop() ?? fileName;
-  const lastDot = cleanName.lastIndexOf(".");
-  if (lastDot <= 0 || lastDot === cleanName.length - 1) return "";
-  return cleanName.slice(lastDot + 1).toLowerCase();
 }
 
 function makeFriendlyDocumentName(fileName: string): string {
@@ -81,14 +49,6 @@ function slugifyRepoName(value: string): string {
     .replace(/-{2,}/g, "-");
 }
 
-function titleCase(value: string): string {
-  return value
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
-
 function formatFileSize(bytes: number): string {
   const mebibytes = bytes / (1024 * 1024);
   if (mebibytes >= 1) {
@@ -96,91 +56,6 @@ function formatFileSize(bytes: number): string {
   }
   const kibibytes = bytes / 1024;
   return `${kibibytes.toFixed(0)} KiB`;
-}
-
-async function repoExists(
-  client: GiteaClient,
-  owner: string,
-  repo: string,
-): Promise<boolean> {
-  try {
-    await unwrap(
-      client.GET("/repos/{owner}/{repo}", {
-        params: { path: { owner, repo } },
-      }),
-    );
-    return true;
-  } catch (err) {
-    if (err instanceof GiteaApiError && err.status === 404) {
-      return false;
-    }
-    throw err;
-  }
-}
-
-async function deleteReadmeIfPresent(
-  client: GiteaClient,
-  owner: string,
-  repo: string,
-): Promise<void> {
-  try {
-    const readme = await unwrap(
-      client.GET("/repos/{owner}/{repo}/contents/{filepath}", {
-        params: {
-          path: { owner, repo, filepath: "README.md" },
-          query: { ref: "main" },
-        },
-      }),
-    );
-
-    const sha =
-      !Array.isArray(readme) && typeof readme.sha === "string"
-        ? readme.sha
-        : "";
-
-    if (!sha) return;
-
-    await unwrap(
-      client.DELETE("/repos/{owner}/{repo}/contents/{filepath}", {
-        params: {
-          path: { owner, repo, filepath: "README.md" },
-        },
-        body: {
-          branch: "main",
-          message: "Bootstrap empty repository",
-          sha,
-        },
-      }),
-    );
-  } catch (err) {
-    if (err instanceof GiteaApiError && err.status === 404) {
-      return;
-    }
-    throw err;
-  }
-}
-
-async function createMainBranchProtection(
-  client: GiteaClient,
-  owner: string,
-  repo: string,
-): Promise<void> {
-  await unwrap(
-    client.POST("/repos/{owner}/{repo}/branch_protections", {
-      params: { path: { owner, repo } },
-      body: {
-        rule_name: "main",
-        required_approvals: 1,
-        block_on_official_review_requests: true,
-        block_on_outdated_branch: true,
-        block_on_rejected_reviews: true,
-        dismiss_stale_approvals: true,
-        enable_approvals_whitelist: false,
-        enable_merge_whitelist: false,
-        enable_push: false,
-      },
-    }),
-  );
 }
 
 export function CreateDocumentModal({
@@ -197,16 +72,10 @@ export function CreateDocumentModal({
 
   const repoSlug = useMemo(() => slugifyRepoName(documentName), [documentName]);
   const repoSlugValid = repoSlug.length > 0;
-  const originalExtension = selectedFile
-    ? getOriginalExtension(selectedFile.name)
-    : "";
-  const canonicalFileName = originalExtension
-    ? `document.${originalExtension}`
+  const canonicalFileName = selectedFile
+    ? buildCanonicalDocumentFileName(getFileExtension(selectedFile.name))
     : "document";
   const friendlyDocumentName = documentName.trim();
-  const displayDocumentName = titleCase(
-    (friendlyDocumentName || repoSlug.replace(/-/g, " ")).trim(),
-  );
   const isBusy = status !== "idle" && status !== "error" && status !== "done";
 
   useEffect(() => {
@@ -282,83 +151,16 @@ export function CreateDocumentModal({
         return;
       }
 
-      setStatus("hashing");
-      const fileHashSha256 = await computeFileHash(selectedFile);
-      const contentHash8 = fileHashSha256.slice(0, 8);
-
-      const base64Content = await readFileAsBase64(selectedFile);
-
-      setStatus("creating-repo");
-      await unwrap(
-        giteaClient.POST("/user/repos", {
-          body: {
-            name: repoSlug,
-            private: true,
-            auto_init: true,
-            default_branch: "main",
-          },
-        }),
-      );
-
-      setStatus("bootstrapping");
-      await deleteReadmeIfPresent(giteaClient, owner, repoSlug);
-
-      setStatus("protecting");
-      await createMainBranchProtection(giteaClient, owner, repoSlug);
-
-      setStatus("creating-branch");
-      const branchName = buildUploadBranchName(repoSlug, owner, contentHash8);
-      await createUploadBranch({
+      const result = await createInitialDocumentUpload({
         client: giteaClient,
-        owner,
-        repo: repoSlug,
-        branchName,
-        from: "main",
-      });
-
-      setStatus("committing");
-      const commitMessage = buildUploadCommitMessage({
-        docSlug: repoSlug,
-        canonicalFile: canonicalFileName,
-        sourceFilename: selectedFile.name,
-        uploadBranch: branchName,
+        repoName: repoSlug,
+        file: selectedFile,
         uploaderSlug: owner,
-        fileHashSha256,
+        nextVersion: 1,
+        onProgress: setStatus,
       });
-
-      await commitBinaryFile({
-        client: giteaClient,
-        owner,
-        repo: repoSlug,
-        branch: branchName,
-        filePath: canonicalFileName,
-        base64Content,
-        message: commitMessage,
-      });
-
-      setStatus("opening-pr");
-      const prTitle = `Upload v1: ${displayDocumentName}`;
-      const prBody = [
-        "Automated upload from Bindersnap file vault.",
-        "",
-        `Source file: ${selectedFile.name}`,
-        `Document: ${trimmedName}`,
-        `Uploaded by: ${owner}`,
-        `File hash (SHA-256): ${fileHashSha256}`,
-      ].join("\n");
-
-      await createPullRequest({
-        client: giteaClient,
-        owner,
-        repo: repoSlug,
-        title: prTitle,
-        head: branchName,
-        base: "main",
-        body: prBody,
-      });
-
       setStatus("done");
-      onSuccess(owner, repoSlug);
+      onSuccess(result.owner, result.repo);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Unable to create document.";

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -7,7 +7,8 @@ import type {
   RepoBranchProtection,
 } from "../../../packages/gitea-client/repos";
 import type { UploadResult } from "../../../packages/gitea-client/uploads";
-import { GiteaApiError } from "../../../packages/gitea-client/client";
+import { getStoredToken } from "../../../packages/gitea-client/auth";
+import { GiteaApiError, unwrap } from "../../../packages/gitea-client/client";
 import {
   listPullRequests,
   mergePullRequest,
@@ -33,6 +34,22 @@ interface PRActionState {
   error: string | null;
   changesComment: string;
   showChangesForm: boolean;
+}
+
+interface CanonicalFileInfo {
+  storedFileName: string;
+  downloadFileName: string;
+}
+
+interface RepoContentsEntry {
+  name?: string;
+  path?: string;
+  type?: string;
+}
+
+interface RepoContentsExtResponse {
+  dir_contents?: RepoContentsEntry[];
+  file_contents?: RepoContentsEntry;
 }
 
 function getApprovalStateBadgeClass(state: string): string {
@@ -98,6 +115,96 @@ function buildRawFileUrl(
   canonicalFile: string,
 ): string {
   return `${giteaBaseUrl}/${owner}/${repo}/raw/${ref}/${canonicalFile}`;
+}
+
+function triggerBrowserDownload(blob: Blob, fileName: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = fileName;
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(objectUrl);
+}
+
+function extractFileExtension(fileName: string): string | null {
+  const trimmed = fileName.trim();
+  const lastDotIndex = trimmed.lastIndexOf(".");
+
+  if (lastDotIndex <= 0 || lastDotIndex === trimmed.length - 1) {
+    return null;
+  }
+
+  return trimmed.slice(lastDotIndex + 1);
+}
+
+function buildDownloadFileName(repo: string, storedFileName: string): string {
+  const extension = extractFileExtension(storedFileName);
+  return extension ? `${repo}.${extension}` : repo;
+}
+
+function inferStoredDocumentFileName(
+  entries: RepoContentsEntry[],
+  repo: string,
+): string | null {
+  const files = entries.filter(
+    (entry): entry is RepoContentsEntry & { name: string } =>
+      entry.type === "file" && typeof entry.name === "string",
+  );
+
+  const documentFile = files.find(
+    (entry) => entry.name === "document" || entry.name.startsWith("document."),
+  );
+  if (documentFile) {
+    return documentFile.name;
+  }
+
+  const legacyFile = files.find(
+    (entry) => entry.name === repo || entry.name.startsWith(`${repo}.`),
+  );
+  if (legacyFile) {
+    return legacyFile.name;
+  }
+
+  if (files.length === 1) {
+    return files[0]?.name ?? null;
+  }
+
+  return null;
+}
+
+async function resolveCanonicalFileInfo(
+  giteaClient: GiteaClient,
+  owner: string,
+  repo: string,
+  ref = "main",
+): Promise<CanonicalFileInfo | null> {
+  const result = await unwrap(
+    giteaClient.GET("/repos/{owner}/{repo}/contents-ext/{filepath}", {
+      params: {
+        path: { owner, repo, filepath: "." },
+        query: { ref },
+      },
+    }),
+  );
+
+  const response = result as RepoContentsExtResponse;
+  const entries = [
+    ...(response.dir_contents ?? []),
+    ...(response.file_contents ? [response.file_contents] : []),
+  ];
+  const storedFileName = inferStoredDocumentFileName(entries, repo);
+
+  if (!storedFileName) {
+    return null;
+  }
+
+  return {
+    storedFileName,
+    downloadFileName: buildDownloadFileName(repo, storedFileName),
+  };
 }
 
 function readPermissionError(err: unknown, fallback: string): string {
@@ -166,9 +273,15 @@ export function DocumentDetail({
   const [openPRs, setOpenPRs] = useState<PullRequestWithApprovalState[]>([]);
   const [branchProtection, setBranchProtection] =
     useState<RepoBranchProtection | null>(null);
+  const [canonicalFileInfo, setCanonicalFileInfo] =
+    useState<CanonicalFileInfo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showUploadModal, setShowUploadModal] = useState(false);
+  const [downloadState, setDownloadState] = useState<{
+    ref: string | null;
+    error: string | null;
+  }>({ ref: null, error: null });
   const [prActionStates, setPrActionStates] = useState<
     Record<number, PRActionState>
   >({});
@@ -195,15 +308,39 @@ export function DocumentDetail({
         ),
       ]);
 
+      const uploadPRs = pullRequests
+        .filter((pr) => (pr.head?.ref ?? "").startsWith("upload/"))
+        .sort((left, right) => (right.number ?? 0) - (left.number ?? 0));
+
+      let fileInfo =
+        (await resolveCanonicalFileInfo(giteaClient, owner, repo).catch(
+          () => null,
+        )) ?? null;
+
+      if (!fileInfo) {
+        const fallbackRef = uploadPRs[0]?.head?.ref;
+        if (fallbackRef) {
+          fileInfo =
+            (await resolveCanonicalFileInfo(
+              giteaClient,
+              owner,
+              repo,
+              fallbackRef,
+            ).catch(() => null)) ?? null;
+        }
+      }
+
       setTags(docTags);
       setOpenPRs(pullRequests);
       setBranchProtection(protection);
+      setCanonicalFileInfo(fileInfo);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Unable to load document details.";
       setError(message);
       setTags([]);
       setOpenPRs([]);
+      setCanonicalFileInfo(null);
     } finally {
       setIsLoading(false);
     }
@@ -214,7 +351,6 @@ export function DocumentDetail({
   }, [loadDocumentData]);
 
   const latestTag = tags.length > 0 ? tags[0] : null;
-  const canonicalFileName = `${repo}.pdf`;
   const nextVersion = (latestTag?.version ?? 0) + 1;
 
   function getPRActionState(pullNumber: number): PRActionState {
@@ -314,6 +450,58 @@ export function DocumentDetail({
     }
   }
 
+  async function handleDownload(ref: string) {
+    if (!canonicalFileInfo) {
+      setDownloadState({
+        ref: null,
+        error: "Unable to determine which file to download for this document.",
+      });
+      return;
+    }
+
+    const token = getStoredToken();
+    if (!token) {
+      setDownloadState({
+        ref: null,
+        error: "Your Gitea session expired. Sign in again to download files.",
+      });
+      return;
+    }
+
+    setDownloadState({ ref, error: null });
+
+    try {
+      const response = await fetch(
+        buildRawFileUrl(
+          giteaBaseUrl,
+          owner,
+          repo,
+          ref,
+          canonicalFileInfo.storedFileName,
+        ),
+        {
+          headers: {
+            Authorization: `token ${token}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`Download failed (${response.status}).`);
+      }
+
+      const blob = await response.blob();
+      triggerBrowserDownload(blob, canonicalFileInfo.downloadFileName);
+      setDownloadState({ ref: null, error: null });
+    } catch (err) {
+      setDownloadState({
+        ref: null,
+        error:
+          err instanceof Error ? err.message : "Unable to download document.",
+      });
+    }
+  }
+
   const handleUploadSuccess = (_result: UploadResult) => {
     setShowUploadModal(false);
     void loadDocumentData();
@@ -393,21 +581,25 @@ export function DocumentDetail({
               Published on {formatTimestamp(latestTag.created)} (tag:{" "}
               <code>{latestTag.name}</code>)
             </p>
-            <a
-              className="bs-btn bs-btn-secondary"
-              href={buildRawFileUrl(
-                giteaBaseUrl,
-                owner,
-                repo,
-                "main",
-                canonicalFileName,
-              )}
-              download
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Download Current Version
-            </a>
+            {canonicalFileInfo ? (
+              <button
+                className="bs-btn bs-btn-secondary"
+                type="button"
+                disabled={downloadState.ref === "main"}
+                onClick={() => void handleDownload("main")}
+              >
+                {downloadState.ref === "main"
+                  ? "Downloading…"
+                  : "Download Current Version"}
+              </button>
+            ) : (
+              <p>Unable to determine the document file for this repository.</p>
+            )}
+            {downloadState.error ? (
+              <p className="vault-pr-error" role="alert">
+                {downloadState.error}
+              </p>
+            ) : null}
           </>
         ) : (
           <p>
@@ -583,21 +775,20 @@ export function DocumentDetail({
                 <p className="vault-version-sha">
                   Commit: <code>{tag.sha.slice(0, 7)}</code>
                 </p>
-                <a
-                  className="bs-btn bs-btn-secondary vault-version-download"
-                  href={buildRawFileUrl(
-                    giteaBaseUrl,
-                    owner,
-                    repo,
-                    tag.name,
-                    canonicalFileName,
-                  )}
-                  download
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Download v{tag.version}
-                </a>
+                {canonicalFileInfo ? (
+                  <button
+                    className="bs-btn bs-btn-secondary vault-version-download"
+                    type="button"
+                    disabled={downloadState.ref === tag.name}
+                    onClick={() => void handleDownload(tag.name)}
+                  >
+                    {downloadState.ref === tag.name
+                      ? "Downloading…"
+                      : `Download v${tag.version}`}
+                  </button>
+                ) : (
+                  <p>No document file is available for this version.</p>
+                )}
               </div>
             ))}
           </div>
@@ -614,6 +805,7 @@ export function DocumentDetail({
           docSlug={repo}
           uploaderSlug={uploaderSlug}
           nextVersion={nextVersion}
+          canonicalFileName={canonicalFileInfo?.storedFileName ?? null}
           onClose={() => setShowUploadModal(false)}
           onSuccess={handleUploadSuccess}
         />

--- a/apps/app/components/FileVaultWorkspace.tsx
+++ b/apps/app/components/FileVaultWorkspace.tsx
@@ -11,9 +11,11 @@ import {
   getLatestDocTag,
   listWorkspaceRepos,
 } from "../../../packages/gitea-client/repos";
+import { CreateDocumentModal } from "./CreateDocumentModal";
 
 interface FileVaultWorkspaceProps {
   giteaClient: GiteaClient;
+  currentUsername: string;
   onSelectDocument: (owner: string, repo: string) => void;
 }
 
@@ -87,6 +89,7 @@ function getApprovalStateLabel(state: string): string {
 
 export function FileVaultWorkspace({
   giteaClient,
+  currentUsername,
   onSelectDocument,
 }: FileVaultWorkspaceProps) {
   const [repos, setRepos] = useState<WorkspaceRepo[]>([]);
@@ -95,6 +98,7 @@ export function FileVaultWorkspace({
   );
   const [isLoadingRepos, setIsLoadingRepos] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showCreateDocumentModal, setShowCreateDocumentModal] = useState(false);
 
   const loadRepos = useCallback(async () => {
     setIsLoadingRepos(true);
@@ -233,7 +237,29 @@ export function FileVaultWorkspace({
             Your workspace is empty. Create a repository in Gitea to get
             started.
           </p>
+          <div className="vault-empty-state-actions">
+            <button
+              className="bs-btn bs-btn-primary"
+              type="button"
+              onClick={() => setShowCreateDocumentModal(true)}
+            >
+              New Document
+            </button>
+          </div>
         </div>
+
+        {showCreateDocumentModal ? (
+          <CreateDocumentModal
+            giteaClient={giteaClient}
+            owner={currentUsername}
+            onClose={() => setShowCreateDocumentModal(false)}
+            onSuccess={(owner, repo) => {
+              setShowCreateDocumentModal(false);
+              void loadRepos();
+              onSelectDocument(owner, repo);
+            }}
+          />
+        ) : null}
       </div>
     );
   }
@@ -241,8 +267,19 @@ export function FileVaultWorkspace({
   return (
     <div className="vault-workspace">
       <section className="vault-section">
-        <div className="bs-eyebrow">File Vault</div>
-        <h1>Your Documents</h1>
+        <div className="vault-section-header">
+          <div>
+            <div className="bs-eyebrow">File Vault</div>
+            <h1>Your Documents</h1>
+          </div>
+          <button
+            className="bs-btn bs-btn-primary"
+            type="button"
+            onClick={() => setShowCreateDocumentModal(true)}
+          >
+            New Document
+          </button>
+        </div>
         <p>
           All documents are stored as Gitea repositories. Each card shows the
           current published version and any pending reviews.
@@ -316,6 +353,19 @@ export function FileVaultWorkspace({
           );
         })}
       </div>
+
+      {showCreateDocumentModal ? (
+        <CreateDocumentModal
+          giteaClient={giteaClient}
+          owner={currentUsername}
+          onClose={() => setShowCreateDocumentModal(false)}
+          onSuccess={(owner, repo) => {
+            setShowCreateDocumentModal(false);
+            void loadRepos();
+            onSelectDocument(owner, repo);
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/app/components/FileVaultWorkspace.tsx
+++ b/apps/app/components/FileVaultWorkspace.tsx
@@ -202,7 +202,7 @@ export function FileVaultWorkspace({
         <div className="bs-card vault-empty-state">
           <div className="bs-eyebrow">Loading</div>
           <h2>Loading workspace repositories...</h2>
-          <p>Fetching your document repositories from Gitea.</p>
+          <p>Fetching your documents.</p>
         </div>
       </div>
     );
@@ -233,10 +233,7 @@ export function FileVaultWorkspace({
         <div className="bs-card vault-empty-state">
           <div className="bs-eyebrow">Empty Workspace</div>
           <h2>No documents found</h2>
-          <p>
-            Your workspace is empty. Create a repository in Gitea to get
-            started.
-          </p>
+          <p>Your workspace is empty. Create your first document to get started.</p>
           <div className="vault-empty-state-actions">
             <button
               className="bs-btn bs-btn-primary"
@@ -281,8 +278,7 @@ export function FileVaultWorkspace({
           </button>
         </div>
         <p>
-          All documents are stored as Gitea repositories. Each card shows the
-          current published version and any pending reviews.
+          Each card shows the current published version and any pending reviews.
         </p>
       </section>
 

--- a/apps/app/components/UploadModal.tsx
+++ b/apps/app/components/UploadModal.tsx
@@ -19,6 +19,7 @@ interface UploadModalProps {
   docSlug: string;
   uploaderSlug: string;
   nextVersion: number;
+  canonicalFileName?: string | null;
   onClose: () => void;
   onSuccess: (result: UploadResult) => void;
 }
@@ -54,6 +55,7 @@ export function UploadModal({
   docSlug,
   uploaderSlug,
   nextVersion,
+  canonicalFileName,
   onClose,
   onSuccess,
 }: UploadModalProps) {
@@ -118,8 +120,10 @@ export function UploadModal({
 
       // Step 4: Commit file
       setStatus("committing");
-      const ext = selectedFile.name.split(".").pop()!.toLowerCase();
-      const canonicalFile = `${docSlug}.${ext}`;
+      const canonicalFile =
+        canonicalFileName && canonicalFileName.trim() !== ""
+          ? canonicalFileName
+          : `${docSlug}.${selectedFile.name.split(".").pop()!.toLowerCase()}`;
 
       const commitMessage = buildUploadCommitMessage({
         docSlug,

--- a/apps/app/giteaTokenScopes.ts
+++ b/apps/app/giteaTokenScopes.ts
@@ -1,0 +1,19 @@
+const REQUIRED_GITEA_TOKEN_SCOPES = [
+  "write:user",
+  "write:repository",
+  "write:issue",
+] as const;
+
+export function resolveGiteaTokenScopes(scopesRaw?: string): string[] {
+  const configuredScopes = (scopesRaw ?? "")
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+
+  const mergedScopes = new Set<string>([
+    ...configuredScopes,
+    ...REQUIRED_GITEA_TOKEN_SCOPES,
+  ]);
+
+  return Array.from(mergedScopes);
+}

--- a/packages/gitea-client/repos.test.ts
+++ b/packages/gitea-client/repos.test.ts
@@ -12,6 +12,7 @@ type Tag = Partial<components["schemas"]["Tag"]>;
 function createMockClient(handlers: {
   GET?: Record<string, (...args: any[]) => unknown>;
   POST?: Record<string, (...args: any[]) => unknown>;
+  DELETE?: Record<string, (...args: any[]) => unknown>;
 }) {
   const mockGet = mock(async (path: string, init?: unknown) => {
     const handler = handlers.GET?.[path];
@@ -47,16 +48,34 @@ function createMockClient(handlers: {
     };
   });
 
+  const mockDelete = mock(async (path: string, init?: { params?: unknown; body?: unknown }) => {
+    const handler = handlers.DELETE?.[path];
+    if (handler) {
+      const data = await handler(init);
+      return {
+        data,
+        error: undefined,
+        response: new Response(null, { status: 200 }),
+      };
+    }
+    return {
+      data: undefined,
+      error: { message: "not found" },
+      response: new Response(null, { status: 404 }),
+    };
+  });
+
   return {
     client: {
       GET: mockGet,
       POST: mockPost,
+      DELETE: mockDelete,
       PUT: mock(),
-      DELETE: mock(),
       use: mock(),
     } as unknown as GiteaClient,
     mockGet,
     mockPost,
+    mockDelete,
   };
 }
 
@@ -104,6 +123,131 @@ test("listWorkspaceRepos handles empty response", async () => {
   const result = await listWorkspaceRepos(client);
 
   expect(result).toHaveLength(0);
+});
+
+test("createPrivateCurrentUserRepo creates a private initialized repo on main", async () => {
+  const { client, mockPost } = createMockClient({
+    POST: {
+      "/user/repos": (init: { body?: { name?: string; private?: boolean; auto_init?: boolean; default_branch?: string } }) => ({
+        id: 42,
+        name: init?.body?.name,
+        full_name: `alice/${init?.body?.name ?? ""}`,
+        owner: { login: "alice" },
+      }),
+    },
+  });
+
+  const { createPrivateCurrentUserRepo } = await import("./repos");
+  const repo = await createPrivateCurrentUserRepo({
+    client,
+    name: "quarterly-report",
+    description: "Q2 report",
+  });
+
+  expect(mockPost).toHaveBeenCalled();
+  expect(repo.name).toBe("quarterly-report");
+  expect(repo.owner?.login).toBe("alice");
+
+  const calls = mockPost.mock.calls as Array<[string, { body?: { name?: string; private?: boolean; auto_init?: boolean; default_branch?: string; description?: string } }]>;
+  expect(calls[0]?.[1]?.body).toMatchObject({
+    name: "quarterly-report",
+    description: "Q2 report",
+    private: true,
+    auto_init: true,
+    default_branch: "main",
+  });
+});
+
+test("repoExists returns false for missing repos and true for existing repos", async () => {
+  const { client } = createMockClient({
+    GET: {
+      "/repos/{owner}/{repo}": () => ({
+        id: 7,
+        name: "quarterly-report",
+        full_name: "alice/quarterly-report",
+        owner: { login: "alice" },
+      }),
+    },
+  });
+
+  const missingClient = createMockClient({});
+
+  const { repoExists } = await import("./repos");
+  await expect(repoExists(client, "alice", "quarterly-report")).resolves.toBe(true);
+  await expect(repoExists(missingClient.client, "alice", "missing")).resolves.toBe(false);
+});
+
+test("createMainBranchProtection creates a main rule with required approvals", async () => {
+  const { client, mockPost } = createMockClient({
+    POST: {
+      "/repos/{owner}/{repo}/branch_protections": (init: { body?: { rule_name?: string; required_approvals?: number } }) => ({
+        rule_name: init?.body?.rule_name,
+        required_approvals: init?.body?.required_approvals,
+      }),
+    },
+  });
+
+  const { createMainBranchProtection } = await import("./repos");
+  const protection = await createMainBranchProtection({
+    client,
+    owner: "alice",
+    repo: "quarterly-report",
+    requiredApprovals: 2,
+  });
+
+  expect(mockPost).toHaveBeenCalled();
+  expect(protection.requiredApprovals).toBe(2);
+
+  const calls = mockPost.mock.calls as Array<[string, { body?: { rule_name?: string; required_approvals?: number; enable_approvals_whitelist?: boolean; enable_merge_whitelist?: boolean; block_on_rejected_reviews?: boolean } }]>;
+  expect(calls[0]?.[1]?.body).toMatchObject({
+    rule_name: "main",
+    required_approvals: 2,
+    enable_approvals_whitelist: false,
+    enable_merge_whitelist: false,
+    block_on_rejected_reviews: true,
+  });
+});
+
+test("bootstrapEmptyMainBranch deletes README.md from main when present", async () => {
+  const { client, mockDelete } = createMockClient({
+    GET: {
+      "/repos/{owner}/{repo}/contents/{filepath}": () => ({
+        sha: "readme-sha",
+        type: "file",
+      }),
+    },
+    DELETE: {
+      "/repos/{owner}/{repo}/contents/{filepath}": () => ({}),
+    },
+  });
+
+  const { bootstrapEmptyMainBranch } = await import("./repos");
+  await bootstrapEmptyMainBranch({
+    client,
+    owner: "alice",
+    repo: "quarterly-report",
+  });
+
+  expect(mockDelete).toHaveBeenCalled();
+  const calls = mockDelete.mock.calls as Array<[string, { body?: { branch?: string; sha?: string; message?: string } }]>;
+  expect(calls[0]?.[1]?.body).toMatchObject({
+    branch: "main",
+    sha: "readme-sha",
+    message: "Bootstrap empty main branch",
+  });
+});
+
+test("bootstrapEmptyMainBranch is a no-op when README.md is missing", async () => {
+  const { client, mockDelete } = createMockClient({});
+
+  const { bootstrapEmptyMainBranch } = await import("./repos");
+  await bootstrapEmptyMainBranch({
+    client,
+    owner: "alice",
+    repo: "quarterly-report",
+  });
+
+  expect(mockDelete).not.toHaveBeenCalled();
 });
 
 test("getLatestDocTag returns the highest version tag", async () => {

--- a/packages/gitea-client/repos.ts
+++ b/packages/gitea-client/repos.ts
@@ -152,12 +152,7 @@ function normalizeBranchProtection(
 export async function createMainBranchProtection(
   params: CreateMainBranchProtectionParams,
 ): Promise<RepoBranchProtection> {
-  const {
-    client,
-    owner,
-    repo,
-    requiredApprovals = 1,
-  } = params;
+  const { client, owner, repo, requiredApprovals = 0 } = params;
 
   const protection = await unwrap(
     client.POST("/repos/{owner}/{repo}/branch_protections", {

--- a/packages/gitea-client/repos.ts
+++ b/packages/gitea-client/repos.ts
@@ -4,6 +4,13 @@ import { GiteaApiError, unwrap, type GiteaClient } from "./client";
 
 type Repository = components["schemas"]["Repository"];
 type Tag = components["schemas"]["Tag"];
+type BranchProtection = components["schemas"]["BranchProtection"];
+type CreateBranchProtectionOption =
+  components["schemas"]["CreateBranchProtectionOption"];
+type RepoFileContent = {
+  sha?: string;
+  type?: string;
+};
 
 export interface WorkspaceRepo {
   id: number;
@@ -19,6 +26,25 @@ export interface DocTag {
   version: number;
   sha: string;
   created: string;
+}
+
+export interface CreatePrivateCurrentUserRepoParams {
+  client: GiteaClient;
+  name: string;
+  description?: string;
+}
+
+export interface CreateMainBranchProtectionParams {
+  client: GiteaClient;
+  owner: string;
+  repo: string;
+  requiredApprovals?: number;
+}
+
+export interface BootstrapEmptyMainBranchParams {
+  client: GiteaClient;
+  owner: string;
+  repo: string;
 }
 
 function normalizeWorkspaceRepo(repo: Repository): WorkspaceRepo {
@@ -70,6 +96,128 @@ export async function listWorkspaceRepos(
   );
 
   return result.data?.map(normalizeWorkspaceRepo) ?? [];
+}
+
+export async function createPrivateCurrentUserRepo(
+  params: CreatePrivateCurrentUserRepoParams,
+): Promise<Repository> {
+  const { client, name, description } = params;
+
+  return await unwrap(
+    client.POST("/user/repos", {
+      body: {
+        name,
+        description,
+        private: true,
+        auto_init: true,
+        default_branch: "main",
+      },
+    }),
+  );
+}
+
+export async function repoExists(
+  client: GiteaClient,
+  owner: string,
+  repo: string,
+): Promise<boolean> {
+  try {
+    await unwrap(
+      client.GET("/repos/{owner}/{repo}", {
+        params: { path: { owner, repo } },
+      }),
+    );
+    return true;
+  } catch (err) {
+    if (err instanceof GiteaApiError && err.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+function normalizeBranchProtection(
+  raw: BranchProtection,
+): RepoBranchProtection {
+  return {
+    requiredApprovals: raw.required_approvals ?? 0,
+    enableApprovalsWhitelist: raw.enable_approvals_whitelist ?? false,
+    approvalsWhitelistUsernames: raw.approvals_whitelist_username ?? [],
+    enableMergeWhitelist: raw.enable_merge_whitelist ?? false,
+    mergeWhitelistUsernames: raw.merge_whitelist_usernames ?? [],
+    blockOnRejectedReviews: raw.block_on_rejected_reviews ?? false,
+  };
+}
+
+export async function createMainBranchProtection(
+  params: CreateMainBranchProtectionParams,
+): Promise<RepoBranchProtection> {
+  const {
+    client,
+    owner,
+    repo,
+    requiredApprovals = 1,
+  } = params;
+
+  const protection = await unwrap(
+    client.POST("/repos/{owner}/{repo}/branch_protections", {
+      params: { path: { owner, repo } },
+      body: {
+        rule_name: "main",
+        required_approvals: requiredApprovals,
+        enable_approvals_whitelist: false,
+        enable_merge_whitelist: false,
+        block_on_rejected_reviews: true,
+        block_on_outdated_branch: true,
+        dismiss_stale_approvals: true,
+        enable_force_push: false,
+        enable_push: false,
+      } satisfies CreateBranchProtectionOption,
+    }),
+  );
+
+  return normalizeBranchProtection(protection);
+}
+
+export async function bootstrapEmptyMainBranch(
+  params: BootstrapEmptyMainBranchParams,
+): Promise<void> {
+  const { client, owner, repo } = params;
+
+  let readme: RepoFileContent | RepoFileContent[] | null = null;
+
+  try {
+    readme = await unwrap(
+      client.GET("/repos/{owner}/{repo}/contents/{filepath}", {
+        params: {
+          path: { owner, repo, filepath: "README.md" },
+          query: { ref: "main" },
+        },
+      }),
+    );
+  } catch (err) {
+    if (err instanceof GiteaApiError && err.status === 404) {
+      return;
+    }
+    throw err;
+  }
+
+  if (Array.isArray(readme) || typeof readme?.sha !== "string") {
+    return;
+  }
+
+  await unwrap(
+    client.DELETE("/repos/{owner}/{repo}/contents/{filepath}", {
+      params: {
+        path: { owner, repo, filepath: "README.md" },
+      },
+      body: {
+        branch: "main",
+        sha: readme.sha,
+        message: "Bootstrap empty main branch",
+      },
+    }),
+  );
 }
 
 export async function getLatestDocTag(
@@ -127,19 +275,6 @@ export interface RepoBranchProtection {
   enableMergeWhitelist: boolean;
   mergeWhitelistUsernames: string[];
   blockOnRejectedReviews: boolean;
-}
-
-function normalizeBranchProtection(
-  raw: components["schemas"]["BranchProtection"],
-): RepoBranchProtection {
-  return {
-    requiredApprovals: raw.required_approvals ?? 0,
-    enableApprovalsWhitelist: raw.enable_approvals_whitelist ?? false,
-    approvalsWhitelistUsernames: raw.approvals_whitelist_username ?? [],
-    enableMergeWhitelist: raw.enable_merge_whitelist ?? false,
-    mergeWhitelistUsernames: raw.merge_whitelist_usernames ?? [],
-    blockOnRejectedReviews: raw.block_on_rejected_reviews ?? false,
-  };
 }
 
 export async function getRepoBranchProtection(

--- a/packages/gitea-client/uploads.test.ts
+++ b/packages/gitea-client/uploads.test.ts
@@ -1,9 +1,83 @@
-import { describe, expect, test } from "bun:test";
+import { expect, mock, test } from "bun:test";
 import {
+  buildCanonicalDocumentFileName,
   buildUploadBranchName,
   buildUploadCommitMessage,
+  createInitialDocumentUpload,
+  getFileExtension,
   validateUploadFile,
 } from "./uploads";
+import type { GiteaClient } from "./client";
+
+function createMockClient(handlers: {
+  GET?: Record<string, (...args: any[]) => unknown>;
+  POST?: Record<string, (...args: any[]) => unknown>;
+  DELETE?: Record<string, (...args: any[]) => unknown>;
+}) {
+  const mockGet = mock(async (path: string, init?: unknown) => {
+    const handler = handlers.GET?.[path];
+    if (handler) {
+      const data = await handler(init);
+      return {
+        data,
+        error: undefined,
+        response: new Response(null, { status: 200 }),
+      };
+    }
+    return {
+      data: undefined,
+      error: { message: "not found" },
+      response: new Response(null, { status: 404 }),
+    };
+  });
+
+  const mockPost = mock(async (path: string, init?: { params?: unknown; body?: unknown }) => {
+    const handler = handlers.POST?.[path];
+    if (handler) {
+      const data = await handler(init);
+      return {
+        data,
+        error: undefined,
+        response: new Response(null, { status: 200 }),
+      };
+    }
+    return {
+      data: undefined,
+      error: { message: "not found" },
+      response: new Response(null, { status: 404 }),
+    };
+  });
+
+  const mockDelete = mock(async (path: string, init?: { params?: unknown; body?: unknown }) => {
+    const handler = handlers.DELETE?.[path];
+    if (handler) {
+      const data = await handler(init);
+      return {
+        data,
+        error: undefined,
+        response: new Response(null, { status: 200 }),
+      };
+    }
+    return {
+      data: undefined,
+      error: { message: "not found" },
+      response: new Response(null, { status: 404 }),
+    };
+  });
+
+  return {
+    client: {
+      GET: mockGet,
+      POST: mockPost,
+      DELETE: mockDelete,
+      PUT: mock(),
+      use: mock(),
+    } as unknown as GiteaClient,
+    mockGet,
+    mockPost,
+    mockDelete,
+  };
+}
 
 // ────────────────────────────────────────────────────────────────
 // validateUploadFile tests
@@ -64,6 +138,26 @@ test("validateUploadFile accepts files exactly at 25 MiB limit", () => {
     type: "application/pdf",
   });
   expect(validateUploadFile(file).valid).toBe(true);
+});
+
+// ────────────────────────────────────────────────────────────────
+// filename utility tests
+// ────────────────────────────────────────────────────────────────
+
+test("getFileExtension returns the trailing extension when present", () => {
+  expect(getFileExtension("quarterly-report-final.docx")).toBe("docx");
+  expect(getFileExtension("archive.tar.gz")).toBe("gz");
+});
+
+test("getFileExtension returns empty string when no extension exists", () => {
+  expect(getFileExtension("Makefile")).toBe("");
+  expect(getFileExtension(".env")).toBe("");
+});
+
+test("buildCanonicalDocumentFileName normalizes the canonical file name", () => {
+  expect(buildCanonicalDocumentFileName("pdf")).toBe("document.pdf");
+  expect(buildCanonicalDocumentFileName(".DOCX")).toBe("document.docx");
+  expect(buildCanonicalDocumentFileName("")).toBe("document");
 });
 
 // ────────────────────────────────────────────────────────────────
@@ -173,4 +267,123 @@ test("buildUploadCommitMessage handles special characters in filenames", () => {
   expect(message).toContain(
     "Bindersnap-Source-Filename: File (with) [special] chars & stuff.pdf",
   );
+});
+
+test("createInitialDocumentUpload creates the repo, bootstraps main, and opens a PR", async () => {
+  const file = new File(["hello world"], "Quarterly Report Final.docx", {
+    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  });
+
+  const { client, mockPost, mockDelete } = createMockClient({
+    GET: {
+      "/repos/{owner}/{repo}/contents/{filepath}": () => ({
+        sha: "readme-sha",
+        type: "file",
+      }),
+      "/repos/{owner}/{repo}/pulls/{index}/reviews": () => [],
+    },
+    POST: {
+      "/user/repos": (init: { body?: { name?: string; private?: boolean; auto_init?: boolean; default_branch?: string; description?: string } }) => ({
+        id: 99,
+        name: init?.body?.name,
+        full_name: `alice/${init?.body?.name ?? ""}`,
+        owner: { login: "alice" },
+      }),
+      "/repos/{owner}/{repo}/branch_protections": (init: { body?: { rule_name?: string; required_approvals?: number } }) => ({
+        rule_name: init?.body?.rule_name,
+        required_approvals: init?.body?.required_approvals,
+      }),
+      "/repos/{owner}/{repo}/branches": (init: { body?: { new_branch_name?: string; old_branch_name?: string } }) => ({
+        name: init?.body?.new_branch_name,
+      }),
+      "/repos/{owner}/{repo}/contents/{filepath}": (init: {
+        params?: { path?: { filepath?: string } };
+        body?: { content?: string; message?: string; branch?: string };
+      }) => ({
+        commit: { sha: "commit-sha" },
+        content: {
+          path: init?.params?.path?.filepath,
+        },
+      }),
+      "/repos/{owner}/{repo}/pulls": (init: { body?: { title?: string; head?: string; base?: string } }) => ({
+        number: 17,
+        title: init?.body?.title,
+      }),
+    },
+    DELETE: {
+      "/repos/{owner}/{repo}/contents/{filepath}": () => ({}),
+    },
+  });
+
+  const originalFileReader = globalThis.FileReader;
+  class MockFileReader {
+    result: string | ArrayBuffer | null = null;
+    onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => unknown) | null = null;
+    onerror: ((this: FileReader, ev: ProgressEvent<FileReader>) => unknown) | null = null;
+
+    readAsDataURL() {
+      this.result = "data:application/octet-stream;base64,aGVsbG8gd29ybGQ=";
+      this.onload?.(new Event("load") as unknown as ProgressEvent<FileReader>);
+    }
+  }
+  globalThis.FileReader = MockFileReader as unknown as typeof FileReader;
+
+  try {
+    const { computeFileHash, createInitialDocumentUpload } = await import("./uploads");
+    const fullHash = await computeFileHash(file);
+
+    const result = await createInitialDocumentUpload({
+      client,
+      repoName: "quarterly-report",
+      file,
+      uploaderSlug: "alice",
+      nextVersion: 1,
+    });
+
+    expect(result.owner).toBe("alice");
+    expect(result.repo).toBe("quarterly-report");
+    expect(result.canonicalFile).toBe("document.docx");
+    expect(result.prNumber).toBe(17);
+    expect(result.prTitle).toBe("Upload v1: Quarterly Report");
+    expect(result.commitSha).toBe("commit-sha");
+    expect(mockDelete).toHaveBeenCalled();
+
+    const postCalls = mockPost.mock.calls as Array<[string, { body?: { name?: string; private?: boolean; auto_init?: boolean; default_branch?: string; rule_name?: string; required_approvals?: number; new_branch_name?: string; old_branch_name?: string; content?: string; message?: string; branch?: string; title?: string; head?: string; base?: string } } ]>;
+
+    expect(postCalls.find(([path]) => path === "/user/repos")?.[1]?.body).toMatchObject({
+      name: "quarterly-report",
+      private: true,
+      auto_init: true,
+      default_branch: "main",
+    });
+    expect(postCalls.find(([path]) => path === "/repos/{owner}/{repo}/branch_protections")?.[1]?.body).toMatchObject({
+      rule_name: "main",
+      required_approvals: 1,
+      enable_approvals_whitelist: false,
+      enable_merge_whitelist: false,
+      block_on_rejected_reviews: true,
+    });
+
+    const branchCall = postCalls.find(([path]) => path === "/repos/{owner}/{repo}/branches");
+    expect(branchCall?.[1]?.body?.old_branch_name).toBe("main");
+    expect(branchCall?.[1]?.body?.new_branch_name).toContain("upload/quarterly-report/");
+    expect(branchCall?.[1]?.body?.new_branch_name).toContain(`-alice-${fullHash.slice(0, 8)}`);
+
+    const fileCall = postCalls.find(([path]) => path === "/repos/{owner}/{repo}/contents/{filepath}");
+    expect(fileCall?.[0]).toBe("/repos/{owner}/{repo}/contents/{filepath}");
+    expect(fileCall?.[1]?.params?.path?.filepath).toBe("document.docx");
+    expect(fileCall?.[1]?.body).toMatchObject({
+      branch: result.branchName,
+    });
+    expect(fileCall?.[1]?.body?.message).toContain("Bindersnap-Canonical-File: document.docx");
+
+    const prCall = postCalls.find(([path]) => path === "/repos/{owner}/{repo}/pulls");
+    expect(prCall?.[1]?.body).toMatchObject({
+      title: "Upload v1: Quarterly Report",
+      head: result.branchName,
+      base: "main",
+    });
+  } finally {
+    globalThis.FileReader = originalFileReader;
+  }
 });

--- a/packages/gitea-client/uploads.ts
+++ b/packages/gitea-client/uploads.ts
@@ -1,6 +1,11 @@
 import { unwrap, type GiteaClient } from "./client";
 import { createPullRequest } from "./pullRequests";
 import type { PullRequestWithApprovalState } from "./pullRequests";
+import {
+  bootstrapEmptyMainBranch,
+  createMainBranchProtection,
+  createPrivateCurrentUserRepo,
+} from "./repos";
 
 const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MiB
 
@@ -54,6 +59,32 @@ export interface UploadResult {
   commitSha: string;
 }
 
+export interface InitialDocumentUploadParams {
+  client: GiteaClient;
+  repoName: string;
+  file: File;
+  uploaderSlug: string;
+  nextVersion: number;
+  requiredApprovals?: number;
+  description?: string;
+  onProgress?: (step: InitialDocumentUploadStep) => void;
+}
+
+export interface InitialDocumentUploadResult extends UploadResult {
+  owner: string;
+  repo: string;
+  canonicalFile: string;
+}
+
+export type InitialDocumentUploadStep =
+  | "hashing"
+  | "creating-repo"
+  | "bootstrapping"
+  | "protecting"
+  | "creating-branch"
+  | "committing"
+  | "opening-pr";
+
 export function validateUploadFile(file: File): UploadValidationResult {
   if (file.size > MAX_FILE_SIZE_BYTES) {
     const sizeMiB = (file.size / (1024 * 1024)).toFixed(1);
@@ -63,6 +94,20 @@ export function validateUploadFile(file: File): UploadValidationResult {
     };
   }
   return { valid: true };
+}
+
+export function getFileExtension(fileName: string): string {
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
+    return "";
+  }
+
+  return fileName.slice(dotIndex + 1).toLowerCase();
+}
+
+export function buildCanonicalDocumentFileName(extension: string): string {
+  const normalized = extension.replace(/^\.+/, "").trim().toLowerCase();
+  return normalized === "" ? "document" : `document.${normalized}`;
 }
 
 export async function computeFileHash(file: File): Promise<string> {
@@ -112,6 +157,13 @@ export function buildUploadCommitMessage(
   ].join("\n");
 }
 
+function humanizeRepositoryName(repoName: string): string {
+  return repoName
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 export async function createUploadBranch(
   params: CreateUploadBranchParams,
 ): Promise<void> {
@@ -146,6 +198,128 @@ export async function commitBinaryFile(
   );
 
   return { sha: result.commit?.sha ?? "" };
+}
+
+export async function createInitialDocumentUpload(
+  params: InitialDocumentUploadParams,
+): Promise<InitialDocumentUploadResult> {
+  const {
+    client,
+    repoName,
+    file,
+    uploaderSlug,
+    nextVersion,
+    requiredApprovals = 1,
+    description,
+    onProgress,
+  } = params;
+
+  const validation = validateUploadFile(file);
+  if (!validation.valid) {
+    const { GiteaApiError } = await import("./client");
+    throw new GiteaApiError(0, validation.reason ?? "Invalid file.");
+  }
+
+  onProgress?.("hashing");
+  const fullHash = await computeFileHash(file);
+  const contentHash8 = fullHash.slice(0, 8);
+  const base64Content = await readFileAsBase64(file);
+  const extension = getFileExtension(file.name);
+  const canonicalFile = buildCanonicalDocumentFileName(extension);
+  const branchName = buildUploadBranchName(
+    repoName,
+    uploaderSlug,
+    contentHash8,
+  );
+
+  onProgress?.("creating-repo");
+  const createdRepo = await createPrivateCurrentUserRepo({
+    client,
+    name: repoName,
+    description,
+  });
+
+  const owner = createdRepo.owner?.login ?? "";
+  if (owner.trim() === "") {
+    throw new Error(
+      "Gitea did not return an owner for the created repository.",
+    );
+  }
+
+  onProgress?.("bootstrapping");
+  await bootstrapEmptyMainBranch({
+    client,
+    owner,
+    repo: repoName,
+  });
+
+  onProgress?.("protecting");
+  await createMainBranchProtection({
+    client,
+    owner,
+    repo: repoName,
+    requiredApprovals,
+  });
+
+  onProgress?.("creating-branch");
+  await createUploadBranch({
+    client,
+    owner,
+    repo: repoName,
+    branchName,
+    from: "main",
+  });
+
+  const commitMessage = buildUploadCommitMessage({
+    docSlug: repoName,
+    canonicalFile,
+    sourceFilename: file.name,
+    uploadBranch: branchName,
+    uploaderSlug,
+    fileHashSha256: fullHash,
+  });
+
+  onProgress?.("committing");
+  const { sha: commitSha } = await commitBinaryFile({
+    client,
+    owner,
+    repo: repoName,
+    branch: branchName,
+    filePath: canonicalFile,
+    base64Content,
+    message: commitMessage,
+  });
+
+  const prTitle = `Upload v${nextVersion}: ${humanizeRepositoryName(repoName)}`;
+  const prBody = [
+    `Automated upload from Bindersnap file vault.`,
+    ``,
+    `Source file: ${file.name}`,
+    `Document: ${repoName}`,
+    `Uploaded by: ${uploaderSlug}`,
+    `File hash (SHA-256): ${fullHash}`,
+  ].join("\n");
+
+  onProgress?.("opening-pr");
+  const pr = await createPullRequest({
+    client,
+    owner,
+    repo: repoName,
+    title: prTitle,
+    head: branchName,
+    base: "main",
+    body: prBody,
+  });
+
+  return {
+    owner,
+    repo: repoName,
+    canonicalFile,
+    prNumber: pr.number ?? 0,
+    prTitle,
+    branchName,
+    commitSha,
+  };
 }
 
 async function readFileAsBase64(file: File): Promise<string> {

--- a/tests/document-creation.pw.ts
+++ b/tests/document-creation.pw.ts
@@ -1,0 +1,93 @@
+/**
+ * End-to-end coverage for the UI-driven document creation flow.
+ *
+ * Signs in as bob through the app, creates a new document from the workspace
+ * modal, and verifies the new repo opens in the document detail view with an
+ * unpublished v1 and an open review PR.
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+
+import { GITEA_BOB_PASS, GITEA_BOB_USER } from "./helpers";
+
+function buildUniqueDocumentMetadata() {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    fileName: `ui-document-creation-${suffix}.pdf`,
+  };
+}
+
+function expectedPrefilledDocumentName(fileName: string): string {
+  return fileName
+    .replace(/\.[^.]+$/, "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function signInAsBob(page: Page): Promise<void> {
+  await page.goto("/login");
+  await expect(
+    page.getByRole("heading", { name: "Step into the clean version." }),
+  ).toBeVisible();
+
+  await page.getByLabel("Username or Email").fill(GITEA_BOB_USER);
+  await page.getByLabel("Password", { exact: true }).fill(GITEA_BOB_PASS);
+  await page.getByRole("button", { name: "Open workspace" }).click();
+
+  await expect(page).toHaveURL(/\/app$/);
+  await expect(page.getByText(`Signed in as ${GITEA_BOB_USER}`)).toBeVisible();
+}
+
+async function openNewDocumentModal(page: Page): Promise<void> {
+  await expect(
+    page.getByRole("button", { name: "New Document" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "New Document" }).first().click();
+
+  await expect(
+    page.getByRole("heading", { name: "Create workspace document" }),
+  ).toBeVisible();
+}
+
+test.describe("UI document creation flow", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test("creates a new document as bob and leaves version 1 in review", async ({
+    page,
+  }) => {
+    const doc = buildUniqueDocumentMetadata();
+    const fileData = Buffer.from(
+      `Bindersnap UI document creation test: ${doc.fileName}\n`,
+    );
+
+    await signInAsBob(page);
+    await openNewDocumentModal(page);
+
+    await page.locator("#create-document-file").setInputFiles({
+      name: doc.fileName,
+      mimeType: "application/pdf",
+      buffer: fileData,
+    });
+
+    await expect(page.locator("#create-document-name")).toHaveValue(
+      expectedPrefilledDocumentName(doc.fileName),
+    );
+
+    await page.getByRole("button", { name: "Create Document" }).click();
+
+    await expect(
+      page.getByRole("button", { name: "← Back to workspace" }),
+    ).toBeVisible({ timeout: 120_000 });
+    await expect(
+      page.getByRole("heading", { name: "Unpublished" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("No published version exists yet."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /1 Open Pull Request/ }),
+    ).toBeVisible();
+    await expect(page.getByText(/Upload v1:/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Added a flow to upload a new document. That creates a new repo, creates a `main` branch, creates a new branch, uploads the file, and finally opens a PR on the created branch.

I made the decision to name every document `document.{extension)` to make it easy to download/upload. All repos are private.

## Workflow Evidence (Required)

- Issue read method used:
- Branch creation method used:
- Commit SHA(s):
- PR creation method used:
- Fallback used (`none` if not used):
- If fallback used, reason:

## Scope Check

- [ ] Changes are focused on one issue/task
- [ ] No unrelated refactors or formatting-only churn included

## Validation

- [ ] Local validation/tests run (list commands below)
- Commands run:

## Merge Gate

- [ ] This PR includes complete workflow evidence
- [ ] Any fallback is explicitly documented and justified
