### PR TITLE
infra: address architect review (6/6 concerns)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ conf/app.prod.ini
 
 # Terraform
 **/.terraform
+**/tfplan.out
+*.tfstate
+*.tfstate.backup
+terraform.tfvars
+infra/state/backend.hcl

--- a/infra/apply-all.sh
+++ b/infra/apply-all.sh
@@ -3,11 +3,11 @@
 #
 # Usage:
 #   cd infra/
-#   ./apply-all.sh          # plan + apply all modules
-#   ./apply-all.sh plan     # plan only (no changes)
+#   ./apply-all.sh          # apply all modules (wires outputs between them)
+#   ./apply-all.sh plan     # plan only — each module uses its own tfvars
 #
 # Prerequisites:
-#   1. infra/state/ already applied (local state, one-time bootstrap)
+#   1. infra/state/ already applied (bun run tf:bootstrap)
 #   2. infra/state/backend.hcl exists with real values
 #   3. Each module has a terraform.tfvars with non-derivable values filled in
 
@@ -19,7 +19,7 @@ BACKEND_CONFIG="${SCRIPT_DIR}/state/backend.hcl"
 
 if [[ ! -f "$BACKEND_CONFIG" ]]; then
   echo "ERROR: ${BACKEND_CONFIG} not found."
-  echo "Run: cd infra/state && terraform apply, then copy backend.hcl.example to backend.hcl"
+  echo "Run: bun run tf:bootstrap"
   exit 1
 fi
 
@@ -29,54 +29,90 @@ tf_init() {
   terraform -chdir="${SCRIPT_DIR}/${dir}" init -backend-config="${BACKEND_CONFIG}" -input=false -reconfigure
 }
 
+# Read a terraform output. Returns empty string if state has no outputs yet.
 tf_output() {
   local dir="$1" key="$2"
-  terraform -chdir="${SCRIPT_DIR}/${dir}" output -raw "${key}" 2>/dev/null
+  local val
+  val="$(terraform -chdir="${SCRIPT_DIR}/${dir}" output -raw "${key}" 2>/dev/null)" || true
+  # Terraform emits ANSI warning text when no outputs exist — detect and discard
+  if [[ -z "$val" || "$val" == *"Warning"* || "$val" == *"No outputs"* ]]; then
+    echo ""
+  else
+    echo "$val"
+  fi
 }
 
-tf_apply() {
+tf_run() {
   local dir="$1"
   shift
   local extra_vars=("$@")
 
   tf_init "${dir}"
 
-  local var_args=()
-  for v in "${extra_vars[@]}"; do
-    var_args+=(-var "${v}")
-  done
+  local tf_args=(-input=false)
 
+  # tfvars file (if present)
   local tfvars="${SCRIPT_DIR}/${dir}/terraform.tfvars"
-  local var_file_arg=()
   if [[ -f "$tfvars" ]]; then
-    var_file_arg=(-var-file="${tfvars}")
+    tf_args+=(-var-file="${tfvars}")
+  fi
+
+  # Extra vars passed by the caller (output wiring from upstream modules)
+  if [[ ${#extra_vars[@]} -gt 0 ]]; then
+    for v in "${extra_vars[@]}"; do
+      tf_args+=(-var "${v}")
+    done
   fi
 
   if [[ "$ACTION" == "plan" ]]; then
     echo "--- Planning ${dir} ---"
-    terraform -chdir="${SCRIPT_DIR}/${dir}" plan "${var_file_arg[@]}" "${var_args[@]}" -input=false
+    terraform -chdir="${SCRIPT_DIR}/${dir}" plan "${tf_args[@]}"
   else
     echo "--- Applying ${dir} ---"
-    terraform -chdir="${SCRIPT_DIR}/${dir}" apply "${var_file_arg[@]}" "${var_args[@]}" -input=false -auto-approve
+    terraform -chdir="${SCRIPT_DIR}/${dir}" apply "${tf_args[@]}" -auto-approve
   fi
 }
 
 echo "=== Bindersnap infrastructure: ${ACTION} ==="
 
-# 1. Compute (no upstream deps — other modules depend on its outputs)
-tf_apply "compute"
+# --- Plan mode: each module plans independently using its own tfvars ---
+if [[ "$ACTION" == "plan" ]]; then
+  tf_run "compute"
+  tf_run "secrets"
+  tf_run "backups"
+  tf_run "monitoring"
+  tf_run "ci"
+
+  echo ""
+  echo "=== Done. All modules planned. ==="
+  echo "Cross-module output wiring happens at apply time."
+  exit 0
+fi
+
+# --- Apply mode: chain modules, wire outputs forward ---
+
+# 1. Compute (no upstream deps)
+tf_run "compute"
 
 INSTANCE_ID="$(tf_output compute instance_id)"
 INSTANCE_ROLE="$(tf_output compute instance_role_name)"
 DATA_VOLUME_ID="$(tf_output compute data_volume_id)"
 
+if [[ -z "$INSTANCE_ID" || -z "$INSTANCE_ROLE" || -z "$DATA_VOLUME_ID" ]]; then
+  echo "ERROR: compute module applied but outputs are missing."
+  echo "  instance_id=${INSTANCE_ID:-<empty>}"
+  echo "  instance_role_name=${INSTANCE_ROLE:-<empty>}"
+  echo "  data_volume_id=${DATA_VOLUME_ID:-<empty>}"
+  exit 1
+fi
+
 echo "  Compute outputs: instance=${INSTANCE_ID} role=${INSTANCE_ROLE} volume=${DATA_VOLUME_ID}"
 
 # 2. Secrets (needs instance role for policy attachment)
-tf_apply "secrets" "ec2_instance_role_name=${INSTANCE_ROLE}"
+tf_run "secrets" "ec2_instance_role_name=${INSTANCE_ROLE}"
 
 # 3. Backups (needs instance role + volume ID)
-tf_apply "backups" \
+tf_run "backups" \
   "ec2_instance_role_name=${INSTANCE_ROLE}" \
   "gitea_data_volume_id=${DATA_VOLUME_ID}"
 
@@ -84,10 +120,10 @@ LITESTREAM_BUCKET="$(tf_output backups litestream_bucket_name)"
 echo "  Backups outputs: litestream_bucket=${LITESTREAM_BUCKET}"
 
 # 4. Monitoring (needs instance ID)
-tf_apply "monitoring" "instance_id=${INSTANCE_ID}"
+tf_run "monitoring" "instance_id=${INSTANCE_ID}"
 
-# 5. CI (needs SPA bucket + CloudFront dist — these come from tfvars since SPA module doesn't exist yet)
-tf_apply "ci"
+# 5. CI (SPA bucket + CloudFront dist come from tfvars — no upstream module yet)
+tf_run "ci"
 
 echo ""
-echo "=== Done. All modules ${ACTION}ed successfully. ==="
+echo "=== Done. All modules applied successfully. ==="

--- a/infra/apply-all.sh
+++ b/infra/apply-all.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Applies all Terraform modules in dependency order, wiring outputs forward.
+#
+# Usage:
+#   cd infra/
+#   ./apply-all.sh          # plan + apply all modules
+#   ./apply-all.sh plan     # plan only (no changes)
+#
+# Prerequisites:
+#   1. infra/state/ already applied (local state, one-time bootstrap)
+#   2. infra/state/backend.hcl exists with real values
+#   3. Each module has a terraform.tfvars with non-derivable values filled in
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ACTION="${1:-apply}"
+BACKEND_CONFIG="${SCRIPT_DIR}/state/backend.hcl"
+
+if [[ ! -f "$BACKEND_CONFIG" ]]; then
+  echo "ERROR: ${BACKEND_CONFIG} not found."
+  echo "Run: cd infra/state && terraform apply, then copy backend.hcl.example to backend.hcl"
+  exit 1
+fi
+
+tf_init() {
+  local dir="$1"
+  echo "--- Initializing ${dir} ---"
+  terraform -chdir="${SCRIPT_DIR}/${dir}" init -backend-config="${BACKEND_CONFIG}" -input=false -reconfigure
+}
+
+tf_output() {
+  local dir="$1" key="$2"
+  terraform -chdir="${SCRIPT_DIR}/${dir}" output -raw "${key}" 2>/dev/null
+}
+
+tf_apply() {
+  local dir="$1"
+  shift
+  local extra_vars=("$@")
+
+  tf_init "${dir}"
+
+  local var_args=()
+  for v in "${extra_vars[@]}"; do
+    var_args+=(-var "${v}")
+  done
+
+  local tfvars="${SCRIPT_DIR}/${dir}/terraform.tfvars"
+  local var_file_arg=()
+  if [[ -f "$tfvars" ]]; then
+    var_file_arg=(-var-file="${tfvars}")
+  fi
+
+  if [[ "$ACTION" == "plan" ]]; then
+    echo "--- Planning ${dir} ---"
+    terraform -chdir="${SCRIPT_DIR}/${dir}" plan "${var_file_arg[@]}" "${var_args[@]}" -input=false
+  else
+    echo "--- Applying ${dir} ---"
+    terraform -chdir="${SCRIPT_DIR}/${dir}" apply "${var_file_arg[@]}" "${var_args[@]}" -input=false -auto-approve
+  fi
+}
+
+echo "=== Bindersnap infrastructure: ${ACTION} ==="
+
+# 1. Compute (no upstream deps — other modules depend on its outputs)
+tf_apply "compute"
+
+INSTANCE_ID="$(tf_output compute instance_id)"
+INSTANCE_ROLE="$(tf_output compute instance_role_name)"
+DATA_VOLUME_ID="$(tf_output compute data_volume_id)"
+
+echo "  Compute outputs: instance=${INSTANCE_ID} role=${INSTANCE_ROLE} volume=${DATA_VOLUME_ID}"
+
+# 2. Secrets (needs instance role for policy attachment)
+tf_apply "secrets" "ec2_instance_role_name=${INSTANCE_ROLE}"
+
+# 3. Backups (needs instance role + volume ID)
+tf_apply "backups" \
+  "ec2_instance_role_name=${INSTANCE_ROLE}" \
+  "gitea_data_volume_id=${DATA_VOLUME_ID}"
+
+LITESTREAM_BUCKET="$(tf_output backups litestream_bucket_name)"
+echo "  Backups outputs: litestream_bucket=${LITESTREAM_BUCKET}"
+
+# 4. Monitoring (needs instance ID)
+tf_apply "monitoring" "instance_id=${INSTANCE_ID}"
+
+# 5. CI (needs SPA bucket + CloudFront dist — these come from tfvars since SPA module doesn't exist yet)
+tf_apply "ci"
+
+echo ""
+echo "=== Done. All modules ${ACTION}ed successfully. ==="

--- a/infra/backups/main.tf
+++ b/infra/backups/main.tf
@@ -98,6 +98,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "litestream" {
     id     = "expire-old-versions"
     status = "Enabled"
 
+    filter {} # required by AWS provider ~> 5.0 — applies to all objects
+
     noncurrent_version_expiration {
       noncurrent_days = 30
     }

--- a/infra/backups/main.tf
+++ b/infra/backups/main.tf
@@ -18,6 +18,12 @@ terraform {
       version = "~> 5.0"
     }
   }
+
+  backend "s3" {
+    key = "backups/terraform.tfstate"
+    # Remaining config (bucket, region, dynamodb_table, encrypt) loaded from:
+    #   terraform init -backend-config=../state/backend.hcl
+  }
 }
 
 provider "aws" {

--- a/infra/backups/terraform.tfvars.example
+++ b/infra/backups/terraform.tfvars.example
@@ -1,0 +1,6 @@
+# Copy to terraform.tfvars and fill in real values.
+
+aws_account_id       = "123456789012"
+aws_region           = "us-east-1"
+# gitea_data_volume_id = "vol-0123456789abcdef0"  # from: cd ../compute && terraform output data_volume_id
+# ec2_instance_role_name = "bindersnap-prod-instance"  # from: cd ../compute && terraform output instance_role_name

--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# One-time bootstrap: creates the S3 state bucket + DynamoDB lock table,
+# then generates backend.hcl for all other modules.
+#
+# Usage:
+#   bun run tf:bootstrap
+#
+# After this completes, run: bun run tf:apply
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STATE_DIR="${SCRIPT_DIR}/state"
+BACKEND_HCL="${STATE_DIR}/backend.hcl"
+
+if [[ -f "$BACKEND_HCL" ]]; then
+  echo "backend.hcl already exists at ${BACKEND_HCL}"
+  echo "Bootstrap has already run. If you need to re-bootstrap, delete backend.hcl first."
+  exit 0
+fi
+
+# Detect AWS account ID
+AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)" || {
+  echo "ERROR: Could not determine AWS account ID."
+  echo "Ensure AWS credentials are configured (aws configure / env vars / SSO)."
+  exit 1
+}
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+
+echo "=== Bindersnap Terraform Bootstrap ==="
+echo "  Account: ${AWS_ACCOUNT_ID}"
+echo "  Region:  ${AWS_REGION}"
+echo ""
+
+# Init + apply the state module (local state — intentional)
+echo "--- Initializing state module ---"
+terraform -chdir="${STATE_DIR}" init -input=false
+
+echo "--- Applying state module ---"
+terraform -chdir="${STATE_DIR}" apply \
+  -var="aws_account_id=${AWS_ACCOUNT_ID}" \
+  -var="aws_region=${AWS_REGION}" \
+  -input=false \
+  -auto-approve
+
+# Extract outputs and write backend.hcl
+BUCKET="$(terraform -chdir="${STATE_DIR}" output -raw bucket_name)"
+LOCK_TABLE="$(terraform -chdir="${STATE_DIR}" output -raw lock_table_name)"
+
+cat > "${BACKEND_HCL}" <<EOF
+bucket         = "${BUCKET}"
+region         = "${AWS_REGION}"
+dynamodb_table = "${LOCK_TABLE}"
+encrypt        = true
+EOF
+
+echo ""
+echo "=== Bootstrap complete ==="
+echo "  State bucket:  ${BUCKET}"
+echo "  Lock table:    ${LOCK_TABLE}"
+echo "  Backend config: ${BACKEND_HCL}"
+echo ""
+echo "Next steps:"
+echo "  1. Copy terraform.tfvars.example → terraform.tfvars in each infra/ subdirectory"
+echo "  2. Fill in real values (see comments in each file)"
+echo "  3. Run: bun run tf:plan    (dry run)"
+echo "  4. Run: bun run tf:apply   (apply all)"

--- a/infra/ci/oidc.tf
+++ b/infra/ci/oidc.tf
@@ -6,6 +6,10 @@ terraform {
       version = "~> 5.0"
     }
   }
+
+  backend "s3" {
+    key = "ci/terraform.tfstate"
+  }
 }
 
 provider "aws" {

--- a/infra/ci/terraform.tfvars.example
+++ b/infra/ci/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy to terraform.tfvars and fill in real values.
+
+github_owner               = "your-github-org"
+spa_bucket_name            = "bindersnap-spa"
+cloudfront_distribution_id = "E1234567890ABC"  # from: cd ../spa && terraform output distribution_id
+# aws_region               = "us-east-1"
+# github_repository        = "bindersnap-editor-demo"
+# github_branch            = "main"

--- a/infra/compute/.terraform.lock.hcl
+++ b/infra/compute/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/compute/cloudwatch-agent-config.json
+++ b/infra/compute/cloudwatch-agent-config.json
@@ -12,7 +12,13 @@
         "measurement": ["used_percent"],
         "metrics_collection_interval": 300,
         "resources": ["/", "/data"],
-        "ignore_file_system_types": ["sysfs", "devtmpfs", "tmpfs", "squashfs", "overlay"]
+        "ignore_file_system_types": [
+          "sysfs",
+          "devtmpfs",
+          "tmpfs",
+          "squashfs",
+          "overlay"
+        ]
       },
       "mem": {
         "measurement": ["mem_used_percent"],

--- a/infra/compute/cloudwatch-agent-config.json
+++ b/infra/compute/cloudwatch-agent-config.json
@@ -1,0 +1,23 @@
+{
+  "agent": {
+    "metrics_collection_interval": 300
+  },
+  "metrics": {
+    "namespace": "Bindersnap",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "disk": {
+        "measurement": ["used_percent"],
+        "metrics_collection_interval": 300,
+        "resources": ["/", "/data"],
+        "ignore_file_system_types": ["sysfs", "devtmpfs", "tmpfs", "squashfs", "overlay"]
+      },
+      "mem": {
+        "measurement": ["mem_used_percent"],
+        "metrics_collection_interval": 300
+      }
+    }
+  }
+}

--- a/infra/compute/main.tf
+++ b/infra/compute/main.tf
@@ -1,0 +1,349 @@
+# Compute module: EC2 instance, security group, EBS, IAM instance profile.
+#
+# This is the missing piece the architect flagged — the actual box that runs
+# Gitea + the API was created by hand. This module makes it reproducible.
+#
+# Usage:
+#   cd infra/compute
+#   terraform init -backend-config=../state/backend.hcl
+#   terraform plan -var-file=terraform.tfvars
+#   terraform apply -var-file=terraform.tfvars
+#
+# To rebuild from scratch: terraform destroy && terraform apply
+# The EBS data volume is RETAINED on destroy to protect Gitea data.
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    key = "compute/terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# ---------- Variables ----------
+
+variable "aws_region" {
+  description = "AWS region for all compute resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project" {
+  description = "Project name for resource tagging"
+  type        = string
+  default     = "bindersnap"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "prod"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type (ARM recommended: t4g.small for MVP, t4g.medium for growth)"
+  type        = string
+  default     = "t4g.small"
+}
+
+variable "ami_id" {
+  description = "AMI ID — use latest Amazon Linux 2023 ARM64. Set to null to auto-discover."
+  type        = string
+  default     = null
+}
+
+variable "key_pair_name" {
+  description = "EC2 key pair name for SSH access (break-glass only; prefer SSM Session Manager)"
+  type        = string
+  default     = null
+}
+
+variable "vpc_id" {
+  description = "VPC ID. Defaults to the default VPC if null."
+  type        = string
+  default     = null
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for the instance. Defaults to the first default subnet if null."
+  type        = string
+  default     = null
+}
+
+variable "data_volume_size_gb" {
+  description = "EBS gp3 volume size in GB for Gitea data + API sessions"
+  type        = number
+  default     = 20
+}
+
+variable "data_volume_device_name" {
+  description = "Device name for the data EBS volume"
+  type        = string
+  default     = "/dev/xvdf"
+}
+
+variable "allowed_ssh_cidrs" {
+  description = "CIDRs allowed to SSH (empty list disables SSH ingress entirely)"
+  type        = list(string)
+  default     = []
+}
+
+variable "ssm_parameter_path" {
+  description = "SSM path prefix for the env refresh script (must match secrets module)"
+  type        = string
+  default     = "/bindersnap/prod"
+}
+
+# ---------- Data sources ----------
+
+# Auto-discover latest AL2023 ARM64 AMI if not pinned
+data "aws_ami" "al2023_arm64" {
+  count       = var.ami_id == null ? 1 : 0
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-arm64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_vpc" "selected" {
+  id      = var.vpc_id
+  default = var.vpc_id == null ? true : null
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
+
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+locals {
+  ami_id    = var.ami_id != null ? var.ami_id : data.aws_ami.al2023_arm64[0].id
+  subnet_id = var.subnet_id != null ? var.subnet_id : data.aws_subnets.default.ids[0]
+
+  common_tags = {
+    Project     = var.project
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# ---------- Security Group ----------
+
+resource "aws_security_group" "app" {
+  name_prefix = "${var.project}-app-"
+  description = "Bindersnap prod: HTTP/S inbound, all outbound"
+  vpc_id      = data.aws_vpc.selected.id
+
+  tags = merge(local.common_tags, { Name = "${var.project}-app" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https" {
+  security_group_id = aws_security_group.app.id
+  description       = "HTTPS from anywhere (Caddy terminates TLS)"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  security_group_id = aws_security_group.app.id
+  description       = "HTTP from anywhere (Caddy redirects to HTTPS)"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh" {
+  count = length(var.allowed_ssh_cidrs)
+
+  security_group_id = aws_security_group.app.id
+  description       = "SSH from allowed CIDR"
+  cidr_ipv4         = var.allowed_ssh_cidrs[count.index]
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.app.id
+  description       = "All outbound"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+# ---------- IAM Instance Profile ----------
+
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "instance" {
+  name               = "${var.project}-${var.environment}-instance"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+  tags               = local.common_tags
+}
+
+# SSM Session Manager (replaces SSH for most ops)
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# CloudWatch agent (needed for disk metrics — concern #6)
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name = "${var.project}-${var.environment}-instance"
+  role = aws_iam_role.instance.name
+  tags = local.common_tags
+}
+
+# ---------- Elastic IP ----------
+
+resource "aws_eip" "app" {
+  domain = "vpc"
+  tags   = merge(local.common_tags, { Name = "${var.project}-app" })
+}
+
+# ---------- EBS Data Volume ----------
+# Retained on destroy to protect Gitea data.
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = data.aws_subnets.default.ids[0] != "" ? "${var.aws_region}a" : "${var.aws_region}a"
+  size              = var.data_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+
+  tags = merge(local.common_tags, {
+    Name   = "${var.project}-data"
+    Backup = "daily" # Picked up by DLM policy in backups module
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# ---------- EC2 Instance ----------
+
+resource "aws_instance" "app" {
+  ami                    = local.ami_id
+  instance_type          = var.instance_type
+  subnet_id              = local.subnet_id
+  vpc_security_group_ids = [aws_security_group.app.id]
+  iam_instance_profile   = aws_iam_instance_profile.instance.name
+  key_name               = var.key_pair_name
+
+  user_data                   = file("${path.module}/user-data.sh")
+  user_data_replace_on_change = false
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required" # IMDSv2 only
+  }
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  tags = merge(local.common_tags, { Name = "${var.project}-app" })
+
+  lifecycle {
+    ignore_changes = [ami, user_data] # Prevent accidental rebuilds on AMI rotation
+  }
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name = var.data_volume_device_name
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.app.id
+}
+
+resource "aws_eip_association" "app" {
+  instance_id   = aws_instance.app.id
+  allocation_id = aws_eip.app.id
+}
+
+# ---------- Outputs ----------
+
+output "instance_id" {
+  description = "EC2 instance ID (consumed by monitoring and CI modules)"
+  value       = aws_instance.app.id
+}
+
+output "instance_public_ip" {
+  description = "Elastic IP address"
+  value       = aws_eip.app.public_ip
+}
+
+output "instance_role_name" {
+  description = "IAM role name (consumed by secrets and backups modules for policy attachment)"
+  value       = aws_iam_role.instance.name
+}
+
+output "instance_profile_name" {
+  description = "IAM instance profile name"
+  value       = aws_iam_instance_profile.instance.name
+}
+
+output "security_group_id" {
+  description = "Security group ID"
+  value       = aws_security_group.app.id
+}
+
+output "data_volume_id" {
+  description = "EBS data volume ID (consumed by backups module for DLM tagging)"
+  value       = aws_ebs_volume.data.id
+}
+
+output "eip_allocation_id" {
+  description = "Elastic IP allocation ID (for Route53 A records)"
+  value       = aws_eip.app.id
+}

--- a/infra/compute/terraform.tfvars.example
+++ b/infra/compute/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Copy to terraform.tfvars and fill in real values.
+# terraform.tfvars is gitignored — never commit it.
+
+aws_region          = "us-east-1"
+instance_type       = "t4g.small"
+data_volume_size_gb = 20
+# ami_id            = null          # null = auto-discover latest AL2023 ARM64
+# key_pair_name     = "my-key"      # optional, prefer SSM Session Manager
+# vpc_id            = null          # null = default VPC
+# subnet_id         = null          # null = first default subnet
+# allowed_ssh_cidrs = ["1.2.3.4/32"]

--- a/infra/compute/user-data.sh
+++ b/infra/compute/user-data.sh
@@ -8,6 +8,37 @@ COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
 
 install -d -m 0755 "${APP_DIR}"
 
+# --- CloudWatch Agent (disk + memory metrics) ---
+if ! command -v amazon-cloudwatch-agent-ctl &>/dev/null; then
+  yum install -y amazon-cloudwatch-agent 2>/dev/null || dnf install -y amazon-cloudwatch-agent 2>/dev/null || true
+fi
+
+if command -v amazon-cloudwatch-agent-ctl &>/dev/null; then
+  install -m 0644 /dev/stdin /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'CW_CONFIG'
+{
+  "agent": { "metrics_collection_interval": 300 },
+  "metrics": {
+    "namespace": "Bindersnap",
+    "append_dimensions": { "InstanceId": "${aws:InstanceId}" },
+    "metrics_collected": {
+      "disk": {
+        "measurement": ["used_percent"],
+        "metrics_collection_interval": 300,
+        "resources": ["/", "/data"],
+        "ignore_file_system_types": ["sysfs", "devtmpfs", "tmpfs", "squashfs", "overlay"]
+      },
+      "mem": {
+        "measurement": ["mem_used_percent"],
+        "metrics_collection_interval": 300
+      }
+    }
+  }
+}
+CW_CONFIG
+  amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 \
+    -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s
+fi
+
 cat >/usr/local/bin/bindersnap-refresh-env <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -81,6 +112,46 @@ ExecStart=/usr/local/bin/bindersnap-refresh-env
 WantedBy=multi-user.target
 SERVICE
 
+# Timer: re-fetch secrets every 6 hours and restart compose if the env file changed.
+# Catches rotated secrets without a reboot. Also triggerable manually:
+#   systemctl start bindersnap-refresh-and-restart.service
+cat >/etc/systemd/system/bindersnap-refresh-and-restart.service <<SERVICE
+[Unit]
+Description=Refresh SSM secrets and restart Bindersnap if env changed
+After=network-online.target docker.service
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=APP_DIR=${APP_DIR}
+Environment=ENV_FILE=${ENV_FILE}
+Environment=SSM_PARAMETER_PATH=${PARAMETER_PATH}
+ExecStart=/bin/bash -c '\
+  BEFORE=\$(sha256sum "\${ENV_FILE}" 2>/dev/null || echo "none"); \
+  /usr/local/bin/bindersnap-refresh-env; \
+  AFTER=\$(sha256sum "\${ENV_FILE}"); \
+  if [ "\$BEFORE" != "\$AFTER" ]; then \
+    echo "Env file changed — restarting compose stack"; \
+    cd ${APP_DIR} && docker compose --env-file ${ENV_FILE} -f ${COMPOSE_FILE} up -d; \
+  else \
+    echo "Env file unchanged — no restart needed"; \
+  fi'
+SERVICE
+
+cat >/etc/systemd/system/bindersnap-refresh-and-restart.timer <<TIMER
+[Unit]
+Description=Periodic SSM secret refresh for Bindersnap
+
+[Timer]
+OnCalendar=*-*-* 00/6:00:00
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMER
+
 cat >/etc/systemd/system/bindersnap-compose.service <<SERVICE
 [Unit]
 Description=Start the Bindersnap production Docker Compose stack
@@ -103,3 +174,4 @@ SERVICE
 systemctl daemon-reload
 systemctl enable --now bindersnap-refresh-env.service
 systemctl enable --now bindersnap-compose.service
+systemctl enable --now bindersnap-refresh-and-restart.timer

--- a/infra/monitoring/main.tf
+++ b/infra/monitoring/main.tf
@@ -6,6 +6,10 @@ terraform {
       version = "~> 5.0"
     }
   }
+
+  backend "s3" {
+    key = "monitoring/terraform.tfstate"
+  }
 }
 
 provider "aws" {
@@ -105,6 +109,59 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high_warning" {
   insufficient_data_actions = []
 
   tags = local.common_tags
+}
+
+# Disk usage alarm — requires CloudWatch agent emitting to Bindersnap namespace.
+# Triggers when any monitored mount (/, /data) exceeds 85% for 10 minutes.
+resource "aws_cloudwatch_metric_alarm" "disk_high" {
+  alarm_name          = "${var.project}-instance-disk-high"
+  alarm_description   = "Alert when disk usage exceeds 85% on any mount for 10+ minutes"
+  namespace           = "Bindersnap"
+  metric_name         = "disk_used_percent"
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 2
+  threshold           = 85
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    InstanceId = var.instance_id
+  }
+
+  tags = local.common_tags
+}
+
+# Memory usage alarm — bonus, since CW agent is already installed.
+resource "aws_cloudwatch_metric_alarm" "mem_high" {
+  alarm_name          = "${var.project}-instance-mem-high"
+  alarm_description   = "Alert when memory usage exceeds 90% for 10+ minutes"
+  namespace           = "Bindersnap"
+  metric_name         = "mem_used_percent"
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 2
+  threshold           = 90
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    InstanceId = var.instance_id
+  }
+
+  tags = local.common_tags
+}
+
+output "disk_high_alarm_name" {
+  description = "CloudWatch alarm name for disk usage"
+  value       = aws_cloudwatch_metric_alarm.disk_high.alarm_name
+}
+
+output "mem_high_alarm_name" {
+  description = "CloudWatch alarm name for memory usage"
+  value       = aws_cloudwatch_metric_alarm.mem_high.alarm_name
 }
 
 output "alerts_topic_arn" {

--- a/infra/monitoring/terraform.tfvars.example
+++ b/infra/monitoring/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Copy to terraform.tfvars and fill in real values.
+
+instance_id = "i-0123456789abcdef0"  # from: cd ../compute && terraform output instance_id
+alert_email = "alerts@bindersnap.com"
+# aws_region = "us-east-1"

--- a/infra/secrets/main.tf
+++ b/infra/secrets/main.tf
@@ -6,6 +6,10 @@ terraform {
       version = "~> 5.0"
     }
   }
+
+  backend "s3" {
+    key = "secrets/terraform.tfstate"
+  }
 }
 
 provider "aws" {

--- a/infra/secrets/terraform.tfvars.example
+++ b/infra/secrets/terraform.tfvars.example
@@ -1,0 +1,15 @@
+# Copy to terraform.tfvars and fill in real values.
+# THIS FILE CONTAINS SENSITIVE DEFAULTS — never commit the real terraform.tfvars.
+
+aws_region = "us-east-1"
+# ec2_instance_role_name = "bindersnap-prod-instance"  # from: cd ../compute && terraform output instance_role_name
+
+# Generate with: openssl rand -base64 32
+# gitea_secret_key     = "CHANGE_ME"
+# gitea_internal_token = "CHANGE_ME"
+
+# Bootstrap with: bun scripts/bootstrap-gitea-service-account.ts
+# gitea_service_token  = "CHANGE_ME"
+
+bindersnap_user_email_domain = "users.bindersnap.com"
+# litestream_s3_bucket = "bindersnap-litestream-123456789012"  # from: cd ../backups && terraform output litestream_bucket_name

--- a/infra/state/.terraform.lock.hcl
+++ b/infra/state/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/state/backend.hcl.example
+++ b/infra/state/backend.hcl.example
@@ -1,0 +1,14 @@
+# Partial backend config for all Bindersnap Terraform modules.
+#
+# Copy this file to backend.hcl and fill in the values from:
+#   cd infra/state && terraform output
+#
+# Then init each module with:
+#   terraform init -backend-config=../state/backend.hcl
+#
+# Each module sets its own `key` in its backend block (e.g. "backups/terraform.tfstate").
+
+bucket         = "bindersnap-tfstate-REPLACE_WITH_ACCOUNT_ID"
+region         = "us-east-1"
+dynamodb_table = "bindersnap-tfstate-lock"
+encrypt        = true

--- a/infra/state/main.tf
+++ b/infra/state/main.tf
@@ -1,0 +1,138 @@
+# Bootstrap module: S3 backend + DynamoDB lock table for Terraform state.
+#
+# This module uses LOCAL state intentionally — it's the one resource that
+# bootstraps everything else. Run once, then never touch it again.
+#
+# Usage:
+#   cd infra/state
+#   terraform init
+#   terraform apply -var="aws_account_id=123456789012"
+#
+# After apply, copy the backend config from the output into each module's
+# terraform { backend "s3" { ... } } block, or use the generated
+# backend.hcl partial config with: terraform init -backend-config=../state/backend.hcl
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  description = "AWS region for the state bucket and lock table"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID (used in bucket name for global uniqueness)"
+  type        = string
+}
+
+variable "project" {
+  description = "Project name for resource tagging"
+  type        = string
+  default     = "bindersnap"
+}
+
+locals {
+  bucket_name = "${var.project}-tfstate-${var.aws_account_id}"
+  table_name  = "${var.project}-tfstate-lock"
+  common_tags = {
+    Project = var.project
+    Purpose = "Terraform state management"
+  }
+}
+
+# --- S3 bucket for state files ---
+
+resource "aws_s3_bucket" "state" {
+  bucket = local.bucket_name
+  tags   = local.common_tags
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket                  = aws_s3_bucket.state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+  rule {
+    id     = "expire-old-state-versions"
+    status = "Enabled"
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+}
+
+# --- DynamoDB table for state locking ---
+
+resource "aws_dynamodb_table" "lock" {
+  name         = local.table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = local.common_tags
+}
+
+# --- Outputs ---
+
+output "bucket_name" {
+  description = "S3 bucket name for Terraform state"
+  value       = aws_s3_bucket.state.id
+}
+
+output "bucket_arn" {
+  description = "S3 bucket ARN for Terraform state"
+  value       = aws_s3_bucket.state.arn
+}
+
+output "lock_table_name" {
+  description = "DynamoDB table name for state locking"
+  value       = aws_dynamodb_table.lock.name
+}
+
+output "backend_config" {
+  description = "Copy this block into each module's terraform { backend \"s3\" { ... } } section"
+  value       = <<-EOT
+    bucket         = "${local.bucket_name}"
+    region         = "${var.aws_region}"
+    dynamodb_table = "${local.table_name}"
+    encrypt        = true
+  EOT
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindersnap-editor-demo",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "scripts": {
@@ -36,6 +36,9 @@
     "test:integration": "bunx playwright test --config=playwright.config.ts",
     "test:unit": "bun test",
     "up": "docker compose up --build",
+    "tf:bootstrap": "bash infra/bootstrap.sh",
+    "tf:apply": "bash infra/apply-all.sh",
+    "tf:plan": "bash infra/apply-all.sh plan",
     "version": "auto-changelog -p && git add CHANGELOG.md"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test:integration": "bunx playwright test --config=playwright.config.ts",
     "test:unit": "bun test",
     "up": "docker compose up --build",
-    "tf:bootstrap": "bash infra/bootstrap.sh",
     "tf:apply": "bash infra/apply-all.sh",
+    "tf:bootstrap": "bash infra/bootstrap.sh",
     "tf:plan": "bash infra/apply-all.sh plan",
     "version": "auto-changelog -p && git add CHANGELOG.md"
   },


### PR DESCRIPTION
## Summary

Addresses all 6 concerns from the external architecture assessment. No application code changes — infra only.

- **Remote state** — new `infra/state/` bootstrap module creates S3 bucket + DynamoDB lock table. All 5 existing modules now use `backend "s3"` with a shared `backend.hcl` partial config. `bun run tf:bootstrap` handles first-time setup.
- **EC2 compute module** — instance, security group, EBS data volume, IAM instance profile, and elastic IP are now fully managed in `infra/compute/main.tf`. Data volume uses `prevent_destroy` to protect Gitea data.
- **tfvars defaults** — every module gets a `.tfvars.example` with comments pointing to upstream `terraform output` commands for cross-module values. `terraform.tfvars` and `*.tfstate` added to `.gitignore`.
- **Secret refresh timer** — new systemd timer runs every 6h, checksums `.env.prod` before/after SSM fetch, only restarts compose if values actually changed. Also manually triggerable.
- **Cross-module wiring** — `infra/apply-all.sh` chains `terraform apply` in dependency order, piping outputs as `-var` flags. `bun run tf:plan` and `bun run tf:apply` wrap it.
- **Disk + memory alarms** — CloudWatch agent installed via `user-data.sh`, emitting `disk_used_percent` and `mem_used_percent` to a `Bindersnap` namespace. Alarms fire at 85% disk / 90% memory to the existing SNS topic.

## Test plan

- [ ] `bun run tf:bootstrap` creates state bucket + lock table (first-time only)
- [ ] `bun run tf:plan` runs all modules without errors
- [ ] `bun run tf:apply` provisions compute + wires outputs to downstream modules
- [ ] Verify EBS volume tagged `Backup=daily` (picked up by existing DLM policy)
- [ ] Rotate an SSM secret → wait 6h (or `systemctl start bindersnap-refresh-and-restart`) → confirm new value in `.env.prod`
- [ ] Confirm CloudWatch metrics appear in `Bindersnap` namespace after ~5 min
- [ ] Fill EBS past 85% in staging → verify SNS alert fires