### PR TITLE
[codex] add tagged deploy pipeline

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -1,15 +1,7 @@
 name: Build API Image
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/build-api.yml"
-      - "services/api/**"
-      - "packages/gitea-client/**"
-      - "package.json"
-      - "bun.lock"
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -19,6 +11,7 @@ permissions:
 jobs:
   build-api:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,294 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  workflow_dispatch:
+    inputs:
+      api_tag:
+        description: "Optional API image tag to deploy instead of the current commit SHA"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: "1.3.12"
+  AWS_REGION: ${{ vars.AWS_REGION != '' && vars.AWS_REGION || 'us-east-1' }}
+  DEPLOY_ROLE_ARN: ${{ vars.BINDERSNAP_DEPLOY_ROLE_ARN }}
+  SPA_BUCKET: ${{ vars.BINDERSNAP_SPA_BUCKET }}
+  CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.BINDERSNAP_CLOUDFRONT_DISTRIBUTION_ID }}
+  DEPLOY_TARGET_TAG_KEY: ${{ vars.BINDERSNAP_DEPLOY_TARGET_TAG_KEY != '' && vars.BINDERSNAP_DEPLOY_TARGET_TAG_KEY || 'Project' }}
+  DEPLOY_TARGET_TAG_VALUE: ${{ vars.BINDERSNAP_DEPLOY_TARGET_TAG_VALUE != '' && vars.BINDERSNAP_DEPLOY_TARGET_TAG_VALUE || 'bindersnap' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Restore Bun cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run test suite
+        run: bun run test
+
+  build-api:
+    name: Build API Image
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-api.yml
+
+  build-spa:
+    name: Build SPA
+    needs: test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Restore Bun cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build app bundle
+        env:
+          BUN_PUBLIC_API_BASE_URL: https://api.bindersnap.com
+        run: bun run build:app
+
+      - name: Upload SPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-dist
+          path: dist/app
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-24.04
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build-api
+      - build-spa
+    timeout-minutes: 30
+
+    steps:
+      - name: Resolve deploy inputs
+        id: deploy-inputs
+        env:
+          MANUAL_API_TAG: ${{ github.event.inputs.api_tag || '' }}
+        run: |
+          set -euo pipefail
+
+          api_tag="${MANUAL_API_TAG:-}"
+          if [ -z "${api_tag}" ]; then
+            api_tag="${GITHUB_SHA}"
+          fi
+
+          echo "api_tag=${api_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate deploy configuration
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for var_name in DEPLOY_ROLE_ARN SPA_BUCKET CLOUDFRONT_DISTRIBUTION_ID AWS_REGION DEPLOY_TARGET_TAG_KEY DEPLOY_TARGET_TAG_VALUE; do
+            value="${!var_name:-}"
+            if [ -z "${value}" ]; then
+              echo "::error title=Missing workflow configuration::${var_name} is not set"
+              missing=1
+            fi
+          done
+
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Download SPA artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-dist
+          path: dist/app
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ env.DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: bindersnap-deploy-${{ github.run_id }}
+
+      - name: Upload hashed assets to S3
+        run: |
+          set -euo pipefail
+
+          aws s3 sync dist/app "s3://${SPA_BUCKET}/" \
+            --delete \
+            --exclude "index.html" \
+            --cache-control "public,max-age=31536000,immutable"
+
+      - name: Upload index.html to S3
+        run: |
+          set -euo pipefail
+
+          aws s3 cp dist/app/index.html "s3://${SPA_BUCKET}/index.html" \
+            --cache-control "no-cache,no-store,must-revalidate" \
+            --content-type "text/html; charset=utf-8"
+
+      - name: Invalidate CloudFront cache
+        run: |
+          set -euo pipefail
+
+          aws cloudfront create-invalidation \
+            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/" "/index.html"
+
+      - name: Deploy API over SSM
+        env:
+          API_TAG_TO_DEPLOY: ${{ steps.deploy-inputs.outputs.api_tag }}
+        run: |
+          set -euo pipefail
+
+          python3 <<'PY' > /tmp/bindersnap-ssm-commands.json
+          import json
+          import os
+
+          api_tag = os.environ["API_TAG_TO_DEPLOY"]
+          commands = [
+              "set -euo pipefail",
+              "cd /opt/bindersnap",
+              "python3 - <<'PY2'\nfrom pathlib import Path\napi_tag = "
+              + repr(api_tag)
+              + "\npath = Path('/opt/bindersnap/.env.prod')\nlines = path.read_text().splitlines()\nupdated = False\nnew_lines = []\nfor line in lines:\n    if line.startswith('API_TAG='):\n        new_lines.append(f'API_TAG={api_tag}')\n        updated = True\n    else:\n        new_lines.append(line)\nif not updated:\n    new_lines.append(f'API_TAG={api_tag}')\npath.write_text('\\n'.join(new_lines) + '\\n')\nprint(f'Persisted API_TAG={api_tag}')\nPY2",
+              "docker compose --env-file /opt/bindersnap/.env.prod -f docker-compose.prod.yml pull api",
+              "docker compose --env-file /opt/bindersnap/.env.prod -f docker-compose.prod.yml up -d api",
+              "docker compose --env-file /opt/bindersnap/.env.prod -f docker-compose.prod.yml ps api",
+          ]
+
+          print(json.dumps({"commands": commands}))
+          PY
+
+          command_id="$(
+            aws ssm send-command \
+              --document-name AWS-RunShellScript \
+              --targets "Key=tag:${DEPLOY_TARGET_TAG_KEY},Values=${DEPLOY_TARGET_TAG_VALUE}" \
+              --comment "Bindersnap deploy ${GITHUB_SHA}" \
+              --parameters file:///tmp/bindersnap-ssm-commands.json \
+              --max-concurrency 1 \
+              --max-errors 0 \
+              --timeout-seconds 600 \
+              --query 'Command.CommandId' \
+              --output text
+          )"
+
+          echo "Started SSM command ${command_id}"
+
+          instance_id=""
+          for _ in $(seq 1 30); do
+            instance_id="$(
+              aws ssm list-command-invocations \
+                --command-id "${command_id}" \
+                --details \
+                --query 'CommandInvocations[0].InstanceId' \
+                --output text 2>/dev/null || true
+            )"
+
+            if [ -n "${instance_id}" ] && [ "${instance_id}" != "None" ]; then
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
+            echo "::error title=SSM target not found::No managed instance matched tag ${DEPLOY_TARGET_TAG_KEY}=${DEPLOY_TARGET_TAG_VALUE}"
+            exit 1
+          fi
+
+          echo "SSM target instance: ${instance_id}"
+
+          aws ssm wait command-executed \
+            --command-id "${command_id}" \
+            --instance-id "${instance_id}" || true
+
+          invocation_json="$(
+            aws ssm get-command-invocation \
+              --command-id "${command_id}" \
+              --instance-id "${instance_id}" \
+              --output json
+          )"
+
+          INVOCATION_JSON="${invocation_json}" python3 <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["INVOCATION_JSON"])
+          print(f"SSM status: {payload.get('Status')}")
+          print(f"SSM status details: {payload.get('StatusDetails')}")
+
+          stdout = payload.get("StandardOutputContent", "").strip()
+          stderr = payload.get("StandardErrorContent", "").strip()
+
+          if stdout:
+              print("\n--- stdout ---")
+              print(stdout)
+
+          if stderr:
+              print("\n--- stderr ---")
+              print(stderr)
+          PY
+
+          status="$(
+            INVOCATION_JSON="${invocation_json}" python3 <<'PY'
+            import json
+            import os
+
+            print(json.loads(os.environ["INVOCATION_JSON"]).get("Status", "Unknown"))
+            PY
+          )"
+
+          if [ "${status}" != "Success" ]; then
+            echo "::error title=SSM deploy failed::Run Command finished with status ${status}"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -157,3 +157,7 @@ docker compose -f docker-compose.prod.yml --env-file /opt/bindersnap/.env.prod u
 To roll back, set `API_TAG` to a previous commit SHA in
 `/opt/bindersnap/.env.prod`, then run the same `pull` and `up -d api` commands
 again.
+
+The end-to-end production deploy workflow, required GitHub variables, and the
+GitHub Actions rollback path are documented in
+[`docs/ops/deploy.md`](docs/ops/deploy.md).

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -1,0 +1,94 @@
+# Production Deploys
+
+`git push origin main` is the production deploy path for the private app stack.
+The workflow lives in [`../../.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml) and assumes the AWS role provisioned by [`../../infra/ci/oidc.tf`](../../infra/ci/oidc.tf).
+
+## What The Pipeline Does
+
+1. Runs `bun run test`.
+2. Builds and publishes `ghcr.io/davidgraymi/bindersnap-api:${GITHUB_SHA}`.
+3. Builds `dist/app` with `BUN_PUBLIC_API_BASE_URL=https://api.bindersnap.com`.
+4. Uploads the SPA bundle to S3 and invalidates CloudFront for `/` and `/index.html`.
+5. Uses SSM Run Command to:
+   - update `API_TAG` in `/opt/bindersnap/.env.prod`
+   - pull the pinned API image
+   - restart the API with `docker-compose.prod.yml`
+   - print the container status back into the workflow logs
+
+The workflow does not use SSH and does not require long-lived AWS keys in GitHub.
+
+## GitHub Configuration
+
+Set these repository-level variables before enabling the workflow:
+
+- `BINDERSNAP_DEPLOY_ROLE_ARN`: IAM role ARN output by `infra/ci/oidc.tf`
+- `BINDERSNAP_SPA_BUCKET`: production S3 bucket for the app bundle
+- `BINDERSNAP_CLOUDFRONT_DISTRIBUTION_ID`: CloudFront distribution fronting `app.bindersnap.com`
+
+Optional variables:
+
+- `AWS_REGION`: defaults to `us-east-1`
+- `BINDERSNAP_DEPLOY_TARGET_TAG_KEY`: defaults to `Project`
+- `BINDERSNAP_DEPLOY_TARGET_TAG_VALUE`: defaults to `bindersnap`
+
+Do not add a GitHub Environment to the deploy job unless you also change the IAM trust policy. GitHub switches the OIDC `sub` claim from a branch form to an environment form when an environment is attached.
+
+## EC2 Prerequisites
+
+The target instance must already satisfy these conditions:
+
+- It is managed by AWS Systems Manager.
+- It matches the deploy target tag used by the workflow.
+- `/opt/bindersnap` contains the checked-out repo and `docker-compose.prod.yml`.
+- `/opt/bindersnap/.env.prod` exists.
+- The host can pull `ghcr.io/davidgraymi/bindersnap-api`.
+
+The SSM command uses the same production compose contract documented in [`../../README.md`](../../README.md) and established by [`../../infra/compute/user-data.sh`](../../infra/compute/user-data.sh).
+
+## Rollback
+
+The rollback path is a manual rerun of the deploy workflow:
+
+1. Open the `Deploy Production` workflow in GitHub Actions.
+2. Choose `Run workflow`.
+3. Set `api_tag` to a previously published commit SHA.
+4. Run the workflow.
+
+That rerun updates `API_TAG` in `/opt/bindersnap/.env.prod`, pulls the older image, and restarts only the API service.
+
+If GitHub Actions is unavailable, the manual fallback on the instance is:
+
+```bash
+cd /opt/bindersnap
+python3 - <<'PY'
+from pathlib import Path
+
+api_tag = "REPLACE_WITH_OLD_SHA"
+path = Path("/opt/bindersnap/.env.prod")
+lines = path.read_text().splitlines()
+updated = False
+new_lines = []
+
+for line in lines:
+    if line.startswith("API_TAG="):
+        new_lines.append(f"API_TAG={api_tag}")
+        updated = True
+    else:
+        new_lines.append(line)
+
+if not updated:
+    new_lines.append(f"API_TAG={api_tag}")
+
+path.write_text("\n".join(new_lines) + "\n")
+PY
+docker compose --env-file /opt/bindersnap/.env.prod -f docker-compose.prod.yml pull api
+docker compose --env-file /opt/bindersnap/.env.prod -f docker-compose.prod.yml up -d api
+```
+
+## Validation Checklist
+
+- A push to `main` completes in under five minutes.
+- A forced test failure prevents the `deploy` job from running.
+- The workflow log prints SSM stdout and stderr from the remote deploy command.
+- A visible SPA change is live at `https://app.bindersnap.com` after the workflow completes.
+- A manual `api_tag` rollback returns the API to the selected SHA.

--- a/infra/ci/.terraform.lock.hcl
+++ b/infra/ci/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/ci/oidc.tf
+++ b/infra/ci/oidc.tf
@@ -1,0 +1,249 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  description = "AWS region used by the production deployment resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project" {
+  description = "Project name used for resource tagging"
+  type        = string
+  default     = "bindersnap"
+}
+
+variable "github_owner" {
+  description = "GitHub org or user that owns the repository"
+  type        = string
+}
+
+variable "github_repository" {
+  description = "GitHub repository name"
+  type        = string
+  default     = "bindersnap-editor-demo"
+}
+
+variable "github_branch" {
+  description = "Git branch allowed to assume the deploy role"
+  type        = string
+  default     = "main"
+}
+
+variable "deploy_role_name" {
+  description = "IAM role name assumed by the GitHub Actions deploy workflow"
+  type        = string
+  default     = "bindersnap-deploy"
+}
+
+variable "spa_bucket_name" {
+  description = "S3 bucket that stores the production SPA build"
+  type        = string
+}
+
+variable "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID that fronts the production SPA bucket"
+  type        = string
+}
+
+variable "ssm_document_name" {
+  description = "SSM document used by the deploy workflow"
+  type        = string
+  default     = "AWS-RunShellScript"
+}
+
+variable "instance_tag_key" {
+  description = "Tag key used to target the production instance over SSM"
+  type        = string
+  default     = "Project"
+}
+
+variable "instance_tag_value" {
+  description = "Tag value used to target the production instance over SSM"
+  type        = string
+  default     = "bindersnap"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  github_sub = "repo:${var.github_owner}/${var.github_repository}:ref:refs/heads/${var.github_branch}"
+
+  common_tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "deploy_trust" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    actions = [
+      "sts:AssumeRoleWithWebIdentity",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = [local.github_sub]
+    }
+  }
+}
+
+resource "aws_iam_role" "deploy" {
+  name               = var.deploy_role_name
+  assume_role_policy = data.aws_iam_policy_document.deploy_trust.json
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "deploy" {
+  statement {
+    sid    = "SyncSpaBucket"
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${var.spa_bucket_name}",
+    ]
+  }
+
+  statement {
+    sid    = "ManageSpaObjects"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${var.spa_bucket_name}/*",
+    ]
+  }
+
+  statement {
+    sid    = "InvalidateSpaDistribution"
+    effect = "Allow"
+
+    actions = [
+      "cloudfront:CreateInvalidation",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${var.cloudfront_distribution_id}",
+    ]
+  }
+
+  statement {
+    sid    = "RunDeployDocument"
+    effect = "Allow"
+
+    actions = [
+      "ssm:SendCommand",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:document/${var.ssm_document_name}",
+    ]
+  }
+
+  statement {
+    sid    = "RunDeployOnTaggedTargets"
+    effect = "Allow"
+
+    actions = [
+      "ssm:SendCommand",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:managed-instance/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/${var.instance_tag_key}"
+      values   = [var.instance_tag_value]
+    }
+  }
+
+  statement {
+    sid    = "ReadDeployCommandStatus"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetCommandInvocation",
+      "ssm:ListCommandInvocations",
+      "ssm:ListCommands",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "deploy" {
+  name        = "${var.deploy_role_name}-policy"
+  description = "Least-privilege access for the GitHub Actions production deploy workflow"
+  policy      = data.aws_iam_policy_document.deploy.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "deploy" {
+  role       = aws_iam_role.deploy.name
+  policy_arn = aws_iam_policy.deploy.arn
+}
+
+output "github_actions_oidc_provider_arn" {
+  description = "IAM OIDC provider ARN for GitHub Actions"
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+}
+
+output "deploy_role_arn" {
+  description = "IAM role ARN to store in the BINDERSNAP_DEPLOY_ROLE_ARN GitHub variable"
+  value       = aws_iam_role.deploy.arn
+}
+
+output "deploy_role_subject" {
+  description = "GitHub OIDC subject allowed to assume the deploy role"
+  value       = local.github_sub
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindersnap-editor-demo",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
This PR adds the Task 10 production deploy pipeline and keeps the actual deploy step gated to tag refs. It also converts the API image build workflow into a reusable workflow so the deploy pipeline can guarantee that the image tag it wants to deploy exists before it tries to roll out the API.

## What changed
The production workflow now runs repository tests, builds the API image, builds the app bundle with the production API base URL, uploads the SPA to S3, invalidates CloudFront, and deploys the API over SSM. The deploy job itself only runs on tag refs, which prevents a regular push to `main` from automatically shipping production while still letting tagged releases drive deployment.

A new Terraform module provisions the GitHub OIDC provider, the deploy role, and the least-privilege IAM policy needed for S3 sync, CloudFront invalidation, and SSM command execution. The ops docs now describe the required GitHub variables, EC2 prerequisites, and the rollback path. The staged package version bump from `0.1.6` to `0.1.8` is also included because it was part of the staged change set requested for commit.

## Why this fixes the problem
Before this change there was no end-to-end GitHub Actions path for the private app deployment. The architecture doc expected a workflow that could build both artifacts, assume AWS credentials via OIDC, publish the SPA, and roll the API on EC2 without SSH. This PR adds that path and aligns the rollout command with the repo's actual production compose contract by using `/opt/bindersnap/.env.prod` and `docker-compose.prod.yml`.

The tag-only deploy guard also tightens release control. Tests and builds can still run earlier in the workflow, but production rollout is reserved for an explicit tagged release instead of every `main` push.

## Validation
I validated the changes locally before creating this PR:

- `bun run test`
- `bun run test:ops`
- `BUN_PUBLIC_API_BASE_URL=https://api.bindersnap.com bun run build:app`
- `terraform -chdir=infra/ci fmt -check`
- `terraform -chdir=infra/ci init -backend=false`
- `terraform -chdir=infra/ci validate`
- `bunx prettier --check .github/workflows/*.yml docs/ops/deploy.md README.md`

## Remaining external validation
I did not run a live tagged GitHub Actions deployment against AWS from this environment. The final acceptance items that depend on a real tag push, S3 sync, CloudFront invalidation, and SSM execution still need to be exercised in GitHub Actions against the production AWS resources.