### PR TITLE
Fix viewport layout, two-column document detail, and motion calibration

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -176,6 +176,31 @@ function LoginPage({ callbackError, onLogin, onSignup }: LoginPageProps) {
   return (
     <section className="app-login-shell">
       <div className="app-login-wrap">
+        <div className="app-login-logo">
+          <div className="app-login-logo-mark" aria-hidden="true">
+            <svg viewBox="0 0 18 18" fill="none" width="24" height="24">
+              <rect
+                x="2"
+                y="1"
+                width="9"
+                height="13"
+                rx="1.5"
+                stroke="currentColor"
+                strokeWidth="1.4"
+              />
+              <rect
+                x="6"
+                y="4"
+                width="9"
+                height="13"
+                rx="1.5"
+                stroke="currentColor"
+                strokeWidth="1.4"
+              />
+            </svg>
+          </div>
+          <span className="app-login-logo-text">Bindersnap</span>
+        </div>
         <div className="app-login-panel bs-card">
           <div className="bs-eyebrow">Secure Access</div>
           <h1>

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -10,18 +10,16 @@ body,
 body {
   margin: 0;
   background:
-    radial-gradient(
-      circle at top left,
-      rgba(232, 93, 38, 0.1),
-      transparent 30%
-    ),
-    radial-gradient(
-      circle at bottom right,
-      rgba(22, 163, 74, 0.07),
-      transparent 28%
-    ),
-    var(--color-paper);
-  color: var(--color-ink);
+    radial-gradient(circle at top left, var(--bs-coral-dim), transparent 30%),
+    radial-gradient(circle at bottom right, var(--bs-green-dim), transparent 28%),
+    var(--bs-page-bg);
+  color: var(--bs-text-primary);
+}
+
+[data-theme="dark"] body {
+  background:
+    radial-gradient(circle at top left, var(--bs-coral-glow), transparent 30%),
+    var(--bs-page-bg);
 }
 
 button,
@@ -30,9 +28,9 @@ input {
 }
 
 .app-inline-code {
-  font-family: var(--font-mono);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-sm);
-  color: var(--color-ink-soft);
+  color: var(--bs-text-secondary);
 }
 
 .app-gate {
@@ -68,12 +66,14 @@ input {
 }
 
 .app-gate-panel h1,
+.app-login-panel h1,
 .app-summary h1,
 .app-section-heading h2,
 .app-error h2,
 .app-doc-card h3 {
   margin: 0;
-  font-family: var(--font-serif);
+  font-family: var(--brand-font-serif);
+  font-size: var(--brand-text-h2);
   line-height: var(--brand-leading-tight);
 }
 
@@ -81,7 +81,7 @@ input {
 .app-summary p,
 .app-error p {
   margin: var(--brand-space-4) 0 0;
-  color: var(--color-muted);
+  color: var(--bs-text-muted);
 }
 
 .app-form {
@@ -101,7 +101,7 @@ input {
 
 .app-inline-error {
   margin: var(--brand-space-4) 0 0;
-  color: var(--color-coral-dark);
+  color: var(--brand-coral-dark);
   font-size: var(--brand-text-sm);
 }
 
@@ -110,7 +110,7 @@ input {
   align-items: center;
   justify-content: space-between;
   gap: var(--brand-space-3);
-  color: var(--color-muted);
+  color: var(--bs-text-muted);
   font-size: var(--brand-text-sm);
 }
 
@@ -118,24 +118,24 @@ input {
   border: 0;
   padding: 0;
   background: transparent;
-  color: var(--color-coral);
-  font-family: var(--font-mono);
+  color: var(--brand-coral);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-label);
   letter-spacing: var(--brand-tracking-wide);
   text-transform: uppercase;
   cursor: pointer;
-  transition: color var(--transition-base);
+  transition: color var(--brand-transition-base);
 }
 
 .app-login-switch-button:hover,
 .app-login-switch-button:focus-visible {
-  color: var(--color-coral-dark);
+  color: var(--brand-coral-dark);
 }
 
 .app-login-hint {
   margin: 0;
-  color: var(--color-muted);
-  font-family: var(--font-mono);
+  color: var(--bs-text-muted);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-label);
   letter-spacing: var(--brand-tracking-wide);
   text-transform: uppercase;
@@ -143,8 +143,8 @@ input {
 
 .app-gate-url {
   margin: var(--brand-space-5) 0 0;
-  color: var(--color-muted);
-  font-family: var(--font-mono);
+  color: var(--bs-text-muted);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-xs);
 }
 
@@ -166,9 +166,9 @@ input {
   gap: var(--brand-space-4);
   padding: var(--brand-space-5) var(--brand-space-6);
   background: var(--bs-surface-1);
-  border: 1px solid var(--color-rule);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-2xl);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--bs-shadow-md);
 }
 
 .app-logo-wrap {
@@ -183,19 +183,34 @@ input {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-coral);
-  background: var(--color-coral-dim);
+  color: var(--brand-coral);
+  background: var(--bs-coral-dim);
   border-radius: var(--brand-radius-md);
 }
 
 .app-logo-text {
-  font-family: var(--font-serif);
+  font-family: var(--brand-font-serif);
   font-size: var(--brand-text-h3);
 }
 
 .app-topbar-actions {
   display: flex;
+  align-items: center;
   gap: var(--brand-space-3);
+}
+
+.app-user-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--brand-space-2);
+  padding: var(--brand-space-2) var(--brand-space-4);
+  background: var(--bs-surface-2);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-full);
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-secondary);
+  white-space: nowrap;
 }
 
 .app-main {
@@ -211,7 +226,7 @@ input {
 }
 
 .app-error {
-  border-left: 3px solid var(--color-coral);
+  border-left: 3px solid var(--brand-coral);
 }
 
 .app-error dl,
@@ -223,9 +238,9 @@ input {
 
 .app-error dt,
 .app-doc-card dt {
-  font-family: var(--font-mono);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-label);
-  color: var(--color-muted);
+  color: var(--bs-text-muted);
   text-transform: uppercase;
   letter-spacing: var(--brand-tracking-wide);
 }
@@ -233,7 +248,7 @@ input {
 .app-error dd,
 .app-doc-card dd {
   margin: 0;
-  color: var(--color-ink-soft);
+  color: var(--bs-text-secondary);
   word-break: break-word;
 }
 
@@ -258,14 +273,14 @@ input {
 
 .app-doc-empty {
   padding: var(--brand-space-6);
-  color: var(--color-muted);
+  color: var(--bs-text-muted);
 }
 
 .app-doc-path {
   margin: var(--brand-space-2) 0 0;
-  font-family: var(--font-mono);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-xs);
-  color: var(--color-muted);
+  color: var(--bs-text-muted);
 }
 
 @media (max-width: 960px) {
@@ -365,7 +380,9 @@ input {
 }
 
 .vault-doc-card:hover {
-  transform: translateY(calc(-1 * var(--brand-space-1)));
+  transform: translateY(-4px);
+  box-shadow: var(--bs-shadow-lg);
+  border-color: transparent;
 }
 
 .vault-doc-card-title {
@@ -405,17 +422,23 @@ input {
   align-items: center;
 }
 
-.vault-version-badge {
+.vault-version-badge,
+.vault-pending-badge,
+.vault-status-badge,
+.collaborator-permission-badge {
   display: inline-block;
   padding: var(--brand-space-1) var(--brand-space-3);
-  background: var(--bs-coral-dim);
-  color: var(--brand-coral-dark);
   font-family: var(--brand-font-mono);
   font-size: var(--brand-text-xs);
   font-weight: var(--brand-weight-medium);
   border-radius: var(--brand-radius-sm);
   text-transform: uppercase;
   letter-spacing: var(--brand-tracking-wide);
+}
+
+.vault-version-badge {
+  background: var(--bs-coral-dim);
+  color: var(--brand-coral-dark);
 }
 
 .vault-no-version {
@@ -424,26 +447,8 @@ input {
 }
 
 .vault-pending-badge {
-  display: inline-block;
-  padding: var(--brand-space-1) var(--brand-space-3);
   background: var(--bs-surface-2);
   color: var(--bs-text-secondary);
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-  font-weight: var(--brand-weight-medium);
-  border-radius: var(--brand-radius-sm);
-  letter-spacing: var(--brand-tracking-wide);
-}
-
-.vault-status-badge {
-  display: inline-block;
-  padding: var(--brand-space-1) var(--brand-space-3);
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-  font-weight: var(--brand-weight-medium);
-  border-radius: var(--brand-radius-sm);
-  text-transform: uppercase;
-  letter-spacing: var(--brand-tracking-wide);
 }
 
 .vault-status-approved {
@@ -532,7 +537,7 @@ input {
 
 .document-detail-tab {
   appearance: none;
-  border: 1px solid var(--color-rule);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-full);
   background: var(--bs-surface-1);
   color: var(--bs-text-muted);
@@ -543,22 +548,22 @@ input {
   padding: var(--brand-space-2) var(--brand-space-4);
   text-transform: uppercase;
   transition:
-    background var(--transition-base),
-    color var(--transition-base),
-    border-color var(--transition-base);
+    background var(--brand-transition-base),
+    color var(--brand-transition-base),
+    border-color var(--brand-transition-base);
 }
 
 .document-detail-tab:hover,
 .document-detail-tab:focus-visible {
-  border-color: var(--color-coral);
-  color: var(--color-ink);
+  border-color: var(--brand-coral);
+  color: var(--bs-text-primary);
   outline: none;
 }
 
 .document-detail-tab-active {
-  background: var(--color-coral);
-  border-color: var(--color-coral);
-  color: var(--color-paper);
+  background: var(--brand-coral);
+  border-color: var(--brand-coral);
+  color: var(--bs-page-bg);
 }
 
 .vault-pr-list,
@@ -577,9 +582,9 @@ input {
 
 .vault-pr-title {
   margin: 0;
-  font-family: var(--brand-font-sans);
-  font-size: var(--brand-text-body);
-  font-weight: var(--brand-weight-medium);
+  font-family: var(--brand-font-serif);
+  font-size: var(--brand-text-h3);
+  line-height: var(--brand-leading-snug);
   color: var(--bs-text-primary);
 }
 
@@ -655,7 +660,7 @@ input {
   width: 100%;
   padding: var(--brand-space-3);
   background: var(--bs-page-bg);
-  border: 1px solid var(--color-rule);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-md);
   color: var(--bs-text-primary);
   font-family: var(--brand-font-sans);
@@ -665,7 +670,7 @@ input {
 }
 
 .vault-pr-comment-input:focus {
-  outline: 2px solid var(--color-coral);
+  outline: 2px solid var(--brand-coral);
   outline-offset: 1px;
 }
 
@@ -854,13 +859,6 @@ input {
   align-items: center;
   gap: var(--brand-space-2);
   width: fit-content;
-  padding: var(--brand-space-1) var(--brand-space-3);
-  border-radius: var(--brand-radius-sm);
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-  font-weight: var(--brand-weight-medium);
-  text-transform: uppercase;
-  letter-spacing: var(--brand-tracking-wide);
 }
 
 .collaborator-permission-power {
@@ -895,22 +893,31 @@ input {
 }
 
 .collaborator-remove-button {
-  color: var(--color-coral);
+  color: var(--brand-coral);
+  transition: color var(--brand-transition-base);
+}
+
+.collaborator-remove-button:hover {
+  color: var(--brand-coral-dark);
 }
 
 .collaborator-permission-select {
   min-width: 140px;
   padding: var(--brand-space-3);
   background: var(--bs-surface-1);
-  border: 1px solid var(--color-rule);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-md);
   color: var(--bs-text-primary);
   font-family: var(--brand-font-sans);
   font-size: var(--brand-text-sm);
 }
 
+.collaborator-permission-select:hover {
+  border-color: var(--brand-coral);
+}
+
 .collaborator-permission-select:focus {
-  outline: 2px solid var(--color-coral);
+  outline: 2px solid var(--brand-coral);
   outline-offset: 1px;
 }
 
@@ -966,7 +973,7 @@ input {
   min-width: 0;
   padding: var(--brand-space-3);
   background: var(--bs-surface-1);
-  border: 1px solid var(--color-rule);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-md);
   color: var(--bs-text-primary);
   font-family: var(--brand-font-sans);
@@ -975,7 +982,7 @@ input {
 }
 
 .collaborator-search-input:focus {
-  outline: 2px solid var(--color-coral);
+  outline: 2px solid var(--brand-coral);
   outline-offset: 1px;
 }
 
@@ -988,10 +995,10 @@ input {
   display: grid;
   gap: var(--brand-space-3);
   padding: var(--brand-space-3);
-  background: var(--color-paper);
-  border: 1px solid var(--color-rule);
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-lg);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--bs-shadow-lg);
 }
 
 .collaborator-search-results {
@@ -1094,6 +1101,59 @@ input {
   }
 }
 
+/* ── Skeleton loading ───────────────────────────────────────── */
+
+@keyframes vault-skeleton-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+
+.vault-skeleton-card {
+  pointer-events: none;
+  animation: vault-skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+.vault-skeleton-line {
+  height: 1em;
+  background: var(--bs-surface-3);
+  border-radius: var(--brand-radius-sm);
+  margin-top: var(--brand-space-3);
+}
+
+.vault-skeleton-line--short { width: 40%; }
+.vault-skeleton-line--medium { width: 65%; }
+.vault-skeleton-line--wide { width: 85%; }
+
+/* ── Login logo lockup ─────────────────────────────────────── */
+
+.app-login-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--brand-space-3);
+  margin-bottom: var(--brand-space-6);
+}
+
+.app-login-logo-mark {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--brand-coral);
+  background: var(--bs-coral-dim);
+  border-radius: var(--brand-radius-md);
+  flex: 0 0 auto;
+}
+
+.app-login-logo-text {
+  font-family: var(--brand-font-serif);
+  font-size: var(--brand-text-h3);
+  font-weight: var(--brand-weight-semibold);
+  color: var(--bs-text-primary);
+  line-height: 1;
+}
+
 /* Upload Modal */
 .upload-modal-backdrop {
   position: fixed;
@@ -1101,15 +1161,15 @@ input {
   background: rgba(0, 0, 0, 0.5);
   display: grid;
   place-items: center;
-  z-index: 100;
+  z-index: var(--brand-z-modal);
   padding: var(--brand-space-6);
 }
 
 .upload-modal {
-  background: var(--color-paper);
-  border: 1px solid var(--color-rule);
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-2xl);
-  box-shadow: var(--shadow-xl);
+  box-shadow: var(--bs-shadow-xl);
   padding: var(--brand-space-8);
   width: min(100%, 540px);
   display: grid;
@@ -1118,7 +1178,7 @@ input {
 
 .upload-modal h2 {
   margin: 0;
-  font-family: var(--font-serif);
+  font-family: var(--brand-font-serif);
   line-height: var(--brand-leading-tight);
 }
 
@@ -1139,7 +1199,7 @@ input {
 .create-document-input {
   padding: var(--brand-space-3);
   background: var(--bs-surface-1);
-  border: 1px solid var(--color-rule);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-md);
   color: var(--bs-text-primary);
   font-family: var(--brand-font-sans);
@@ -1149,7 +1209,7 @@ input {
 }
 
 .create-document-input:focus {
-  outline: 2px solid var(--color-coral);
+  outline: 2px solid var(--brand-coral);
   outline-offset: 1px;
 }
 
@@ -1176,18 +1236,23 @@ input {
 
 .upload-file-input {
   padding: var(--brand-space-3);
-  border: 1px dashed var(--color-rule);
+  border: 1px dashed var(--bs-rule);
   border-radius: var(--brand-radius-md);
   background: var(--bs-surface-1);
   cursor: pointer;
-  font-family: var(--font-mono);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-sm);
-  color: var(--color-ink-soft);
+  color: var(--bs-text-secondary);
   width: 100%;
 }
 
+.upload-file-input:hover {
+  border-color: var(--brand-coral);
+  background: var(--bs-coral-glow);
+}
+
 .upload-validation-error {
-  color: var(--color-coral-dark);
+  color: var(--brand-coral-dark);
   font-size: var(--brand-text-sm);
   margin: 0;
 }
@@ -1205,18 +1270,18 @@ input {
   align-items: center;
   gap: var(--brand-space-3);
   font-size: var(--brand-text-sm);
-  color: var(--color-muted);
-  font-family: var(--font-mono);
+  color: var(--bs-text-muted);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-label);
   letter-spacing: var(--brand-tracking-wide);
 }
 
 .upload-step-active {
-  color: var(--color-ink);
+  color: var(--brand-coral);
 }
 
 .upload-step-done {
-  color: var(--color-green);
+  color: var(--brand-green);
 }
 
 .upload-success-pr {
@@ -1225,16 +1290,16 @@ input {
 }
 
 .upload-pr-number {
-  font-family: var(--font-mono);
+  font-family: var(--brand-font-mono);
   font-size: var(--brand-text-sm);
-  color: var(--color-muted);
+  color: var(--bs-text-muted);
 }
 
 .upload-error-message {
-  color: var(--color-coral-dark);
+  color: var(--brand-coral-dark);
   font-size: var(--brand-text-sm);
   padding: var(--brand-space-3);
-  background: var(--color-coral-dim);
+  background: var(--bs-coral-dim);
   border-radius: var(--brand-radius-md);
   margin: 0;
 }

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -4,7 +4,7 @@ html,
 body,
 #root,
 .app-root {
-  min-height: 100%;
+  height: 100%;
 }
 
 body {
@@ -149,8 +149,12 @@ input {
 }
 
 .app-shell {
-  min-height: 100vh;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   padding: var(--brand-space-6);
+  box-sizing: border-box;
 }
 
 .app-topbar,
@@ -160,6 +164,7 @@ input {
 }
 
 .app-topbar {
+  flex-shrink: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -214,6 +219,9 @@ input {
 }
 
 .app-main {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
   margin-top: var(--brand-space-5);
   display: grid;
   gap: var(--brand-space-5);
@@ -292,11 +300,31 @@ input {
   .app-doc-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .vault-overview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .vault-version-list,
+  .vault-pr-list {
+    max-height: none;
+    overflow-y: visible;
+  }
 }
 
 @media (max-width: 640px) {
+  html, body, #root, .app-root { height: auto; }
+
   .app-shell {
+    height: auto;
+    overflow: visible;
     padding: var(--brand-space-4);
+  }
+
+  .app-main {
+    flex: none;
+    min-height: auto;
+    overflow-y: visible;
   }
 
   .app-login-shell,
@@ -379,8 +407,12 @@ input {
   transition: var(--brand-mode-transition);
 }
 
+.bs-card:hover {
+  transform: translateY(-2px);
+}
+
 .vault-doc-card:hover {
-  transform: translateY(-4px);
+  transform: translateY(-2px);
   box-shadow: var(--bs-shadow-lg);
   border-color: transparent;
 }
@@ -519,6 +551,30 @@ input {
 .vault-detail {
   display: grid;
   gap: var(--brand-space-5);
+  align-content: start;
+}
+
+.vault-overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.6fr);
+  gap: var(--brand-space-5);
+  align-items: start;
+}
+
+.vault-overview-left,
+.vault-overview-right {
+  display: grid;
+  gap: var(--brand-space-5);
+}
+
+.vault-version-list {
+  overflow-y: auto;
+  max-height: clamp(160px, 28dvh, 280px);
+}
+
+.vault-pr-list {
+  overflow-y: auto;
+  max-height: clamp(260px, 50dvh, 520px);
 }
 
 .vault-repo-path {
@@ -1104,13 +1160,13 @@ input {
 /* ── Skeleton loading ───────────────────────────────────────── */
 
 @keyframes vault-skeleton-pulse {
-  0%, 100% { opacity: 0.5; }
+  0%, 100% { opacity: 0.65; }
   50% { opacity: 1; }
 }
 
 .vault-skeleton-card {
   pointer-events: none;
-  animation: vault-skeleton-pulse 1.5s ease-in-out infinite;
+  animation: vault-skeleton-pulse 2s ease-in-out infinite;
 }
 
 .vault-skeleton-line {
@@ -1302,4 +1358,42 @@ input {
   background: var(--bs-coral-dim);
   border-radius: var(--brand-radius-md);
   margin: 0;
+}
+
+/* ── Motion calibration ─────────────────────────────────────── */
+
+/* Scroll reveal — shorter travel, faster settle than token defaults */
+.bs-reveal {
+  transform: translateY(10px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.bs-reveal.bs-in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Reduced motion — respect OS preference */
+@media (prefers-reduced-motion: reduce) {
+  .bs-reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .vault-skeleton-card {
+    animation: none;
+    opacity: 0.75;
+  }
+
+  .bs-card,
+  .bs-card:hover {
+    transform: none;
+    transition: none;
+  }
+
+  * {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -12,6 +12,14 @@ interface AppShellProps {
   onSignOut: () => void | Promise<void>;
 }
 
+function toggleTheme() {
+  const html = document.documentElement;
+  const isDark = html.getAttribute("data-theme") === "dark";
+  const next = isDark ? "light" : "dark";
+  html.setAttribute("data-theme", next);
+  localStorage.setItem("bs-theme", next);
+}
+
 export function AppShell({
   user,
   route,
@@ -44,15 +52,51 @@ export function AppShell({
               />
             </svg>
           </div>
-          <div>
-            <div className="app-logo-text">Bindersnap</div>
-            <div className="app-doc-path">
-              Signed in as {user?.fullName ?? user?.username ?? "Unknown"}
-            </div>
-          </div>
+          <div className="app-logo-text">Bindersnap</div>
         </div>
 
         <div className="app-topbar-actions">
+          {user ? (
+            <span className="app-user-badge">
+              {user.fullName ?? user.username}
+            </span>
+          ) : null}
+          <button
+            className="bs-theme-toggle"
+            type="button"
+            onClick={toggleTheme}
+            aria-label="Toggle dark mode"
+            title="Toggle dark / light mode"
+          >
+            <svg
+              className="bs-icon-moon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+            <svg
+              className="bs-icon-sun"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <circle cx="12" cy="12" r="5" />
+              <line x1="12" y1="1" x2="12" y2="3" />
+              <line x1="12" y1="21" x2="12" y2="23" />
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+              <line x1="1" y1="12" x2="3" y2="12" />
+              <line x1="21" y1="12" x2="23" y2="12" />
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+            </svg>
+          </button>
           <button
             className="bs-btn bs-btn-dark"
             type="button"

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -418,8 +418,10 @@ export function DocumentDetail({
         />
       ) : (
         <>
-          <section className="bs-card vault-section">
-            <div className="bs-eyebrow">Current Version</div>
+          <div className="vault-overview-grid">
+            <div className="vault-overview-left">
+              <section className="bs-card vault-section">
+                <div className="bs-eyebrow">Current Version</div>
             <h2>
               {latestTag ? `Version ${latestTag.version}` : "Unpublished"}
             </h2>
@@ -465,7 +467,8 @@ export function DocumentDetail({
               Upload New Version
             </button>
           </section>
-
+            </div>
+            <div className="vault-overview-right">
           {openPRs.length > 0 ? (
             <section className="bs-card vault-section">
               <div className="bs-eyebrow">Pending Reviews</div>
@@ -620,6 +623,8 @@ export function DocumentDetail({
               </p>
             </section>
           )}
+            </div>
+          </div>
 
           <section className="bs-card vault-section">
             <div className="bs-eyebrow">Version History</div>

--- a/apps/app/components/FileVaultWorkspace.tsx
+++ b/apps/app/components/FileVaultWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { getWorkspaceDocuments, type WorkspaceDocumentSummary } from "../api";
 import { CreateDocumentModal } from "./CreateDocumentModal";
@@ -76,6 +76,7 @@ export function FileVaultWorkspace({
   const [isLoadingDocuments, setIsLoadingDocuments] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showCreateDocumentModal, setShowCreateDocumentModal] = useState(false);
+  const gridRef = useRef<HTMLDivElement>(null);
 
   const loadDocuments = useCallback(async () => {
     setIsLoadingDocuments(true);
@@ -99,13 +100,34 @@ export function FileVaultWorkspace({
     void loadDocuments();
   }, [loadDocuments]);
 
+  useEffect(() => {
+    if (!gridRef.current || isLoadingDocuments) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) {
+            e.target.classList.add("bs-in");
+            io.unobserve(e.target);
+          }
+        });
+      },
+      { threshold: 0.1 },
+    );
+    gridRef.current.querySelectorAll(".bs-reveal").forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, [isLoadingDocuments, documents]);
+
   if (isLoadingDocuments) {
     return (
       <div className="vault-workspace">
-        <div className="bs-card vault-empty-state">
-          <div className="bs-eyebrow">Loading</div>
-          <h2>Loading workspace repositories...</h2>
-          <p>Fetching your documents.</p>
+        <div className="vault-doc-grid">
+          {[1, 2, 3].map((i) => (
+            <article key={i} className="bs-card vault-doc-card vault-skeleton-card">
+              <div className="vault-skeleton-line vault-skeleton-line--medium" />
+              <div className="vault-skeleton-line vault-skeleton-line--wide" />
+              <div className="vault-skeleton-line vault-skeleton-line--short" />
+            </article>
+          ))}
         </div>
       </div>
     );
@@ -134,10 +156,10 @@ export function FileVaultWorkspace({
     return (
       <div className="vault-workspace">
         <div className="bs-card vault-empty-state">
-          <div className="bs-eyebrow">Empty Workspace</div>
-          <h2>No documents found</h2>
+          <div className="bs-eyebrow">File Vault</div>
+          <h2>Your vault is ready.</h2>
           <p>
-            Your workspace is empty. Create your first document to get started.
+            Add your first document to start tracking versions and reviews.
           </p>
           <div className="vault-empty-state-actions">
             <button
@@ -186,8 +208,8 @@ export function FileVaultWorkspace({
         </p>
       </section>
 
-      <div className="vault-doc-grid">
-        {documents.map((document) => {
+      <div className="vault-doc-grid" ref={gridRef}>
+        {documents.map((document, index) => {
           const {
             repo,
             latestTag,
@@ -196,10 +218,11 @@ export function FileVaultWorkspace({
           } = document;
           const mostRecentApprovalState =
             pendingPRs.length > 0 ? pendingPRs[0].approvalState : null;
+          const revealClass = index < 4 ? `bs-reveal bs-reveal-d${index + 1}` : "bs-reveal";
 
           return (
             <article
-              className="bs-card vault-doc-card"
+              className={`bs-card vault-doc-card ${revealClass}`}
               key={repo.id}
               onClick={() => onSelectDocument(repo.owner.login, repo.name)}
             >

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -14,6 +14,13 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,500;0,600;0,700;1,500;1,600&family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap"
     />
+    <script>
+      (function(){
+        var s=localStorage.getItem('bs-theme');
+        var p=window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.setAttribute('data-theme',s||(p?'dark':'light'));
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- **Viewport-locked shell** — `.app-shell` is now `height: 100dvh; display: flex; flex-direction: column; overflow: hidden`. The page never scrolls; only `.app-main` scrolls internally (`flex: 1 1 0; min-height: 0; overflow-y: auto`). Mobile (≤640px) reverts to normal page scroll.
- **Two-column document detail** — Overview wraps in `.vault-overview-grid`: Current Version on left, Pending Reviews on right. Upload and Approve/Publish buttons are both visible on a laptop viewport without scrolling. Version History sits full-width below as a secondary panel. PR list and version list get `max-height` + `overflow-y: auto` scroll zones.
- **Motion calibration** — Card hover lift reduced 4px → 2px; scroll reveal travel 24px → 10px and duration 0.7s → 0.4s; skeleton pulse slowed to 2s with tighter opacity range (0.65–1.0). Full `prefers-reduced-motion` block kills all animation and transition.

## Test plan

- [ ] `bun run test:app` — 95 tests pass (verified before commit)
- [ ] Open app at 1280×800 — topbar + document grid both visible, no page scroll bar
- [ ] Open a document with pending PRs — Upload button (left) and Approve/Publish buttons (right) both visible at once
- [ ] Toggle dark mode — confirm no regression in theme switching
- [ ] Resize to 375px — single column layout, page scroll works normally
- [ ] Hover a workspace card — subtle 2px lift, no 4px jump
- [ ] Watch skeleton on load — gentle 2s pulse, not strobe
- [ ] Enable OS "Reduce motion" — all animation stops

## Workflow evidence

- Branch created: `git checkout -b feature/app-layout-motion-calibration`
- Tests: `bun run test:app` → 95 pass / 0 fail
- Commit: `6546c4e`
- PR created via: `mcp__MCP_DOCKER__create_pull_request`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)