### PR TITLE
feat: harden Gitea production config (disable registration, credential rotation)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,15 @@
+# Copy to .env.prod on EC2. Never commit .env.prod.
+#
+# Generate secrets:
+#   openssl rand -base64 20   (for passwords)
+#   openssl rand -base64 32   (for secret keys)
+
+# Gitea
+GITEA_ADMIN_USER=gitea-admin
+GITEA_ADMIN_PASS=CHANGE_ME_USE_openssl_rand_base64_20
+GITEA_SECRET_KEY=CHANGE_ME_USE_openssl_rand_base64_32
+GITEA_INTERNAL_TOKEN=CHANGE_ME_USE_openssl_rand_base64_32
+
+# App
+BINDERSNAP_USER_EMAIL_DOMAIN=users.bindersnap.com
+BINDERSNAP_GITEA_TOKEN_SCOPES=write:user,write:repository,write:issue

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .env.test.local
 .env.production.local
 .env.local
+.env.prod
+*.env.prod
 
 # caches
 .eslintcache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,17 @@ Every PR must include workflow evidence:
 
 Do not merge PRs that omit workflow evidence or contain unexplained fallback.
 
+## Production Security Rules
+
+These apply to any changes touching `docker-compose.prod.yml`, `Caddyfile.prod`, or EC2 deployment:
+
+1. **Never hardcode credentials.** All secrets (`GITEA_ADMIN_PASS`, `GITEA_SECRET_KEY`, etc.) must come from environment variables, loaded from `.env.prod` on the server. `.env.prod` is in `.gitignore` and must never be committed.
+2. **Registration is disabled in prod.** `GITEA__service__DISABLE_REGISTRATION=true` is non-negotiable for production. Dev compose may differ.
+3. **`INSTALL_LOCK=true` in prod.** Prevents Gitea setup wizard from re-running after first boot.
+4. **Rotate credentials on first deploy.** Generate with `openssl rand -base64 20` for passwords and `openssl rand -base64 32` for secret keys.
+
+---
+
 ## Deterministic MCP Setup
 
 Use one GitHub MCP server configuration path at a time. Avoid mixed auth paths

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -1,0 +1,32 @@
+# Bindersnap production reverse proxy
+# Caddy handles TLS automatically via Let's Encrypt.
+# Run alongside docker-compose.prod.yml on the same network.
+
+(security_headers) {
+	header {
+		X-Frame-Options "DENY"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "same-origin"
+		-Server
+	}
+}
+
+gitea.bindersnap.com {
+	import security_headers
+
+	# Optional: restrict Gitea admin UI to your IP.
+	# Uncomment and replace YOUR.IP.HERE with your static IP.
+	# @admin_routes path /admin/* /-/admin/*
+	# handle @admin_routes {
+	#     @blocked not remote_ip YOUR.IP.HERE
+	#     respond @blocked 403
+	# }
+
+	reverse_proxy gitea:3000
+}
+
+api.bindersnap.com {
+	import security_headers
+
+	reverse_proxy api:8787
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,108 @@
+# Bindersnap production stack (EC2 deployment)
+# Run: docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+#
+# Prerequisites:
+#   1. Copy .env.prod.example to .env.prod and fill in real values
+#   2. Generate secrets: openssl rand -base64 32
+#   3. Never commit .env.prod (it is in .gitignore)
+#
+# This file is standalone — it does NOT extend docker-compose.yml.
+# The dev compose must never be used for production.
+
+services:
+  gitea-init:
+    image: alpine:latest
+    container_name: bindersnap-gitea-init-prod
+    user: "0:0"
+    command: ["sh", "-c", "chown -R 1000:1000 /data"]
+    volumes:
+      - gitea-data:/data
+    restart: "no"
+
+  gitea:
+    image: gitea/gitea:1.25
+    container_name: bindersnap-gitea-prod
+    restart: unless-stopped
+    depends_on:
+      gitea-init:
+        condition: service_completed_successfully
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+      # --- Server ---
+      - GITEA__server__ROOT_URL=https://gitea.bindersnap.com
+      - GITEA__server__HTTP_PORT=3000
+      - GITEA__server__DISABLE_SSH=true
+      # --- Database ---
+      - GITEA__database__DB_TYPE=sqlite3
+      - GITEA__database__PATH=/data/gitea.db
+      # --- Service (registration disabled) ---
+      - GITEA__service__DISABLE_REGISTRATION=true
+      - GITEA__service__REQUIRE_SIGNIN_VIEW=true
+      - GITEA__service__ALLOW_ONLY_EXTERNAL_REGISTRATION=false
+      - GITEA__service__ENABLE_CAPTCHA=false
+      # --- CORS ---
+      - GITEA__cors__ENABLED=true
+      - GITEA__cors__ALLOW_DOMAIN=https://app.bindersnap.com
+      - GITEA__cors__METHODS=GET,POST,PUT,PATCH,DELETE,OPTIONS
+      - GITEA__cors__ALLOW_CREDENTIALS=true
+      # --- Logging ---
+      - GITEA__log__LEVEL=warn
+      - GITEA__log__MODE=console
+      # --- Security ---
+      - GITEA__security__INSTALL_LOCK=true
+      - GITEA__security__SECRET_KEY=${GITEA_SECRET_KEY}
+      - GITEA__security__INTERNAL_TOKEN=${GITEA_INTERNAL_TOKEN}
+      # --- Disable unused auth ---
+      - GITEA__mailer__ENABLED=false
+      - GITEA__openid__ENABLE_OPENID_SIGNIN=false
+      - GITEA__openid__ENABLE_OPENID_SIGNUP=false
+      - GITEA__oauth2__ENABLE=false
+      # --- Admin credentials (first-boot only) ---
+      - GITEA_ADMIN_USER=${GITEA_ADMIN_USER}
+      - GITEA_ADMIN_PASS=${GITEA_ADMIN_PASS}
+    volumes:
+      - gitea-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  hocuspocus:
+    build:
+      context: .
+      dockerfile: services/hocuspocus/Dockerfile
+    container_name: bindersnap-hocuspocus-prod
+    restart: unless-stopped
+
+  api:
+    image: oven/bun:1
+    container_name: bindersnap-api-prod
+    restart: unless-stopped
+    depends_on:
+      gitea:
+        condition: service_healthy
+    working_dir: /app
+    command: ["bun", "services/api/server.ts"]
+    environment:
+      - API_PORT=8787
+      - PORT=8787
+      - GITEA_INTERNAL_URL=http://gitea:3000
+      - GITEA_ADMIN_USER=${GITEA_ADMIN_USER}
+      - GITEA_ADMIN_PASS=${GITEA_ADMIN_PASS}
+      - BINDERSNAP_APP_ORIGIN=https://app.bindersnap.com
+      - BINDERSNAP_USER_EMAIL_DOMAIN=${BINDERSNAP_USER_EMAIL_DOMAIN:-users.bindersnap.com}
+      - BINDERSNAP_GITEA_TOKEN_SCOPES=${BINDERSNAP_GITEA_TOKEN_SCOPES:-write:user,write:repository,write:issue}
+      - BINDERSNAP_REQUIRE_HTTPS=true
+      - BINDERSNAP_AUTH_RATE_LIMIT_ENABLED=true
+    volumes:
+      - .:/app:ro
+
+volumes:
+  gitea-data:
+
+networks:
+  default:
+    name: bindersnap-prod

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,13 +70,6 @@ services:
       retries: 12
       start_period: 30s
 
-  hocuspocus:
-    build:
-      context: .
-      dockerfile: services/hocuspocus/Dockerfile
-    container_name: bindersnap-hocuspocus-prod
-    restart: unless-stopped
-
   api:
     image: oven/bun:1
     container_name: bindersnap-api-prod


### PR DESCRIPTION
## Summary

Closes #131

- **Created `docker-compose.prod.yml`** — standalone production compose with security-hardened Gitea: registration disabled, `INSTALL_LOCK=true`, SSH disabled, CORS locked to `app.bindersnap.com`, all secrets from env vars, no seed/app services
- **Created `Caddyfile.prod`** — Caddy reverse proxy for `gitea.bindersnap.com` and `api.bindersnap.com` with auto TLS and security headers (`X-Frame-Options DENY`, `X-Content-Type-Options nosniff`, `Referrer-Policy same-origin`)
- **Created `.env.prod.example`** — template with placeholder values and generation instructions
- **Updated `.gitignore`** — added `.env.prod` and `*.env.prod`
- **Updated `AGENTS.md`** — added Production Security Rules section (credential management, registration policy, install lock, rotation instructions)

## Acceptance criteria

- [x] `docker-compose.prod.yml` created with hardened Gitea config
- [x] `DISABLE_REGISTRATION=true` in prod compose
- [x] `INSTALL_LOCK=true` in prod compose
- [x] Admin credentials sourced from env vars, never hardcoded
- [x] `Caddyfile.prod` with TLS and security headers
- [x] `.env.prod.example` template with generation instructions
- [x] `.env.prod` added to `.gitignore`
- [x] Production security rules documented in `AGENTS.md`
- [x] Dev `docker-compose.yml` unchanged

## Workflow evidence

- **Issue read:** Task provided in prompt (issue #131)
- **Branch creation:** `git push origin worktree-agent-a682a32b:feat/issue-131-gitea-hardening` (local git)
- **Commit SHA:** `1db6e2cf709478e0999fe8830b02e49123bb4502`
- **PR creation:** `gh pr create` (fallback — MCP `create_branch`/`create_pull_request` tools not available in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)