### PR TITLE
Add URL-based deep-linking to app SPA

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -32,7 +32,12 @@ const API_BASE_URL = (
   (isLocalHost ? devDefaultApiBaseUrl : "")
 ).replace(/\/$/, "");
 
-type AppRoute = "app" | "login" | "callback";
+export type AppRoute =
+  | { kind: "login" }
+  | { kind: "callback" }
+  | { kind: "workspace" }
+  | { kind: "document"; owner: string; repo: string; tab: "overview" | "collaborators" };
+
 type AuthView = "loading" | "callback" | "login" | "app";
 type AuthMode = "signin" | "signup";
 
@@ -56,17 +61,60 @@ function getRoute(pathname: string): AppRoute {
     pathname !== "/" ? pathname.replace(/\/+$/, "") : pathname;
 
   if (normalizedPath === "/auth/callback") {
-    return "callback";
+    return { kind: "callback" };
   }
 
   if (normalizedPath === "/login") {
-    return "login";
+    return { kind: "login" };
   }
 
-  return "app";
+  const collaboratorsMatch = normalizedPath.match(
+    /^\/app\/docs\/([^/]+)\/([^/]+)\/collaborators$/,
+  );
+  if (collaboratorsMatch) {
+    return {
+      kind: "document",
+      owner: collaboratorsMatch[1]!,
+      repo: collaboratorsMatch[2]!,
+      tab: "collaborators",
+    };
+  }
+
+  const docMatch = normalizedPath.match(/^\/app\/docs\/([^/]+)\/([^/]+)$/);
+  if (docMatch) {
+    return {
+      kind: "document",
+      owner: docMatch[1]!,
+      repo: docMatch[2]!,
+      tab: "overview",
+    };
+  }
+
+  return { kind: "workspace" };
 }
 
-function navigateTo(path: "/app" | "/login", replace = false): void {
+function navigateTo(route: AppRoute, replace = false): void {
+  let path: string;
+
+  switch (route.kind) {
+    case "login":
+      path = "/login";
+      break;
+    case "callback":
+      path = "/auth/callback";
+      break;
+    case "document":
+      path =
+        route.tab === "collaborators"
+          ? `/app/docs/${route.owner}/${route.repo}/collaborators`
+          : `/app/docs/${route.owner}/${route.repo}`;
+      break;
+    case "workspace":
+    default:
+      path = "/app";
+      break;
+  }
+
   const method = replace ? "replaceState" : "pushState";
   window.history[method]({}, "", path);
   window.dispatchEvent(new PopStateEvent("popstate"));
@@ -432,7 +480,7 @@ export function App() {
   );
   const [user, setUser] = useState<SessionUser | null>(null);
   const [isCheckingSession, setIsCheckingSession] = useState(
-    () => route !== "callback",
+    () => route.kind !== "callback",
   );
   const [callbackError, setCallbackError] = useState<string | null>(null);
 
@@ -470,7 +518,7 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    if (route === "callback") {
+    if (route.kind === "callback") {
       setIsCheckingSession(false);
       return;
     }
@@ -479,33 +527,33 @@ export function App() {
   }, [refreshSession, route]);
 
   useEffect(() => {
-    if (route === "callback" || isCheckingSession) {
+    if (route.kind === "callback" || isCheckingSession) {
       return;
     }
 
-    if (user && route !== "app") {
-      navigateTo("/app", true);
+    if (user && route.kind !== "workspace" && route.kind !== "document") {
+      navigateTo({ kind: "workspace" }, true);
       return;
     }
 
-    if (!user && route === "app") {
-      navigateTo("/login", true);
+    if (!user && (route.kind === "workspace" || route.kind === "document")) {
+      navigateTo({ kind: "login" }, true);
     }
   }, [isCheckingSession, route, user]);
 
   useEffect(() => {
-    if (route !== "callback") {
+    if (route.kind !== "callback") {
       return;
     }
 
     setCallbackError(
       "Single sign-on callback is not enabled in this build. Sign in with your username or email and password.",
     );
-    navigateTo("/login", true);
+    navigateTo({ kind: "login" }, true);
   }, [route]);
 
   const view: AuthView = useMemo(() => {
-    if (route === "callback") {
+    if (route.kind === "callback") {
       return "callback";
     }
 
@@ -582,7 +630,7 @@ export function App() {
               "Sign-in completed, but the session could not be verified.",
             );
           }
-          navigateTo("/app", true);
+          navigateTo({ kind: "workspace" }, true);
         }}
         onSignup={async (username, email, password) => {
           clearToken();
@@ -609,7 +657,7 @@ export function App() {
               "Account created, but the session could not be verified.",
             );
           }
-          navigateTo("/app", true);
+          navigateTo({ kind: "workspace" }, true);
         }}
       />
     );
@@ -641,7 +689,7 @@ export function App() {
               await logoutSession();
               setUser(null);
               setCallbackError(null);
-              navigateTo("/login", true);
+              navigateTo({ kind: "login" }, true);
             }}
           >
             Sign out
@@ -656,12 +704,14 @@ export function App() {
       <AppShell
         user={user}
         giteaClient={giteaClient}
+        route={route}
+        onNavigate={navigateTo}
         onSignOut={async () => {
           await logoutSession();
           clearToken();
           setUser(null);
           setCallbackError(null);
-          navigateTo("/login", true);
+          navigateTo({ kind: "login" }, true);
         }}
       />
     </div>

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-
 import type { GiteaClient } from "../../../packages/gitea-client/client";
+import type { AppRoute } from "../App";
 import { DocumentDetail } from "./DocumentDetail";
 import { FileVaultWorkspace } from "./FileVaultWorkspace";
 
@@ -10,31 +9,18 @@ interface AppShellProps {
     fullName?: string;
   } | null;
   giteaClient: GiteaClient;
+  route: AppRoute;
+  onNavigate: (route: AppRoute, replace?: boolean) => void;
   onSignOut: () => void | Promise<void>;
 }
 
-type AppView = "workspace" | "document";
-
-interface DocumentSelection {
-  owner: string;
-  repo: string;
-}
-
-export function AppShell({ user, giteaClient, onSignOut }: AppShellProps) {
-  const [view, setView] = useState<AppView>("workspace");
-  const [selectedDocument, setSelectedDocument] =
-    useState<DocumentSelection | null>(null);
-
-  const handleSelectDocument = (owner: string, repo: string) => {
-    setSelectedDocument({ owner, repo });
-    setView("document");
-  };
-
-  const handleBackToWorkspace = () => {
-    setView("workspace");
-    setSelectedDocument(null);
-  };
-
+export function AppShell({
+  user,
+  giteaClient,
+  route,
+  onNavigate,
+  onSignOut,
+}: AppShellProps) {
   return (
     <div className="app-shell">
       <header className="app-topbar">
@@ -81,21 +67,27 @@ export function AppShell({ user, giteaClient, onSignOut }: AppShellProps) {
       </header>
 
       <main className="app-main">
-        {view === "workspace" ? (
+        {route.kind === "document" ? (
+          <DocumentDetail
+            giteaClient={giteaClient}
+            owner={route.owner}
+            repo={route.repo}
+            uploaderSlug={user?.username ?? "unknown"}
+            activeView={route.tab}
+            onTabChange={(tab) =>
+              onNavigate({ kind: "document", owner: route.owner, repo: route.repo, tab })
+            }
+            onBack={() => onNavigate({ kind: "workspace" })}
+          />
+        ) : (
           <FileVaultWorkspace
             giteaClient={giteaClient}
             currentUsername={user?.username ?? ""}
-            onSelectDocument={handleSelectDocument}
+            onSelectDocument={(owner, repo) =>
+              onNavigate({ kind: "document", owner, repo, tab: "overview" })
+            }
           />
-        ) : selectedDocument ? (
-          <DocumentDetail
-            giteaClient={giteaClient}
-            owner={selectedDocument.owner}
-            repo={selectedDocument.repo}
-            uploaderSlug={user?.username ?? "unknown"}
-            onBack={handleBackToWorkspace}
-          />
-        ) : null}
+        )}
       </main>
     </div>
   );

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -27,6 +27,8 @@ interface DocumentDetailProps {
   owner: string;
   repo: string;
   uploaderSlug: string;
+  activeView: "overview" | "collaborators";
+  onTabChange: (tab: "overview" | "collaborators") => void;
   onBack: () => void;
 }
 
@@ -52,8 +54,6 @@ interface RepoContentsExtResponse {
   dir_contents?: RepoContentsEntry[];
   file_contents?: RepoContentsEntry;
 }
-
-type DocumentDetailView = "overview" | "collaborators";
 
 function getApprovalStateBadgeClass(state: string): string {
   switch (state) {
@@ -271,6 +271,8 @@ export function DocumentDetail({
   owner,
   repo,
   uploaderSlug,
+  activeView,
+  onTabChange,
   onBack,
 }: DocumentDetailProps) {
   const [tags, setTags] = useState<DocTag[]>([]);
@@ -289,8 +291,6 @@ export function DocumentDetail({
   const [prActionStates, setPrActionStates] = useState<
     Record<number, PRActionState>
   >({});
-  const [activeView, setActiveView] = useState<DocumentDetailView>("overview");
-
   const giteaBaseUrl =
     (import.meta as ImportMeta & { env?: Record<string, string | undefined> })
       .env?.VITE_GITEA_BASE_URL ?? "http://localhost:3000";
@@ -354,10 +354,6 @@ export function DocumentDetail({
   useEffect(() => {
     void loadDocumentData();
   }, [loadDocumentData]);
-
-  useEffect(() => {
-    setActiveView("overview");
-  }, [owner, repo]);
 
   const latestTag = tags.length > 0 ? tags[0] : null;
   const nextVersion = (latestTag?.version ?? 0) + 1;
@@ -589,7 +585,7 @@ export function DocumentDetail({
             type="button"
             role="tab"
             aria-selected={activeView === "overview"}
-            onClick={() => setActiveView("overview")}
+            onClick={() => onTabChange("overview")}
           >
             Overview
           </button>
@@ -598,7 +594,7 @@ export function DocumentDetail({
             type="button"
             role="tab"
             aria-selected={activeView === "collaborators"}
-            onClick={() => setActiveView("collaborators")}
+            onClick={() => onTabChange("collaborators")}
           >
             Collaborators
           </button>


### PR DESCRIPTION
## Summary

- Replace local `useState` routing in `AppShell` and `DocumentDetail` with History API URL-driven navigation
- `AppRoute` is now a discriminated union (`login | callback | workspace | document`) instead of a string literal
- Documents and their tabs (overview/collaborators) are now bookmarkable, shareable, and survive page refresh

## Route schema

| URL | View |
|-----|------|
| `/login` | Login page |
| `/app` | Workspace (document list) |
| `/app/docs/:owner/:repo` | Document detail — overview tab |
| `/app/docs/:owner/:repo/collaborators` | Document detail — collaborators tab |

## Implementation notes

- No new dependencies — pure History API (`pushState`/`replaceState` + `popstate`)
- `navigateTo()` now accepts `AppRoute` and builds the correct path from the discriminated union
- `AppShell` derives view from `route` prop (passed from `App`) — local `view`/`selectedDocument` state removed
- `DocumentDetail` receives `activeView` as a prop and fires `onTabChange` — local tab state removed
- All 94 unit tests pass; `bun run build:app` clean

## Workflow evidence

- Branch created: local git
- Commit: `7d1fe99`
- PR created: GitHub MCP `create_pull_request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)