### PR TITLE
Fix production SPA API host resolution

### DIFF
--- a/apps/app/api-base-url.build.test.ts
+++ b/apps/app/api-base-url.build.test.ts
@@ -58,7 +58,9 @@ test("production build inlines the configured API base URL origin", () => {
   const jsFiles = collectJavaScriptFiles(outDir);
   expect(jsFiles.length).toBeGreaterThan(0);
 
-  const emittedJs = jsFiles.map((file) => readFileSync(file, "utf8")).join("\n");
+  const emittedJs = jsFiles
+    .map((file) => readFileSync(file, "utf8"))
+    .join("\n");
   expect(emittedJs).toContain(expectedOrigin);
 });
 

--- a/apps/app/api-base-url.build.test.ts
+++ b/apps/app/api-base-url.build.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const expectedOrigin = "https://api.bindersnap.com";
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "bindersnap-app-build-"));
+const outDir = path.join(tempDir, "dist");
+
+function collectJavaScriptFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...collectJavaScriptFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && fullPath.endsWith(".js")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+beforeAll(() => {
+  const buildCommand = [
+    "BUN_PUBLIC_API_BASE_URL='https://api.bindersnap.com'",
+    "bun build ./apps/app/index.html",
+    `--outdir ${JSON.stringify(outDir)}`,
+    "--target=browser",
+    "--minify",
+    "--splitting",
+    "--production",
+    "--env='BUN_PUBLIC_*'",
+  ].join(" ");
+
+  const result = Bun.spawnSync({
+    cmd: ["/bin/sh", "-lc", buildCommand],
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `bun build failed with exit code ${result.exitCode}\n${Buffer.from(result.stderr).toString()}`,
+    );
+  }
+});
+
+test("production build inlines the configured API base URL origin", () => {
+  const jsFiles = collectJavaScriptFiles(outDir);
+  expect(jsFiles.length).toBeGreaterThan(0);
+
+  const emittedJs = jsFiles.map((file) => readFileSync(file, "utf8")).join("\n");
+  expect(emittedJs).toContain(expectedOrigin);
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});

--- a/apps/app/api.ts
+++ b/apps/app/api.ts
@@ -17,19 +17,18 @@ import type {
 } from "../../packages/gitea-client/uploads";
 import { validateUploadFile as validateUploadFileWithClient } from "../../packages/gitea-client/uploads";
 
-type ImportMetaEnv = Record<string, string | undefined>;
-
-const appEnv = (import.meta as ImportMeta & { env?: ImportMetaEnv }).env;
 const isLocalHost =
   window.location.hostname === "localhost" ||
   window.location.hostname === "127.0.0.1";
+const configuredApiBaseUrl =
+  process.env.BUN_PUBLIC_API_BASE_URL ??
+  process.env.BUN_PUBLIC_API_URL ??
+  process.env.VITE_API_URL;
 const devDefaultApiBaseUrl = `${window.location.protocol}//${window.location.hostname}:${
-  appEnv?.BUN_PUBLIC_API_PORT ?? appEnv?.API_PORT ?? "8787"
+  process.env.BUN_PUBLIC_API_PORT ?? process.env.API_PORT ?? "8787"
 }`;
 const API_BASE_URL = (
-  appEnv?.BUN_PUBLIC_API_BASE_URL ??
-  appEnv?.BUN_PUBLIC_API_URL ??
-  appEnv?.VITE_API_URL ??
+  configuredApiBaseUrl ??
   (isLocalHost ? devDefaultApiBaseUrl : "")
 ).replace(/\/$/, "");
 

--- a/apps/app/api.ts
+++ b/apps/app/api.ts
@@ -20,16 +20,30 @@ import { validateUploadFile as validateUploadFileWithClient } from "../../packag
 const isLocalHost =
   window.location.hostname === "localhost" ||
   window.location.hostname === "127.0.0.1";
-const configuredApiBaseUrl =
-  process.env.BUN_PUBLIC_API_BASE_URL ??
-  process.env.BUN_PUBLIC_API_URL ??
-  process.env.VITE_API_URL;
+
+// Production builds: `bun build --env='BUN_PUBLIC_*'` replaces process.env.*
+// with literal strings. Dev mode (Bun HMR): process is undefined in the
+// browser, so we fall back to import.meta.env which Bun populates at runtime.
+const _hasProcess = typeof process !== "undefined";
+type ImportMetaEnv = Record<string, string | undefined>;
+const _env = (import.meta as ImportMeta & { env?: ImportMetaEnv }).env;
+
+const configuredApiBaseUrl: string | undefined =
+  (_hasProcess ? process.env.BUN_PUBLIC_API_BASE_URL : undefined) ??
+  (_hasProcess ? process.env.BUN_PUBLIC_API_URL : undefined) ??
+  (_hasProcess ? process.env.VITE_API_URL : undefined) ??
+  _env?.BUN_PUBLIC_API_BASE_URL ??
+  _env?.BUN_PUBLIC_API_URL ??
+  _env?.VITE_API_URL;
 const devDefaultApiBaseUrl = `${window.location.protocol}//${window.location.hostname}:${
-  process.env.BUN_PUBLIC_API_PORT ?? process.env.API_PORT ?? "8787"
+  (_hasProcess ? process.env.BUN_PUBLIC_API_PORT : undefined) ??
+  (_hasProcess ? process.env.API_PORT : undefined) ??
+  _env?.BUN_PUBLIC_API_PORT ??
+  _env?.API_PORT ??
+  "8787"
 }`;
 const API_BASE_URL = (
-  configuredApiBaseUrl ??
-  (isLocalHost ? devDefaultApiBaseUrl : "")
+  configuredApiBaseUrl ?? (isLocalHost ? devDefaultApiBaseUrl : "")
 ).replace(/\/$/, "");
 
 export interface SessionUser {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindersnap-editor-demo",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- switch the SPA API base URL resolver to `process.env.BUN_PUBLIC_*` so Bun inlines `https://api.bindersnap.com` into the production bundle
- keep the localhost fallback behavior for local development when no public API origin is configured
- add a build regression test that asserts the production bundle contains the configured API origin

## Verification
- `bun test apps/app/api-base-url.build.test.ts`
- `bun test apps/app`
