### PR TITLE
Task 9: implement uptime alarm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,4 @@ conf/app.prod.ini
 /test-results/
 
 # Terraform
-/infra/backups/.terraform
-/infra/secrets/.terraform
+**/.terraform

--- a/infra/monitoring/.terraform.lock.hcl
+++ b/infra/monitoring/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/monitoring/main.tf
+++ b/infra/monitoring/main.tf
@@ -1,0 +1,128 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  description = "AWS region for CloudWatch and SNS resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "bindersnap"
+}
+
+variable "instance_id" {
+  description = "EC2 instance ID to scope the alarms to; override with the real instance ID for production"
+  type        = string
+  default     = "i-0123456789abcdef0"
+
+  validation {
+    condition     = can(regex("^i-[0-9a-f]+$", var.instance_id))
+    error_message = "instance_id must look like an EC2 instance ID, for example i-0123456789abcdef0."
+  }
+}
+
+variable "alert_email" {
+  description = "Optional email address for SNS alert delivery"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.alert_email == null || can(regex("^[^@[:space:]]+@[^@[:space:]]+\\.[^@[:space:]]+$", trimspace(var.alert_email)))
+    error_message = "alert_email must be null or a valid email address."
+  }
+}
+
+locals {
+  alerts_topic_name      = "${var.project}-alerts"
+  email_subscription     = var.alert_email != null && trimspace(var.alert_email) != ""
+  status_alarm_name      = "${var.project}-instance-status-check-failed"
+  cpu_warning_alarm_name = "${var.project}-instance-cpu-high-warning"
+  common_tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_sns_topic" "alerts" {
+  name = local.alerts_topic_name
+
+  tags = local.common_tags
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  count = local.email_subscription ? 1 : 0
+
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = trimspace(var.alert_email)
+}
+
+# Treat missing datapoints as breaching so a stopped instance still trips the uptime alarm.
+resource "aws_cloudwatch_metric_alarm" "status_check_failed" {
+  alarm_name                = local.status_alarm_name
+  alarm_description         = "Alert when the EC2 instance fails system or instance status checks"
+  namespace                 = "AWS/EC2"
+  metric_name               = "StatusCheckFailed"
+  dimensions                = { InstanceId = var.instance_id }
+  statistic                 = "Maximum"
+  period                    = 60
+  evaluation_periods        = 2
+  threshold                 = 1
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  treat_missing_data        = "breaching"
+  alarm_actions             = [aws_sns_topic.alerts.arn]
+  insufficient_data_actions = []
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_high_warning" {
+  alarm_name                = local.cpu_warning_alarm_name
+  alarm_description         = "Warn when EC2 CPU stays above 90 percent for 5 minutes"
+  namespace                 = "AWS/EC2"
+  metric_name               = "CPUUtilization"
+  dimensions                = { InstanceId = var.instance_id }
+  statistic                 = "Average"
+  period                    = 60
+  evaluation_periods        = 5
+  threshold                 = 90
+  comparison_operator       = "GreaterThanThreshold"
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [aws_sns_topic.alerts.arn]
+  insufficient_data_actions = []
+
+  tags = local.common_tags
+}
+
+output "alerts_topic_arn" {
+  description = "SNS topic ARN for alert delivery"
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "status_check_alarm_name" {
+  description = "CloudWatch alarm name for EC2 status checks"
+  value       = aws_cloudwatch_metric_alarm.status_check_failed.alarm_name
+}
+
+output "cpu_warning_alarm_name" {
+  description = "CloudWatch alarm name for sustained CPU warning"
+  value       = aws_cloudwatch_metric_alarm.cpu_high_warning.alarm_name
+}
+
+output "alerts_email_subscription_arn" {
+  description = "SNS email subscription ARN, if an email address was provided"
+  value       = try(aws_sns_topic_subscription.email[0].arn, null)
+}


### PR DESCRIPTION
## Summary
- add a new `infra/monitoring` Terraform module for uptime monitoring
- provision an SNS alerts topic with an optional email subscription
- add EC2 status check and CPU warning CloudWatch alarms, plus outputs and provider lockfile
- expand Terraform ignores to cover `.terraform` directories repo-wide

## Testing
- `terraform -chdir=infra/monitoring fmt`
- `terraform -chdir=infra/monitoring init -backend=false`
- `terraform -chdir=infra/monitoring validate`

## Notes
- The status-check alarm uses `treat_missing_data = "breaching"` so the documented stop-instance alarm test can fire within the expected window.
- SNS email delivery still requires manual subscription confirmation after apply.