### PR TITLE
Harden production Gitea service-token bootstrap and self-heal prod host files

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -13,8 +13,9 @@ GITEA_SERVICE_TOKEN=BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts
 BINDERSNAP_USER_EMAIL_DOMAIN=users.bindersnap.com
 LITESTREAM_S3_BUCKET=bindersnap-litestream-REPLACE_WITH_ACCOUNT_ID
 
-# Optional first-boot-only overrides for the Gitea container.
-# Keep these out of SSM after bootstrap and rotation.
+# First-boot-only values the EC2 bootstrap flow reads from SSM.
+# The refresh script stops writing them to /opt/bindersnap/.env.prod once
+# the service token has been minted.
 # GITEA_ADMIN_USER=gitea-admin
 # GITEA_ADMIN_PASS=SET_MANUALLY_FOR_INITIAL_GITEA_BOOTSTRAP_ONLY
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,26 @@ placeholders for the SSM-backed values and documents the non-secret runtime
 overrides that can still be passed at deploy time.
 
 The production API now expects `GITEA_SERVICE_TOKEN` in that generated env file.
-Create or rotate it with:
+During a fresh Terraform-backed deploy, the EC2 first-boot sequence now
+detects the placeholder value, starts Gitea with the first-boot admin
+credentials from SSM, runs `scripts/bootstrap-gitea-service-account.ts` in a
+throwaway Bun container, writes the real token back to
+`/bindersnap/prod/gitea_service_token`, refreshes `/opt/bindersnap/.env.prod`,
+and only then starts the API.
+
+To support that flow, set these secrets in `infra/secrets/terraform.tfvars`
+before `infra/apply-all.sh apply`:
+
+```hcl
+gitea_admin_user = "gitea-admin"
+gitea_admin_pass = "REPLACE_WITH_OPENSSL_OUTPUT"
+```
+
+`infra/apply-all.sh apply` now also dispatches the same bootstrap over AWS SSM
+to the current prod instance after the secrets module is applied, so existing
+instances pick up the service token without needing an EC2 rebuild.
+
+Manual create or rotation is still available with:
 
 ```bash
 bun scripts/bootstrap-gitea-service-account.ts
@@ -110,8 +129,9 @@ bun scripts/bootstrap-gitea-service-account.ts
 The bootstrap script uses `GITEA_ADMIN_USER` and `GITEA_ADMIN_PASS` only long
 enough to ensure the `bindersnap-service` account exists, grant admin, mint a
 `write:admin` PAT, and write it to `/bindersnap/prod/gitea_service_token`.
-Those admin credentials should remain break-glass only and stay out of the
-steady-state SSM contract after bootstrap.
+After the token is real, the env refresh script stops writing those admin
+credentials into `/opt/bindersnap/.env.prod`, so the steady-state compose stack
+does not keep them in its runtime env file.
 
 ## Production Backups
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -79,6 +79,7 @@ services:
     environment:
       - API_PORT=8787
       - PORT=8787
+      - NODE_ENV=production
       - GITEA_INTERNAL_URL=http://gitea:3000
       - BINDERSNAP_GITEA_SERVICE_TOKEN=${GITEA_SERVICE_TOKEN:?set in the generated env file}
       - BINDERSNAP_APP_ORIGIN=https://bindersnap.com

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -62,6 +62,8 @@ The target instance must already satisfy these conditions:
 - It matches the deploy target tag used by the workflow.
 - `/opt/bindersnap` contains `docker-compose.prod.yml`, `Caddyfile.prod`, and `litestream.yml` (written by `user-data.sh.tftpl` at first boot — no git clone needed).
 - `/opt/bindersnap/.env.prod` exists (generated from SSM Parameter Store by the `bindersnap-refresh-env` systemd service at boot).
+- `infra/secrets/terraform.tfvars` provided `gitea_admin_user` and `gitea_admin_pass` so the first boot can mint `/bindersnap/prod/gitea_service_token` automatically before the API starts.
+- `infra/apply-all.sh apply` can reach the instance through AWS Systems Manager so it can run the bootstrap flow remotely on existing instances after the secrets module updates.
 - Docker and the Compose plugin are installed (handled by `user-data.sh.tftpl`).
 - The host can pull `ghcr.io/davidgraymi/bindersnap-api` (if the package is private, add `ghcr_token` and optionally `ghcr_user` to the SSM parameters under `/bindersnap/prod/`).
 

--- a/infra/apply-all.sh
+++ b/infra/apply-all.sh
@@ -42,6 +42,128 @@ tf_output() {
   fi
 }
 
+# Returns 0 (true) if the Gitea service token SSM parameter still holds the
+# bootstrap placeholder and the bootstrap therefore needs to run.
+# Returns 1 (false) if a real token is already stored, so the bootstrap can be
+# skipped entirely without dispatching any SSM command.
+needs_service_token_bootstrap() {
+  local ssm_path="$1"
+  local parameter="${ssm_path}/gitea_service_token"
+  local placeholder="BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts"
+  local current_value
+
+  if ! command -v aws >/dev/null 2>&1; then
+    # No AWS CLI locally — assume bootstrap is needed; the function itself will
+    # emit a warning if it cannot proceed.
+    return 0
+  fi
+
+  current_value="$(
+    aws ssm get-parameter \
+      --name "${parameter}" \
+      --with-decryption \
+      --query 'Parameter.Value' \
+      --output text 2>/dev/null
+  )" || true  # treat a missing parameter the same as the placeholder
+
+  if [[ -z "${current_value}" || "${current_value}" == "${placeholder}" ]]; then
+    return 0  # needs bootstrap
+  fi
+
+  return 1  # already bootstrapped
+}
+
+bootstrap_service_token_via_ssm() {
+  local instance_id="$1"
+  local commands_file
+  local script_b64
+  local caddyfile_b64
+  local command_id
+  local status
+  local stdout
+  local stderr
+  local attempt
+
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "WARNING: aws CLI not found locally; skipping remote service-token bootstrap."
+    return 0
+  fi
+
+  script_b64="$(
+    base64 <"${SCRIPT_DIR}/../scripts/bootstrap-gitea-service-account.ts" | tr -d '\n'
+  )"
+  caddyfile_b64="$(
+    base64 <"${SCRIPT_DIR}/../Caddyfile.prod" | tr -d '\n'
+  )"
+  commands_file="$(mktemp)"
+
+  bun "${SCRIPT_DIR}/../scripts/bootstrap-gitea-service-account.ts" \
+    print-ssm-commands \
+    --script-b64 "${script_b64}" \
+    --caddyfile-b64 "${caddyfile_b64}" \
+    >"${commands_file}"
+
+  echo "--- Bootstrapping Gitea service token on instance ${instance_id} via SSM ---"
+  command_id=""
+  for attempt in $(seq 1 12); do
+    command_id="$(
+      aws ssm send-command \
+        --instance-ids "${instance_id}" \
+        --document-name "AWS-RunShellScript" \
+        --comment "Bindersnap Gitea service-token bootstrap" \
+        --parameters "file://${commands_file}" \
+        --query 'Command.CommandId' \
+        --output text 2>/dev/null
+    )" && break
+
+    echo "  SSM command dispatch not ready yet (attempt ${attempt}/12); retrying in 10s..."
+    sleep 10
+  done
+
+  rm -f "${commands_file}"
+
+  if [[ -z "${command_id}" ]]; then
+    echo "ERROR: unable to dispatch the remote bootstrap command via SSM."
+    exit 1
+  fi
+
+  aws ssm wait command-executed --command-id "${command_id}" --instance-id "${instance_id}" || true
+
+  status="$(
+    aws ssm get-command-invocation \
+      --command-id "${command_id}" \
+      --instance-id "${instance_id}" \
+      --query 'Status' \
+      --output text
+  )"
+  stdout="$(
+    aws ssm get-command-invocation \
+      --command-id "${command_id}" \
+      --instance-id "${instance_id}" \
+      --query 'StandardOutputContent' \
+      --output text
+  )"
+  stderr="$(
+    aws ssm get-command-invocation \
+      --command-id "${command_id}" \
+      --instance-id "${instance_id}" \
+      --query 'StandardErrorContent' \
+      --output text
+  )"
+
+  if [[ -n "${stdout}" && "${stdout}" != "None" ]]; then
+    echo "${stdout}"
+  fi
+
+  if [[ "${status}" != "Success" ]]; then
+    if [[ -n "${stderr}" && "${stderr}" != "None" ]]; then
+      echo "${stderr}" >&2
+    fi
+    echo "ERROR: remote bootstrap command finished with status ${status}."
+    exit 1
+  fi
+}
+
 tf_run() {
   local dir="$1"
   shift
@@ -110,6 +232,15 @@ echo "  Compute outputs: instance=${INSTANCE_ID} role=${INSTANCE_ROLE} volume=${
 
 # 2. Secrets (needs instance role for policy attachment)
 tf_run "secrets" "ec2_instance_role_name=${INSTANCE_ROLE}"
+
+SSM_PATH="$(tf_output secrets ssm_parameter_path)"
+SSM_PATH="${SSM_PATH:-/bindersnap/prod}"
+
+if needs_service_token_bootstrap "${SSM_PATH}"; then
+  bootstrap_service_token_via_ssm "${INSTANCE_ID}"
+else
+  echo "  Gitea service token already bootstrapped — skipping remote bootstrap."
+fi
 
 # 3. Backups (needs instance role + volume ID)
 tf_run "backups" \

--- a/infra/compute/main.tf
+++ b/infra/compute/main.tf
@@ -284,10 +284,11 @@ resource "aws_instance" "app" {
   key_name               = var.key_pair_name
 
   user_data_base64 = base64gzip(templatefile("${path.module}/user-data.sh.tftpl", {
-    compose_b64        = base64encode(file("${path.root}/../../docker-compose.prod.yml"))
-    caddyfile_b64      = base64encode(file("${path.root}/../../Caddyfile.prod"))
-    litestream_b64     = base64encode(file("${path.root}/../../litestream.yml"))
-    ssm_parameter_path = var.ssm_parameter_path
+    compose_b64          = base64encode(file("${path.root}/../../docker-compose.prod.yml"))
+    caddyfile_b64        = base64encode(file("${path.root}/../../Caddyfile.prod"))
+    litestream_b64       = base64encode(file("${path.root}/../../litestream.yml"))
+    bootstrap_script_b64 = base64encode(file("${path.root}/../../scripts/bootstrap-gitea-service-account.ts"))
+    ssm_parameter_path   = var.ssm_parameter_path
   }))
   user_data_replace_on_change = false
 

--- a/infra/compute/user-data.sh.tftpl
+++ b/infra/compute/user-data.sh.tftpl
@@ -87,6 +87,10 @@ chmod 0644 "$${APP_DIR}/Caddyfile.prod"
 echo '${litestream_b64}' | base64 -d > "$${APP_DIR}/litestream.yml"
 chmod 0644 "$${APP_DIR}/litestream.yml"
 
+install -d -m 0755 "$${APP_DIR}/scripts"
+echo '${bootstrap_script_b64}' | base64 -d > "$${APP_DIR}/scripts/bootstrap-gitea-service-account.ts"
+chmod 0644 "$${APP_DIR}/scripts/bootstrap-gitea-service-account.ts"
+
 # ---------- CloudWatch Agent (disk + memory metrics) ----------
 
 if ! command -v amazon-cloudwatch-agent-ctl &>/dev/null; then
@@ -130,6 +134,7 @@ ENV_FILE="$${ENV_FILE:-$${APP_DIR}/.env.prod}"
 PARAMETER_PATH="$${SSM_PARAMETER_PATH:-/bindersnap/prod}"
 TMP_FILE="$(mktemp "$${ENV_FILE}.XXXXXX")"
 JSON_FILE="$(mktemp "$${ENV_FILE}.json.XXXXXX")"
+BOOTSTRAP_TOKEN_PLACEHOLDER="BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts"
 
 cleanup() {
   rm -f "$${TMP_FILE}" "$${JSON_FILE}"
@@ -150,11 +155,19 @@ import json
 import sys
 
 prefix = sys.argv[1].rstrip("/")
+bootstrap_placeholder = sys.argv[2]
 payload = json.load(sys.stdin)
 parameters = sorted(payload.get("Parameters", []), key=lambda item: item["Name"])
 
 if not parameters:
     raise SystemExit(f"No SSM parameters found under {prefix}")
+
+token_value = None
+for item in parameters:
+    name = item["Name"]
+    if name == f"{prefix}/gitea_service_token":
+        token_value = item["Value"]
+        break
 
 for item in parameters:
     name = item["Name"]
@@ -164,8 +177,14 @@ for item in parameters:
     if "\n" in value:
         raise SystemExit(f"{name} contains a newline and cannot be written to a Docker env file")
     env_name = name.rsplit("/", 1)[-1].replace("-", "_").upper()
+    if (
+        token_value
+        and token_value != bootstrap_placeholder
+        and env_name in {"GITEA_ADMIN_USER", "GITEA_ADMIN_PASS"}
+    ):
+        continue
     print(f"{env_name}={value}")
-' "$${PARAMETER_PATH}" <"$${JSON_FILE}" >"$${TMP_FILE}"
+' "$${PARAMETER_PATH}" "$${BOOTSTRAP_TOKEN_PLACEHOLDER}" <"$${JSON_FILE}" >"$${TMP_FILE}"
 
 install -d -m 0755 "$${APP_DIR}"
 install -m 0600 "$${TMP_FILE}" "$${ENV_FILE}"
@@ -207,6 +226,111 @@ SCRIPT
 
 chmod 0755 /usr/local/bin/bindersnap-ghcr-login
 
+# ---------- Gitea service-token bootstrap ----------
+
+cat >/usr/local/bin/bindersnap-bootstrap-gitea <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="$${APP_DIR:-/opt/bindersnap}"
+ENV_FILE="$${ENV_FILE:-$${APP_DIR}/.env.prod}"
+COMPOSE_FILE="$${COMPOSE_FILE:-docker-compose.prod.yml}"
+PARAMETER_PATH="$${SSM_PARAMETER_PATH:-/bindersnap/prod}"
+AWS_REGION="$${AWS_REGION:-us-east-1}"
+BOOTSTRAP_TOKEN_PLACEHOLDER="BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts"
+GITEA_CONTAINER_NAME="$${GITEA_CONTAINER_NAME:-bindersnap-gitea-prod}"
+COMPOSE_NETWORK="$${COMPOSE_NETWORK:-bindersnap-prod}"
+GITEA_CONFIG="$${GITEA_CONFIG:-/data/gitea/conf/app.ini}"
+GITEA_EXEC_USER="$${GITEA_EXEC_USER:-1000:1000}"
+
+if [ ! -f "$${ENV_FILE}" ]; then
+  echo "Env file $${ENV_FILE} not found"
+  exit 1
+fi
+
+SERVICE_TOKEN="$(grep '^GITEA_SERVICE_TOKEN=' "$${ENV_FILE}" | cut -d= -f2- || true)"
+if [ -z "$${SERVICE_TOKEN}" ]; then
+  echo "No GITEA_SERVICE_TOKEN in $${ENV_FILE}"
+  exit 1
+fi
+
+if [ "$${SERVICE_TOKEN}" != "$${BOOTSTRAP_TOKEN_PLACEHOLDER}" ]; then
+  echo "Gitea service token already bootstrapped"
+  exit 0
+fi
+
+set -a
+. "$${ENV_FILE}"
+set +a
+
+if [ -z "$${GITEA_ADMIN_USER:-}" ] || [ -z "$${GITEA_ADMIN_PASS:-}" ]; then
+  echo "GITEA_ADMIN_USER and GITEA_ADMIN_PASS are required while the service token is still a bootstrap placeholder"
+  exit 1
+fi
+
+cd "$${APP_DIR}"
+docker compose --env-file "$${ENV_FILE}" -f "$${COMPOSE_FILE}" up -d gitea
+
+for _ in $(seq 1 60); do
+  STATUS="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$${GITEA_CONTAINER_NAME}" 2>/dev/null || true)"
+  if [ "$${STATUS}" = "healthy" ]; then
+    break
+  fi
+  sleep 5
+done
+
+STATUS="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$${GITEA_CONTAINER_NAME}" 2>/dev/null || true)"
+if [ "$${STATUS}" != "healthy" ]; then
+  echo "Gitea did not become ready in time"
+  exit 1
+fi
+
+GITEA_ADMIN_EMAIL="$${GITEA_ADMIN_EMAIL:-$${GITEA_ADMIN_USER}@$${BINDERSNAP_USER_EMAIL_DOMAIN:-users.bindersnap.com}}"
+if ! docker exec --user "$${GITEA_EXEC_USER}" "$${GITEA_CONTAINER_NAME}" \
+  gitea --config "$${GITEA_CONFIG}" admin user create \
+    --username "$${GITEA_ADMIN_USER}" \
+    --password "$${GITEA_ADMIN_PASS}" \
+    --email "$${GITEA_ADMIN_EMAIL}" \
+    --admin \
+    --must-change-password=false; then
+  docker exec --user "$${GITEA_EXEC_USER}" "$${GITEA_CONTAINER_NAME}" \
+    gitea --config "$${GITEA_CONFIG}" admin user change-password \
+      --username "$${GITEA_ADMIN_USER}" \
+      --password "$${GITEA_ADMIN_PASS}" \
+      --must-change-password=false
+fi
+
+docker run --rm \
+  --network "$${COMPOSE_NETWORK}" \
+  -e GITEA_ADMIN_USER \
+  -e GITEA_ADMIN_PASS \
+  -e GITEA_INTERNAL_URL="http://gitea:3000" \
+  -e BINDERSNAP_USER_EMAIL_DOMAIN="$${BINDERSNAP_USER_EMAIL_DOMAIN:-users.bindersnap.com}" \
+  -v "$${APP_DIR}:/workspace" \
+  -w /workspace \
+  oven/bun:1 \
+  bun scripts/bootstrap-gitea-service-account.ts mint-token > "$${APP_DIR}/.gitea-service-token.tmp"
+
+SERVICE_TOKEN="$(tr -d '\r\n' < "$${APP_DIR}/.gitea-service-token.tmp")"
+rm -f "$${APP_DIR}/.gitea-service-token.tmp"
+
+if [ -z "$${SERVICE_TOKEN}" ]; then
+  echo "mint-token returned an empty token"
+  exit 1
+fi
+
+aws ssm put-parameter \
+  --name "$${PARAMETER_PATH}/gitea_service_token" \
+  --type SecureString \
+  --value "$${SERVICE_TOKEN}" \
+  --overwrite \
+  --region "$${AWS_REGION}"
+
+/usr/local/bin/bindersnap-refresh-env
+SCRIPT
+
+chmod 0755 /usr/local/bin/bindersnap-bootstrap-gitea
+
 # ---------- Systemd units ----------
 
 cat >/etc/systemd/system/bindersnap-refresh-env.service <<SERVICE
@@ -244,6 +368,7 @@ Environment=SSM_PARAMETER_PATH=$${PARAMETER_PATH}
 ExecStart=/bin/bash -c '\
   BEFORE=\$(sha256sum "\$${ENV_FILE}" 2>/dev/null || echo "none"); \
   /usr/local/bin/bindersnap-refresh-env; \
+  /usr/local/bin/bindersnap-bootstrap-gitea; \
   AFTER=\$(sha256sum "\$${ENV_FILE}"); \
   if [ "\$BEFORE" != "\$AFTER" ]; then \
     echo "Env file changed — restarting compose stack"; \
@@ -281,12 +406,32 @@ ExecStart=/usr/local/bin/bindersnap-ghcr-login
 WantedBy=multi-user.target
 SERVICE
 
+cat >/etc/systemd/system/bindersnap-bootstrap-gitea.service <<SERVICE
+[Unit]
+Description=Bootstrap the Bindersnap Gitea service token on first boot
+ConditionPathExists=$${ENV_FILE}
+After=network-online.target docker.service bindersnap-refresh-env.service
+Requires=docker.service bindersnap-refresh-env.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=APP_DIR=$${APP_DIR}
+Environment=ENV_FILE=$${ENV_FILE}
+Environment=COMPOSE_FILE=$${COMPOSE_FILE}
+Environment=SSM_PARAMETER_PATH=$${PARAMETER_PATH}
+ExecStart=/usr/local/bin/bindersnap-bootstrap-gitea
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
 cat >/etc/systemd/system/bindersnap-compose.service <<SERVICE
 [Unit]
 Description=Start the Bindersnap production Docker Compose stack
 ConditionPathExists=$${APP_DIR}/$${COMPOSE_FILE}
-After=network-online.target docker.service bindersnap-refresh-env.service bindersnap-ghcr-login.service
-Requires=docker.service bindersnap-refresh-env.service
+After=network-online.target docker.service bindersnap-refresh-env.service bindersnap-ghcr-login.service bindersnap-bootstrap-gitea.service
+Requires=docker.service bindersnap-refresh-env.service bindersnap-bootstrap-gitea.service
 Wants=network-online.target bindersnap-ghcr-login.service
 
 [Service]
@@ -303,5 +448,6 @@ SERVICE
 systemctl daemon-reload
 systemctl enable --now bindersnap-refresh-env.service
 systemctl enable --now bindersnap-ghcr-login.service
+systemctl enable --now bindersnap-bootstrap-gitea.service
 systemctl enable --now bindersnap-compose.service
 systemctl enable --now bindersnap-refresh-and-restart.timer

--- a/infra/secrets/main.tf
+++ b/infra/secrets/main.tf
@@ -67,6 +67,20 @@ variable "gitea_service_token" {
   default     = "BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts"
 }
 
+variable "gitea_admin_user" {
+  description = "First-boot Gitea admin username used to bootstrap the bindersnap-service account"
+  type        = string
+  sensitive   = true
+  default     = "gitea-admin"
+}
+
+variable "gitea_admin_pass" {
+  description = "First-boot Gitea admin password used to bootstrap the bindersnap-service account"
+  type        = string
+  sensitive   = true
+  default     = "CHANGE_ME_USE_openssl_rand_base64_20"
+}
+
 variable "bindersnap_user_email_domain" {
   description = "Placeholder email domain used when creating signup email addresses in Gitea"
   type        = string
@@ -88,12 +102,15 @@ locals {
     gitea_secret_key             = var.gitea_secret_key
     gitea_internal_token         = var.gitea_internal_token
     gitea_service_token          = var.gitea_service_token
+    gitea_admin_user             = var.gitea_admin_user
+    gitea_admin_pass             = var.gitea_admin_pass
     bindersnap_user_email_domain = var.bindersnap_user_email_domain
     litestream_s3_bucket         = var.litestream_s3_bucket
   }
 
-  parameter_arn_base   = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${local.parameter_path}"
-  parameter_arn_prefix = "${local.parameter_arn_base}/*"
+  parameter_arn_base         = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${local.parameter_path}"
+  parameter_arn_prefix       = "${local.parameter_arn_base}/*"
+  service_token_parameter_arn = "${local.parameter_arn_base}/gitea_service_token"
 }
 
 resource "aws_kms_key" "ssm" {
@@ -142,6 +159,19 @@ data "aws_iam_policy_document" "instance_ssm_access" {
   }
 
   statement {
+    sid    = "WriteBindersnapServiceTokenParameter"
+    effect = "Allow"
+
+    actions = [
+      "ssm:PutParameter",
+    ]
+
+    resources = [
+      local.service_token_parameter_arn,
+    ]
+  }
+
+  statement {
     sid    = "DecryptBindersnapProdParameters"
     effect = "Allow"
 
@@ -166,11 +196,39 @@ data "aws_iam_policy_document" "instance_ssm_access" {
       values   = [local.parameter_arn_prefix]
     }
   }
+
+  statement {
+    sid    = "EncryptBindersnapServiceTokenParameter"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:DescribeKey",
+    ]
+
+    resources = [
+      aws_kms_key.ssm.arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.aws_region}.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:EncryptionContext:PARAMETER_ARN"
+      values   = [local.service_token_parameter_arn]
+    }
+  }
 }
 
 resource "aws_iam_policy" "instance_ssm_access" {
-  name        = "${var.project}-${var.environment}-ssm-read"
-  description = "Read-only access to the Bindersnap production Parameter Store path"
+  name        = "${var.project}-${var.environment}-ssm-access"
+  description = "Read access to the Bindersnap production Parameter Store path plus service-token bootstrap writes"
   policy      = data.aws_iam_policy_document.instance_ssm_access.json
 
   tags = {
@@ -191,7 +249,7 @@ output "ssm_parameter_path" {
 }
 
 output "instance_ssm_access_policy_arn" {
-  description = "IAM policy ARN granting the EC2 role read access to the production SSM path"
+  description = "IAM policy ARN granting the EC2 role production SSM access plus service-token bootstrap writes"
   value       = aws_iam_policy.instance_ssm_access.arn
 }
 

--- a/infra/secrets/terraform.tfvars.example
+++ b/infra/secrets/terraform.tfvars.example
@@ -8,6 +8,11 @@ aws_region = "us-east-1"
 # gitea_secret_key     = "CHANGE_ME"
 # gitea_internal_token = "CHANGE_ME"
 
+# First-boot admin used by the EC2 bootstrap flow to mint the service token.
+# Generate with: openssl rand -base64 20
+# gitea_admin_user = "gitea-admin"
+# gitea_admin_pass = "CHANGE_ME"
+
 # Bootstrap with: bun scripts/bootstrap-gitea-service-account.ts
 # gitea_service_token  = "CHANGE_ME"
 

--- a/scripts/bootstrap-gitea-service-account.test.ts
+++ b/scripts/bootstrap-gitea-service-account.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+  BOOTSTRAP_SERVICE_TOKEN_PLACEHOLDER,
+  buildRemoteBootstrapCommands,
   buildPutParameterArgs,
   DEFAULT_SERVICE_ACCOUNT_USERNAME,
   DEFAULT_SERVICE_TOKEN_NAME,
+  renderDockerEnvFromSsmPayload,
   resolveBootstrapConfig,
   resolveServiceTokenScopes,
   resolveSsmParameterName,
@@ -48,6 +51,19 @@ describe("bootstrap-gitea-service-account", () => {
     );
   });
 
+  test("uses the service username as the login_name fallback for hosted Gitea users", () => {
+    const config = resolveBootstrapConfig({
+      GITEA_ADMIN_USER: "gitea-admin",
+      GITEA_ADMIN_PASS: "break-glass",
+      GITEA_INTERNAL_URL: "http://gitea:3000",
+    });
+
+    expect(config.serviceUsername).toBe(DEFAULT_SERVICE_ACCOUNT_USERNAME);
+    expect(config.serviceEmail).toBe(
+      `${DEFAULT_SERVICE_ACCOUNT_USERNAME}@users.bindersnap.local`,
+    );
+  });
+
   test("builds the aws put-parameter command with an optional region", () => {
     expect(
       buildPutParameterArgs(
@@ -69,5 +85,72 @@ describe("bootstrap-gitea-service-account", () => {
       "--region",
       "us-east-1",
     ]);
+  });
+
+  test("exports the production bootstrap placeholder token value", () => {
+    expect(BOOTSTRAP_SERVICE_TOKEN_PLACEHOLDER).toBe(
+      "BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts",
+    );
+  });
+
+  test("renders a Docker env file from SSM payloads and hides bootstrap-only admin creds after token rotation", () => {
+    const rendered = renderDockerEnvFromSsmPayload(
+      {
+        Parameters: [
+          {
+            Name: "/bindersnap/prod/gitea_admin_user",
+            Value: "gitea-admin",
+          },
+          {
+            Name: "/bindersnap/prod/gitea_admin_pass",
+            Value: "break-glass",
+          },
+          {
+            Name: "/bindersnap/prod/gitea_service_token",
+            Value: "real-token",
+          },
+          {
+            Name: "/bindersnap/prod/litestream_s3_bucket",
+            Value: "bindersnap-litestream-123",
+          },
+        ],
+      },
+      "/bindersnap/prod",
+    );
+
+    expect(rendered).toContain("GITEA_SERVICE_TOKEN=real-token");
+    expect(rendered).toContain(
+      "LITESTREAM_S3_BUCKET=bindersnap-litestream-123",
+    );
+    expect(rendered).not.toContain("GITEA_ADMIN_USER=");
+    expect(rendered).not.toContain("GITEA_ADMIN_PASS=");
+  });
+
+  test("builds remote bootstrap commands without embedding inline python", () => {
+    const commands = buildRemoteBootstrapCommands("ZHVtbXk=", "Y2FkZHk=");
+
+    expect(commands.some((command) => command.includes("python3 -c"))).toBe(
+      false,
+    );
+    expect(
+      commands.some((command) => command.includes("render-env")),
+    ).toBe(true);
+    expect(
+      commands.some((command) =>
+        command.includes("bun scripts/bootstrap-gitea-service-account.ts"),
+      ),
+    ).toBe(true);
+    expect(
+      commands.some((command) => command.includes("docker exec --user")),
+    ).toBe(true);
+    expect(
+      commands.some((command) => command.includes("mint-token")),
+    ).toBe(true);
+    expect(
+      commands.some((command) => command.includes("aws ssm put-parameter")),
+    ).toBe(true);
+    expect(
+      commands.some((command) => command.includes('"$APP_DIR/Caddyfile.prod"')),
+    ).toBe(true);
   });
 });

--- a/scripts/bootstrap-gitea-service-account.test.ts
+++ b/scripts/bootstrap-gitea-service-account.test.ts
@@ -132,9 +132,9 @@ describe("bootstrap-gitea-service-account", () => {
     expect(commands.some((command) => command.includes("python3 -c"))).toBe(
       false,
     );
-    expect(
-      commands.some((command) => command.includes("render-env")),
-    ).toBe(true);
+    expect(commands.some((command) => command.includes("render-env"))).toBe(
+      true,
+    );
     expect(
       commands.some((command) =>
         command.includes("bun scripts/bootstrap-gitea-service-account.ts"),
@@ -143,9 +143,9 @@ describe("bootstrap-gitea-service-account", () => {
     expect(
       commands.some((command) => command.includes("docker exec --user")),
     ).toBe(true);
-    expect(
-      commands.some((command) => command.includes("mint-token")),
-    ).toBe(true);
+    expect(commands.some((command) => command.includes("mint-token"))).toBe(
+      true,
+    );
     expect(
       commands.some((command) => command.includes("aws ssm put-parameter")),
     ).toBe(true);

--- a/scripts/bootstrap-gitea-service-account.ts
+++ b/scripts/bootstrap-gitea-service-account.ts
@@ -63,7 +63,9 @@ export function resolveSsmParameterName(parameterPathRaw?: string): string {
 }
 
 function resolveParameterPath(parameterPathRaw?: string): string {
-  return parameterPathRaw?.trim().replace(/\/+$/, "") || DEFAULT_SSM_PARAMETER_PATH;
+  return (
+    parameterPathRaw?.trim().replace(/\/+$/, "") || DEFAULT_SSM_PARAMETER_PATH
+  );
 }
 
 function parameterNameToEnvName(parameterName: string): string {
@@ -167,16 +169,16 @@ export function buildRemoteBootstrapCommands(
     'TMP_ENV="$(mktemp "$ENV_FILE.XXXXXX")"',
     'TMP_JSON="$(mktemp "$ENV_FILE.json.XXXXXX")"',
     'cleanup() { rm -f "$TMP_ENV" "$TMP_JSON"; }',
-    'trap cleanup EXIT',
+    "trap cleanup EXIT",
     'aws ssm get-parameters-by-path --path "$PARAMETER_PATH" --recursive --with-decryption --output json > "$TMP_JSON"',
     'docker run --rm -i -v "$APP_DIR:/workspace" -w /workspace oven/bun:1 bun scripts/bootstrap-gitea-service-account.ts render-env --parameter-path "$PARAMETER_PATH" < "$TMP_JSON" > "$TMP_ENV"',
     'install -m 0600 "$TMP_ENV" "$ENV_FILE"',
-    'SERVICE_TOKEN=$(grep \'^GITEA_SERVICE_TOKEN=\' "$ENV_FILE" | cut -d= -f2- || true)',
+    "SERVICE_TOKEN=$(grep '^GITEA_SERVICE_TOKEN=' \"$ENV_FILE\" | cut -d= -f2- || true)",
     'if [ -z "$SERVICE_TOKEN" ]; then echo "GITEA_SERVICE_TOKEN is missing from $ENV_FILE"; exit 1; fi',
     'if [ "$SERVICE_TOKEN" != "$BOOTSTRAP_TOKEN_PLACEHOLDER" ]; then echo "Gitea service token already bootstrapped"; exit 0; fi',
-    'set -a',
+    "set -a",
     '. "$ENV_FILE"',
-    'set +a',
+    "set +a",
     'if [ -z "${GITEA_ADMIN_USER:-}" ] || [ -z "${GITEA_ADMIN_PASS:-}" ]; then echo "GITEA_ADMIN_USER and GITEA_ADMIN_PASS are required while the service token is still a bootstrap placeholder"; exit 1; fi',
     'cd "$APP_DIR"',
     'docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d gitea',
@@ -471,9 +473,12 @@ async function main(): Promise<void> {
   }
 
   if (command === "mint-token") {
-    const token = await ensureServiceUserAndRotateToken(resolveBootstrapConfig(), {
-      log: false,
-    });
+    const token = await ensureServiceUserAndRotateToken(
+      resolveBootstrapConfig(),
+      {
+        log: false,
+      },
+    );
     process.stdout.write(`${token}\n`);
     return;
   }

--- a/scripts/bootstrap-gitea-service-account.ts
+++ b/scripts/bootstrap-gitea-service-account.ts
@@ -7,6 +7,8 @@ export const DEFAULT_SERVICE_TOKEN_NAME = "bindersnap-api-service";
 export const DEFAULT_SSM_PARAMETER_PATH = "/bindersnap/prod";
 export const DEFAULT_SERVICE_ACCOUNT_EMAIL_DOMAIN = "users.bindersnap.local";
 export const DEFAULT_SERVICE_TOKEN_SCOPES = ["write:admin"] as const;
+export const BOOTSTRAP_SERVICE_TOKEN_PLACEHOLDER =
+  "BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts";
 
 type BootstrapConfig = {
   giteaUrl: string;
@@ -23,6 +25,15 @@ type BootstrapConfig = {
 
 type GiteaApiErrorPayload = {
   message?: unknown;
+};
+
+type SsmParameter = {
+  Name: string;
+  Value: string;
+};
+
+type SsmParametersByPathPayload = {
+  Parameters?: SsmParameter[];
 };
 
 function requireEnv(env: NodeJS.ProcessEnv, name: string): string {
@@ -51,6 +62,60 @@ export function resolveSsmParameterName(parameterPathRaw?: string): string {
   return `${trimmedPath}/gitea_service_token`;
 }
 
+function resolveParameterPath(parameterPathRaw?: string): string {
+  return parameterPathRaw?.trim().replace(/\/+$/, "") || DEFAULT_SSM_PARAMETER_PATH;
+}
+
+function parameterNameToEnvName(parameterName: string): string {
+  return parameterName.split("/").at(-1)!.replaceAll("-", "_").toUpperCase();
+}
+
+export function renderDockerEnvFromSsmPayload(
+  payload: SsmParametersByPathPayload,
+  parameterPathRaw?: string,
+  bootstrapPlaceholder = BOOTSTRAP_SERVICE_TOKEN_PLACEHOLDER,
+): string {
+  const parameterPath = resolveParameterPath(parameterPathRaw);
+  const parameters = [...(payload.Parameters ?? [])].sort((a, b) =>
+    a.Name.localeCompare(b.Name),
+  );
+
+  if (parameters.length === 0) {
+    throw new Error(`No SSM parameters found under ${parameterPath}`);
+  }
+
+  const tokenParameterName = `${parameterPath}/gitea_service_token`;
+  const tokenValue = parameters.find(
+    (parameter) => parameter.Name === tokenParameterName,
+  )?.Value;
+
+  const lines: string[] = [];
+  for (const parameter of parameters) {
+    if (!parameter.Name.startsWith(`${parameterPath}/`)) {
+      continue;
+    }
+
+    if (parameter.Value.includes("\n")) {
+      throw new Error(
+        `${parameter.Name} contains a newline and cannot be written to a Docker env file`,
+      );
+    }
+
+    const envName = parameterNameToEnvName(parameter.Name);
+    if (
+      tokenValue &&
+      tokenValue !== bootstrapPlaceholder &&
+      (envName === "GITEA_ADMIN_USER" || envName === "GITEA_ADMIN_PASS")
+    ) {
+      continue;
+    }
+
+    lines.push(`${envName}=${parameter.Value}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
 export function buildPutParameterArgs(
   parameterName: string,
   value: string,
@@ -74,6 +139,60 @@ export function buildPutParameterArgs(
   }
 
   return args;
+}
+
+export function buildRemoteBootstrapCommands(
+  scriptBase64: string,
+  caddyfileBase64?: string,
+): string[] {
+  return [
+    "set -euo pipefail",
+    "APP_DIR=/opt/bindersnap",
+    "ENV_FILE=$APP_DIR/.env.prod",
+    "COMPOSE_FILE=$APP_DIR/docker-compose.prod.yml",
+    'PARAMETER_PATH="${SSM_PARAMETER_PATH:-/bindersnap/prod}"',
+    `BOOTSTRAP_TOKEN_PLACEHOLDER=${BOOTSTRAP_SERVICE_TOKEN_PLACEHOLDER}`,
+    'if ! command -v aws >/dev/null 2>&1; then echo "aws CLI is missing on the instance"; exit 1; fi',
+    'if [ ! -f "$COMPOSE_FILE" ]; then echo "docker-compose.prod.yml is missing on the instance"; exit 1; fi',
+    'mkdir -p "$APP_DIR/scripts"',
+    `echo "${scriptBase64}" | base64 -d > "$APP_DIR/scripts/bootstrap-gitea-service-account.ts"`,
+    'chmod 0644 "$APP_DIR/scripts/bootstrap-gitea-service-account.ts"',
+    ...(caddyfileBase64
+      ? [
+          'if [ -d "$APP_DIR/Caddyfile.prod" ]; then rm -rf "$APP_DIR/Caddyfile.prod"; fi',
+          `echo "${caddyfileBase64}" | base64 -d > "$APP_DIR/Caddyfile.prod"`,
+          'chmod 0644 "$APP_DIR/Caddyfile.prod"',
+        ]
+      : []),
+    'TMP_ENV="$(mktemp "$ENV_FILE.XXXXXX")"',
+    'TMP_JSON="$(mktemp "$ENV_FILE.json.XXXXXX")"',
+    'cleanup() { rm -f "$TMP_ENV" "$TMP_JSON"; }',
+    'trap cleanup EXIT',
+    'aws ssm get-parameters-by-path --path "$PARAMETER_PATH" --recursive --with-decryption --output json > "$TMP_JSON"',
+    'docker run --rm -i -v "$APP_DIR:/workspace" -w /workspace oven/bun:1 bun scripts/bootstrap-gitea-service-account.ts render-env --parameter-path "$PARAMETER_PATH" < "$TMP_JSON" > "$TMP_ENV"',
+    'install -m 0600 "$TMP_ENV" "$ENV_FILE"',
+    'SERVICE_TOKEN=$(grep \'^GITEA_SERVICE_TOKEN=\' "$ENV_FILE" | cut -d= -f2- || true)',
+    'if [ -z "$SERVICE_TOKEN" ]; then echo "GITEA_SERVICE_TOKEN is missing from $ENV_FILE"; exit 1; fi',
+    'if [ "$SERVICE_TOKEN" != "$BOOTSTRAP_TOKEN_PLACEHOLDER" ]; then echo "Gitea service token already bootstrapped"; exit 0; fi',
+    'set -a',
+    '. "$ENV_FILE"',
+    'set +a',
+    'if [ -z "${GITEA_ADMIN_USER:-}" ] || [ -z "${GITEA_ADMIN_PASS:-}" ]; then echo "GITEA_ADMIN_USER and GITEA_ADMIN_PASS are required while the service token is still a bootstrap placeholder"; exit 1; fi',
+    'cd "$APP_DIR"',
+    'docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d gitea',
+    `for _ in $(seq 1 60); do STATUS=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' bindersnap-gitea-prod 2>/dev/null || true); if [ "$STATUS" = "healthy" ]; then break; fi; sleep 5; done`,
+    `STATUS=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' bindersnap-gitea-prod 2>/dev/null || true)`,
+    'if [ "$STATUS" != "healthy" ]; then echo "Gitea did not become ready in time"; exit 1; fi',
+    'GITEA_ADMIN_EMAIL="${GITEA_ADMIN_EMAIL:-${GITEA_ADMIN_USER}@${BINDERSNAP_USER_EMAIL_DOMAIN:-users.bindersnap.com}}"',
+    'if ! docker exec --user "${GITEA_EXEC_USER:-1000:1000}" bindersnap-gitea-prod gitea --config /data/gitea/conf/app.ini admin user create --username "$GITEA_ADMIN_USER" --password "$GITEA_ADMIN_PASS" --email "$GITEA_ADMIN_EMAIL" --admin --must-change-password=false; then docker exec --user "${GITEA_EXEC_USER:-1000:1000}" bindersnap-gitea-prod gitea --config /data/gitea/conf/app.ini admin user change-password --username "$GITEA_ADMIN_USER" --password "$GITEA_ADMIN_PASS" --must-change-password=false; fi',
+    'SERVICE_TOKEN=$(docker run --rm --network bindersnap-prod -e GITEA_ADMIN_USER -e GITEA_ADMIN_PASS -e GITEA_INTERNAL_URL=http://gitea:3000 -e BINDERSNAP_USER_EMAIL_DOMAIN="${BINDERSNAP_USER_EMAIL_DOMAIN:-users.bindersnap.com}" -v "$APP_DIR:/workspace" -w /workspace oven/bun:1 bun scripts/bootstrap-gitea-service-account.ts mint-token)',
+    'if [ -z "$SERVICE_TOKEN" ]; then echo "mint-token returned an empty token"; exit 1; fi',
+    'aws ssm put-parameter --name "$PARAMETER_PATH/gitea_service_token" --type SecureString --value "$SERVICE_TOKEN" --overwrite --region "${AWS_REGION:-us-east-1}"',
+    'aws ssm get-parameters-by-path --path "$PARAMETER_PATH" --recursive --with-decryption --output json > "$TMP_JSON"',
+    'docker run --rm -i -v "$APP_DIR:/workspace" -w /workspace oven/bun:1 bun scripts/bootstrap-gitea-service-account.ts render-env --parameter-path "$PARAMETER_PATH" < "$TMP_JSON" > "$TMP_ENV"',
+    'install -m 0600 "$TMP_ENV" "$ENV_FILE"',
+    'docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d api caddy',
+  ];
 }
 
 export function resolveBootstrapConfig(env = process.env): BootstrapConfig {
@@ -157,6 +276,7 @@ async function ensureServiceUser(config: BootstrapConfig): Promise<void> {
     method: "POST",
     body: JSON.stringify({
       username: config.serviceUsername,
+      login_name: config.serviceUsername,
       email: config.serviceEmail,
       password: config.servicePassword,
       must_change_password: false,
@@ -186,7 +306,7 @@ async function ensureServiceUser(config: BootstrapConfig): Promise<void> {
       method: "PATCH",
       body: JSON.stringify({
         admin: true,
-        login_name: "",
+        login_name: config.serviceUsername,
         source_id: 0,
       }),
     },
@@ -249,6 +369,27 @@ async function rotateServiceToken(config: BootstrapConfig): Promise<string> {
   return payload.sha1.trim();
 }
 
+async function ensureServiceUserAndRotateToken(
+  config: BootstrapConfig,
+  options?: { log?: boolean },
+): Promise<string> {
+  const log = options?.log ?? true;
+
+  if (log) {
+    console.log(
+      `Ensuring Gitea service account ${config.serviceUsername} exists at ${config.giteaUrl}`,
+    );
+  }
+  await ensureServiceUser(config);
+
+  if (log) {
+    console.log(
+      `Rotating PAT ${config.serviceTokenName} with scopes: ${config.serviceTokenScopes.join(", ")}`,
+    );
+  }
+  return rotateServiceToken(config);
+}
+
 function writeTokenToSsm(config: BootstrapConfig, serviceToken: string): void {
   const result = Bun.spawnSync(
     buildPutParameterArgs(
@@ -273,15 +414,9 @@ function writeTokenToSsm(config: BootstrapConfig, serviceToken: string): void {
 export async function bootstrapGiteaServiceAccount(
   config = resolveBootstrapConfig(),
 ): Promise<void> {
-  console.log(
-    `Ensuring Gitea service account ${config.serviceUsername} exists at ${config.giteaUrl}`,
-  );
-  await ensureServiceUser(config);
-
-  console.log(
-    `Rotating PAT ${config.serviceTokenName} with scopes: ${config.serviceTokenScopes.join(", ")}`,
-  );
-  const serviceToken = await rotateServiceToken(config);
+  const serviceToken = await ensureServiceUserAndRotateToken(config, {
+    log: true,
+  });
 
   console.log(`Writing ${config.ssmParameterName} to SSM Parameter Store`);
   writeTokenToSsm(config, serviceToken);
@@ -292,8 +427,62 @@ export async function bootstrapGiteaServiceAccount(
   );
 }
 
+function readRequiredOption(args: string[], name: string): string {
+  const index = args.indexOf(name);
+  const value = index >= 0 ? args[index + 1] : undefined;
+  if (!value) {
+    throw new Error(`Missing required option: ${name}`);
+  }
+
+  return value;
+}
+
+async function readStdinText(): Promise<string> {
+  return Bun.file("/dev/stdin").text();
+}
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2);
+
+  if (!command) {
+    await bootstrapGiteaServiceAccount();
+    return;
+  }
+
+  if (command === "render-env") {
+    const parameterPath = readRequiredOption(args, "--parameter-path");
+    const input = await readStdinText();
+    const payload = JSON.parse(input) as SsmParametersByPathPayload;
+    process.stdout.write(renderDockerEnvFromSsmPayload(payload, parameterPath));
+    return;
+  }
+
+  if (command === "print-ssm-commands") {
+    const scriptBase64 = readRequiredOption(args, "--script-b64");
+    const caddyfileIndex = args.indexOf("--caddyfile-b64");
+    const caddyfileBase64 =
+      caddyfileIndex >= 0 ? args[caddyfileIndex + 1] : undefined;
+    process.stdout.write(
+      JSON.stringify({
+        commands: buildRemoteBootstrapCommands(scriptBase64, caddyfileBase64),
+      }),
+    );
+    return;
+  }
+
+  if (command === "mint-token") {
+    const token = await ensureServiceUserAndRotateToken(resolveBootstrapConfig(), {
+      log: false,
+    });
+    process.stdout.write(`${token}\n`);
+    return;
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}
+
 if (import.meta.main) {
-  bootstrapGiteaServiceAccount().catch((error) => {
+  main().catch((error) => {
     console.error(
       error instanceof Error ? error.message : "Bootstrap failed unexpectedly.",
     );

--- a/scripts/ssm-parameter-store.test.ts
+++ b/scripts/ssm-parameter-store.test.ts
@@ -22,17 +22,23 @@ describe("SSM Parameter Store production wiring", () => {
     expect(secretsTerraform).toContain("gitea_secret_key");
     expect(secretsTerraform).toContain("gitea_internal_token");
     expect(secretsTerraform).toContain("gitea_service_token");
+    expect(secretsTerraform).toContain("gitea_admin_user");
+    expect(secretsTerraform).toContain("gitea_admin_pass");
     expect(secretsTerraform).toContain("bindersnap_user_email_domain");
     expect(secretsTerraform).toContain("litestream_s3_bucket");
   });
 
   test("limits the instance role to the production SSM path and KMS key", () => {
     expect(secretsTerraform).toContain("ssm:GetParametersByPath");
+    expect(secretsTerraform).toContain("ssm:PutParameter");
     expect(secretsTerraform).toContain("kms:Decrypt");
+    expect(secretsTerraform).toContain("kms:Encrypt");
+    expect(secretsTerraform).toContain("kms:GenerateDataKey");
     expect(secretsTerraform).toContain("kms:DescribeKey");
     expect(secretsTerraform).toContain('parameter${local.parameter_path}"');
     expect(secretsTerraform).toContain("local.parameter_arn_base,");
     expect(secretsTerraform).toContain("local.parameter_arn_prefix,");
+    expect(secretsTerraform).toContain("local.service_token_parameter_arn");
     expect(secretsTerraform).toContain("kms:EncryptionContext:PARAMETER_ARN");
     expect(secretsTerraform).toContain('variable "ec2_instance_role_name"');
     expect(secretsTerraform).not.toContain('resources = ["*"]');
@@ -45,6 +51,21 @@ describe("SSM Parameter Store production wiring", () => {
     expect(userData).toContain("chmod 600");
     expect(userData).toContain("chown root:root");
     expect(userData).toContain("bindersnap-refresh-env.service");
+    expect(userData).toContain("bindersnap-bootstrap-gitea.service");
+    expect(userData).toContain(
+      "BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts",
+    );
+    expect(userData).toContain(
+      'docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" up -d gitea',
+    );
+    expect(userData).toContain("gitea --config");
+    expect(userData).toContain('docker exec --user "${GITEA_EXEC_USER}"');
+    expect(userData).toContain("admin user create");
+    expect(userData).toContain("admin user change-password");
+    expect(userData).toContain(
+      "bun scripts/bootstrap-gitea-service-account.ts mint-token",
+    );
+    expect(userData).toContain("aws ssm put-parameter");
     expect(userData).toContain("bindersnap-compose.service");
     expect(userData).toContain(
       "docker compose --env-file ${ENV_FILE} -f ${COMPOSE_FILE} up -d",
@@ -60,6 +81,10 @@ describe("SSM Parameter Store production wiring", () => {
     );
     expect(envExample).toContain(
       `${giteaServiceTokenKey}=BOOTSTRAP_WITH_scripts/bootstrap-gitea-service-account.ts`,
+    );
+    expect(envExample).toContain("# GITEA_ADMIN_USER=gitea-admin");
+    expect(envExample).toContain(
+      "# GITEA_ADMIN_PASS=SET_MANUALLY_FOR_INITIAL_GITEA_BOOTSTRAP_ONLY",
     );
     expect(envExample).toContain("LITESTREAM_S3_BUCKET=bindersnap-litestream-");
     expect(composeFile).toContain(

--- a/services/api/logger.ts
+++ b/services/api/logger.ts
@@ -1,0 +1,70 @@
+/**
+ * Structured JSON logger for the Bindersnap API service.
+ *
+ * Outputs one JSON line per entry to stdout so log aggregators (CloudWatch,
+ * Docker json-file driver, Loki, etc.) can ingest and query structured fields.
+ *
+ * Log levels (lowest → highest severity):
+ *   debug < info < warn < error
+ *
+ * The active level is controlled by the LOG_LEVEL env var.
+ * Default: "info" in production (NODE_ENV=production), "debug" otherwise.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+function resolveActiveLevel(): LogLevel {
+  const raw = process.env.LOG_LEVEL?.trim().toLowerCase();
+  if (raw === "debug" || raw === "info" || raw === "warn" || raw === "error") {
+    return raw;
+  }
+  return process.env.NODE_ENV === "production" ? "info" : "debug";
+}
+
+const activeLevel: LogLevel = resolveActiveLevel();
+const activeLevelRank: number = LEVEL_RANK[activeLevel];
+
+export type LogMeta = Record<string, unknown>;
+
+function emit(level: LogLevel, message: string, meta?: LogMeta): void {
+  if (LEVEL_RANK[level] < activeLevelRank) {
+    return;
+  }
+
+  const entry: Record<string, unknown> = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...meta,
+  };
+
+  // console.log writes to stdout; console.error writes to stderr.
+  // We keep everything on stdout so a single log stream is captured by Docker /
+  // CloudWatch without mixing channels.
+  process.stdout.write(JSON.stringify(entry) + "\n");
+}
+
+export const logger = {
+  debug(message: string, meta?: LogMeta): void {
+    emit("debug", message, meta);
+  },
+
+  info(message: string, meta?: LogMeta): void {
+    emit("info", message, meta);
+  },
+
+  warn(message: string, meta?: LogMeta): void {
+    emit("warn", message, meta);
+  },
+
+  error(message: string, meta?: LogMeta): void {
+    emit("error", message, meta);
+  },
+};

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -429,12 +429,15 @@ function enforceStateChangingOrigin(
 
   const sourceOrigin = requestSourceOrigin(req);
   if (!isAllowedOrigin(sourceOrigin)) {
-    logger.warn("CORS rejected: origin not allowed for state-changing request", {
-      method: req.method,
-      path: new URL(req.url).pathname,
-      origin: sourceOrigin,
-      clientIp: requestClientIp(req),
-    });
+    logger.warn(
+      "CORS rejected: origin not allowed for state-changing request",
+      {
+        method: req.method,
+        path: new URL(req.url).pathname,
+        origin: sourceOrigin,
+        clientIp: requestClientIp(req),
+      },
+    );
     return json(403, { error: "Cross-site request blocked." }, baseHeaders);
   }
 
@@ -1030,8 +1033,7 @@ function responseFromError(
     return json(status, { error: err.message || fallback }, baseHeaders);
   }
 
-  const message =
-    err instanceof Error && err.message ? err.message : fallback;
+  const message = err instanceof Error && err.message ? err.message : fallback;
   logger.error("Unhandled route exception", {
     message,
     errorType: err instanceof Error ? err.constructor.name : typeof err,
@@ -2514,7 +2516,12 @@ export function createApiServer() {
       const origin = requestOrigin(req);
       const clientIp = requestClientIp(req);
 
-      logger.info("Incoming request", { method, path: pathname, origin, clientIp });
+      logger.info("Incoming request", {
+        method,
+        path: pathname,
+        origin,
+        clientIp,
+      });
 
       const baseHeaders = corsHeaders(req);
       const transportError = enforceTransportSecurity(req, baseHeaders);
@@ -2669,7 +2676,12 @@ export function createApiServer() {
           durationMs,
         });
       } else {
-        logger.info("Response sent", { method, path: pathname, status, durationMs });
+        logger.info("Response sent", {
+          method,
+          path: pathname,
+          status,
+          durationMs,
+        });
       }
 
       return response;

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 
+import { logger } from "./logger";
 import { sessionStore, type SessionRecord } from "./sessions";
 import {
   createGiteaClient,
@@ -81,8 +82,9 @@ const giteaServiceToken =
 const isProduction = process.env.NODE_ENV === "production";
 
 if (isProduction && !giteaServiceToken) {
-  console.error(
+  logger.error(
     "FATAL: BINDERSNAP_GITEA_SERVICE_TOKEN is not set in production",
+    { env: "production" },
   );
   process.exit(1);
 }
@@ -403,6 +405,13 @@ function enforceTransportSecurity(
     return null;
   }
 
+  logger.warn("Transport security rejected: HTTPS required", {
+    method: req.method,
+    path: new URL(req.url).pathname,
+    protocol: requestProtocol(req),
+    clientIp: requestClientIp(req),
+  });
+
   return json(400, { error: "HTTPS is required." }, baseHeaders);
 }
 
@@ -420,6 +429,12 @@ function enforceStateChangingOrigin(
 
   const sourceOrigin = requestSourceOrigin(req);
   if (!isAllowedOrigin(sourceOrigin)) {
+    logger.warn("CORS rejected: origin not allowed for state-changing request", {
+      method: req.method,
+      path: new URL(req.url).pathname,
+      origin: sourceOrigin,
+      clientIp: requestClientIp(req),
+    });
     return json(403, { error: "Cross-site request blocked." }, baseHeaders);
   }
 
@@ -998,16 +1013,32 @@ function responseFromError(
   fallback: string,
 ): Response {
   if (err instanceof GiteaApiError) {
-    return json(err.status, { error: err.message || fallback }, baseHeaders);
+    const status = err.status;
+    if (status >= 500) {
+      logger.error("Gitea API error (5xx)", {
+        status,
+        message: err.message || fallback,
+        errorType: "GiteaApiError",
+      });
+    } else {
+      logger.warn("Gitea API error (4xx)", {
+        status,
+        message: err.message || fallback,
+        errorType: "GiteaApiError",
+      });
+    }
+    return json(status, { error: err.message || fallback }, baseHeaders);
   }
 
-  return json(
-    500,
-    {
-      error: err instanceof Error && err.message ? err.message : fallback,
-    },
-    baseHeaders,
-  );
+  const message =
+    err instanceof Error && err.message ? err.message : fallback;
+  logger.error("Unhandled route exception", {
+    message,
+    errorType: err instanceof Error ? err.constructor.name : typeof err,
+    stack: err instanceof Error ? err.stack : undefined,
+  });
+
+  return json(500, { error: message }, baseHeaders);
 }
 
 async function verifyUserCredentials(
@@ -1378,8 +1409,20 @@ async function handleSignup(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
+  const clientIp = requestClientIp(req);
   const rateLimit = consumeAuthRateLimit(req, "signup");
+
+  logger.debug("Auth rate limit check (signup)", {
+    clientIp,
+    limited: rateLimit.limited,
+    retryAfterSeconds: rateLimit.retryAfterSeconds,
+  });
+
   if (rateLimit.limited) {
+    logger.warn("Rate limit hit on signup", {
+      clientIp,
+      retryAfterSeconds: rateLimit.retryAfterSeconds,
+    });
     return json(
       429,
       { error: "Too many signup attempts. Please try again shortly." },
@@ -1408,10 +1451,22 @@ async function handleSignup(
     );
   }
 
+  logger.debug("Attempting Gitea user creation", { username, clientIp });
+
   const created = await createGiteaUser(username, email, password);
   if (created !== "created") {
+    logger.warn("Gitea user creation failed during signup", {
+      username,
+      status: created.status,
+      error: created.error,
+    });
     return json(created.status, { error: created.error }, baseHeaders);
   }
+
+  logger.debug("Gitea user created; establishing session", {
+    username,
+    clientIp,
+  });
 
   const response = await createLoginSession(
     username,
@@ -1421,6 +1476,7 @@ async function handleSignup(
   );
   if (response.ok) {
     resetAuthRateLimit(req, "signup");
+    logger.debug("Session created after signup", { username, clientIp });
   }
   return response;
 }
@@ -1429,8 +1485,20 @@ async function handleLogin(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
+  const clientIp = requestClientIp(req);
   const rateLimit = consumeAuthRateLimit(req, "login");
+
+  logger.debug("Auth rate limit check (login)", {
+    clientIp,
+    limited: rateLimit.limited,
+    retryAfterSeconds: rateLimit.retryAfterSeconds,
+  });
+
   if (rateLimit.limited) {
+    logger.warn("Rate limit hit on login", {
+      clientIp,
+      retryAfterSeconds: rateLimit.retryAfterSeconds,
+    });
     return json(
       429,
       { error: "Too many login attempts. Please try again shortly." },
@@ -1468,22 +1536,42 @@ async function handleLogin(
     );
   }
 
+  logger.debug("Credential verification attempt", {
+    // Log the identifier type (email or username) but never the value itself
+    identifierType: looksLikeEmailAddress(identifier) ? "email" : "username",
+    rememberMe,
+    clientIp,
+  });
+
   const resolution = await resolveLoginUsername(
     identifier,
     emailCandidate,
     password,
   );
+
   if (resolution.kind === "unavailable") {
+    logger.warn("Login resolution unavailable", {
+      status: resolution.status,
+      error: resolution.error,
+      clientIp,
+    });
     return json(resolution.status, { error: resolution.error }, baseHeaders);
   }
 
   if (resolution.kind !== "authenticated") {
+    logger.debug("Login credential verification failed", { clientIp });
     return json(
       401,
       { error: "Invalid username, email, or password." },
       baseHeaders,
     );
   }
+
+  logger.debug("Credentials verified; establishing session", {
+    username: resolution.username,
+    rememberMe,
+    clientIp,
+  });
 
   const response = await createAuthenticatedSession(
     resolution.username,
@@ -1494,6 +1582,10 @@ async function handleLogin(
   );
   if (response.ok) {
     resetAuthRateLimit(req, "login");
+    logger.debug("Session created after login", {
+      username: resolution.username,
+      clientIp,
+    });
   }
   return response;
 }
@@ -1504,8 +1596,16 @@ async function handleLogout(
 ): Promise<Response> {
   const session = getSessionFromRequest(req);
   if (session) {
+    logger.debug("Revoking session on logout", {
+      username: session.username,
+      clientIp: requestClientIp(req),
+    });
     sessionStore.delete(session.id);
     await revokeUserToken(session);
+  } else {
+    logger.debug("Logout called with no active session", {
+      clientIp: requestClientIp(req),
+    });
   }
 
   const headers = mergeHeaders(baseHeaders, {
@@ -1521,8 +1621,16 @@ async function handleAuthMe(
 ): Promise<Response> {
   const session = getSessionFromRequest(req);
   if (!session) {
+    logger.debug("Auth/me: no valid session found", {
+      clientIp: requestClientIp(req),
+    });
     return json(401, { error: "Unauthorized." }, baseHeaders);
   }
+
+  logger.debug("Auth/me: session resolved", {
+    username: session.username,
+    clientIp: requestClientIp(req),
+  });
 
   return json(
     200,
@@ -1575,14 +1683,20 @@ async function handleDocuments(
             error: null,
           };
         } catch (err) {
+          const errorMessage =
+            err instanceof Error
+              ? err.message
+              : "Unable to load document details.";
+          logger.error("Failed to load details for repo", {
+            repo: repo.name,
+            owner: repo.owner?.login,
+            message: errorMessage,
+          });
           return {
             repo: normalizeWorkspaceRepoSummary(repo),
             latestTag: null,
             pendingPRs: [] as PullRequestWithApprovalState[],
-            error:
-              err instanceof Error
-                ? err.message
-                : "Unable to load document details.",
+            error: errorMessage,
           };
         }
       }),
@@ -2163,16 +2277,18 @@ async function handleDocumentDownload(
     );
 
     if (!response.ok) {
-      return json(
-        response.status,
-        {
-          error: await readGiteaErrorMessage(
-            response,
-            "Unable to download document.",
-          ),
-        },
-        baseHeaders,
+      const errorMessage = await readGiteaErrorMessage(
+        response,
+        "Unable to download document.",
       );
+      logger.error("Gitea fetch failure on document download", {
+        status: response.status,
+        owner,
+        repo,
+        ref,
+        message: errorMessage,
+      });
+      return json(response.status, { error: errorMessage }, baseHeaders);
     }
 
     return new Response(response.body, {
@@ -2392,150 +2508,171 @@ export function createApiServer() {
     port: apiPort,
     idleTimeout: 30,
     async fetch(req) {
+      const startMs = Date.now();
       const { pathname } = new URL(req.url);
+      const method = req.method;
+      const origin = requestOrigin(req);
+      const clientIp = requestClientIp(req);
+
+      logger.info("Incoming request", { method, path: pathname, origin, clientIp });
+
       const baseHeaders = corsHeaders(req);
       const transportError = enforceTransportSecurity(req, baseHeaders);
       if (transportError) {
+        const durationMs = Date.now() - startMs;
+        logger.info("Response sent", {
+          method,
+          path: pathname,
+          status: transportError.status,
+          durationMs,
+        });
         return transportError;
       }
 
       const originError = enforceStateChangingOrigin(req, baseHeaders);
       if (originError) {
+        const durationMs = Date.now() - startMs;
+        logger.info("Response sent", {
+          method,
+          path: pathname,
+          status: originError.status,
+          durationMs,
+        });
         return originError;
       }
 
-      if (req.method === "OPTIONS") {
+      if (method === "OPTIONS") {
+        const durationMs = Date.now() - startMs;
+        logger.info("Response sent", {
+          method,
+          path: pathname,
+          status: 204,
+          durationMs,
+        });
         return new Response(null, {
           status: 204,
           headers: baseHeaders,
         });
       }
 
-      if (pathname === "/auth/signup" && req.method === "POST") {
-        return handleSignup(req, baseHeaders);
-      }
+      let response: Response;
 
-      if (pathname === "/auth/login" && req.method === "POST") {
-        return handleLogin(req, baseHeaders);
-      }
-
-      if (pathname === "/auth/logout" && req.method === "POST") {
-        return handleLogout(req, baseHeaders);
-      }
-
-      if (pathname === "/auth/me" && req.method === "GET") {
-        return handleAuthMe(req, baseHeaders);
-      }
-
-      if (pathname === "/api/app/documents" && req.method === "GET") {
-        return handleDocuments(req, baseHeaders);
-      }
-
-      if (pathname === "/api/app/documents" && req.method === "POST") {
-        return handleCreateDocument(req, baseHeaders);
-      }
-
-      if (pathname === "/api/app/users/search" && req.method === "GET") {
-        return handleSearchUsersRoute(req, baseHeaders);
-      }
-
-      const reviewMatch = pathname.match(
-        /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/pull-requests\/(\d+)\/reviews$/,
-      );
-      if (reviewMatch && req.method === "POST") {
-        return handleDocumentReview(
-          req,
-          baseHeaders,
-          decodePathParam(reviewMatch[1] ?? ""),
-          decodePathParam(reviewMatch[2] ?? ""),
-          Number.parseInt(reviewMatch[3] ?? "", 10),
+      if (pathname === "/auth/signup" && method === "POST") {
+        response = await handleSignup(req, baseHeaders);
+      } else if (pathname === "/auth/login" && method === "POST") {
+        response = await handleLogin(req, baseHeaders);
+      } else if (pathname === "/auth/logout" && method === "POST") {
+        response = await handleLogout(req, baseHeaders);
+      } else if (pathname === "/auth/me" && method === "GET") {
+        response = await handleAuthMe(req, baseHeaders);
+      } else if (pathname === "/api/app/documents" && method === "GET") {
+        response = await handleDocuments(req, baseHeaders);
+      } else if (pathname === "/api/app/documents" && method === "POST") {
+        response = await handleCreateDocument(req, baseHeaders);
+      } else if (pathname === "/api/app/users/search" && method === "GET") {
+        response = await handleSearchUsersRoute(req, baseHeaders);
+      } else {
+        const reviewMatch = pathname.match(
+          /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/pull-requests\/(\d+)\/reviews$/,
         );
+        const publishMatch = pathname.match(
+          /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/pull-requests\/(\d+)\/publish$/,
+        );
+        const downloadMatch = pathname.match(
+          /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/download$/,
+        );
+        const versionsMatch = pathname.match(
+          /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/versions$/,
+        );
+        const collaboratorsActionMatch = pathname.match(
+          /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/collaborators\/([^/]+)$/,
+        );
+        const collaboratorsMatch = pathname.match(
+          /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/collaborators$/,
+        );
+        const documentMatch = pathname.match(
+          /^\/api\/app\/documents\/([^/]+)\/([^/]+)$/,
+        );
+
+        if (reviewMatch && method === "POST") {
+          response = await handleDocumentReview(
+            req,
+            baseHeaders,
+            decodePathParam(reviewMatch[1] ?? ""),
+            decodePathParam(reviewMatch[2] ?? ""),
+            Number.parseInt(reviewMatch[3] ?? "", 10),
+          );
+        } else if (publishMatch && method === "POST") {
+          response = await handleDocumentPublish(
+            req,
+            baseHeaders,
+            decodePathParam(publishMatch[1] ?? ""),
+            decodePathParam(publishMatch[2] ?? ""),
+            Number.parseInt(publishMatch[3] ?? "", 10),
+          );
+        } else if (downloadMatch && method === "GET") {
+          response = await handleDocumentDownload(
+            req,
+            baseHeaders,
+            decodePathParam(downloadMatch[1] ?? ""),
+            decodePathParam(downloadMatch[2] ?? ""),
+          );
+        } else if (versionsMatch && method === "POST") {
+          response = await handleDocumentVersions(
+            req,
+            baseHeaders,
+            decodePathParam(versionsMatch[1] ?? ""),
+            decodePathParam(versionsMatch[2] ?? ""),
+          );
+        } else if (collaboratorsActionMatch && method === "PUT") {
+          response = await handleAddCollaborator(
+            req,
+            baseHeaders,
+            decodePathParam(collaboratorsActionMatch[1] ?? ""),
+            decodePathParam(collaboratorsActionMatch[2] ?? ""),
+            decodePathParam(collaboratorsActionMatch[3] ?? ""),
+          );
+        } else if (collaboratorsActionMatch && method === "DELETE") {
+          response = await handleDeleteCollaborator(
+            req,
+            baseHeaders,
+            decodePathParam(collaboratorsActionMatch[1] ?? ""),
+            decodePathParam(collaboratorsActionMatch[2] ?? ""),
+            decodePathParam(collaboratorsActionMatch[3] ?? ""),
+          );
+        } else if (collaboratorsMatch && method === "GET") {
+          response = await handleDocumentCollaborators(
+            req,
+            baseHeaders,
+            decodePathParam(collaboratorsMatch[1] ?? ""),
+            decodePathParam(collaboratorsMatch[2] ?? ""),
+          );
+        } else if (documentMatch && method === "GET") {
+          response = await handleDocumentDetail(
+            req,
+            baseHeaders,
+            decodePathParam(documentMatch[1] ?? ""),
+            decodePathParam(documentMatch[2] ?? ""),
+          );
+        } else {
+          response = json(404, { error: "Not found." }, baseHeaders);
+        }
       }
 
-      const publishMatch = pathname.match(
-        /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/pull-requests\/(\d+)\/publish$/,
-      );
-      if (publishMatch && req.method === "POST") {
-        return handleDocumentPublish(
-          req,
-          baseHeaders,
-          decodePathParam(publishMatch[1] ?? ""),
-          decodePathParam(publishMatch[2] ?? ""),
-          Number.parseInt(publishMatch[3] ?? "", 10),
-        );
+      const durationMs = Date.now() - startMs;
+      const status = response.status;
+      if (status >= 500) {
+        logger.error("Response sent with 5xx status", {
+          method,
+          path: pathname,
+          status,
+          durationMs,
+        });
+      } else {
+        logger.info("Response sent", { method, path: pathname, status, durationMs });
       }
 
-      const downloadMatch = pathname.match(
-        /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/download$/,
-      );
-      if (downloadMatch && req.method === "GET") {
-        return handleDocumentDownload(
-          req,
-          baseHeaders,
-          decodePathParam(downloadMatch[1] ?? ""),
-          decodePathParam(downloadMatch[2] ?? ""),
-        );
-      }
-
-      const versionsMatch = pathname.match(
-        /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/versions$/,
-      );
-      if (versionsMatch && req.method === "POST") {
-        return handleDocumentVersions(
-          req,
-          baseHeaders,
-          decodePathParam(versionsMatch[1] ?? ""),
-          decodePathParam(versionsMatch[2] ?? ""),
-        );
-      }
-
-      const collaboratorsActionMatch = pathname.match(
-        /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/collaborators\/([^/]+)$/,
-      );
-      if (collaboratorsActionMatch && req.method === "PUT") {
-        return handleAddCollaborator(
-          req,
-          baseHeaders,
-          decodePathParam(collaboratorsActionMatch[1] ?? ""),
-          decodePathParam(collaboratorsActionMatch[2] ?? ""),
-          decodePathParam(collaboratorsActionMatch[3] ?? ""),
-        );
-      }
-      if (collaboratorsActionMatch && req.method === "DELETE") {
-        return handleDeleteCollaborator(
-          req,
-          baseHeaders,
-          decodePathParam(collaboratorsActionMatch[1] ?? ""),
-          decodePathParam(collaboratorsActionMatch[2] ?? ""),
-          decodePathParam(collaboratorsActionMatch[3] ?? ""),
-        );
-      }
-
-      const collaboratorsMatch = pathname.match(
-        /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/collaborators$/,
-      );
-      if (collaboratorsMatch && req.method === "GET") {
-        return handleDocumentCollaborators(
-          req,
-          baseHeaders,
-          decodePathParam(collaboratorsMatch[1] ?? ""),
-          decodePathParam(collaboratorsMatch[2] ?? ""),
-        );
-      }
-
-      const documentMatch = pathname.match(
-        /^\/api\/app\/documents\/([^/]+)\/([^/]+)$/,
-      );
-      if (documentMatch && req.method === "GET") {
-        return handleDocumentDetail(
-          req,
-          baseHeaders,
-          decodePathParam(documentMatch[1] ?? ""),
-          decodePathParam(documentMatch[2] ?? ""),
-        );
-      }
-
-      return json(404, { error: "Not found." }, baseHeaders);
+      return response;
     },
   });
 }
@@ -2544,5 +2681,9 @@ export const server = import.meta.main ? createApiServer() : null;
 
 if (import.meta.main && server) {
   startCleanupTimer();
-  console.log(`Bindersnap API listening on http://localhost:${server.port}`);
+  logger.info("Bindersnap API listening", {
+    url: `http://localhost:${server.port}`,
+    port: server.port,
+    env: process.env.NODE_ENV ?? "development",
+  });
 }


### PR DESCRIPTION
## Summary

This change hardens the production bootstrap path that provisions the dedicated Gitea service-account token used by the API. The original flow was fragile on existing EC2 instances and failed across several different boundaries: missing first-boot helpers, insufficient SSM write permissions, root `docker exec` calls against Gitea, invalid `login_name` payloads in the admin API patch, attempting to run `aws` inside `oven/bun:1`, and stale host state around `Caddyfile.prod`.

This PR turns the bootstrap into a repeatable, self-healing flow that works both on fresh first boot and when re-run later through `bun run tf:apply`.

## What changed

The secrets and instance bootstrap contract was expanded so production can mint the service token automatically. Terraform now provisions first-boot Gitea admin credentials into SSM, and the EC2 bootstrap/user-data path writes the bootstrap script onto the host. Once the real service token exists, the generated runtime env file stops exposing the bootstrap-only admin credentials.

The Gitea bootstrap flow itself was hardened in several ways. The in-container Gitea CLI now runs as `1000:1000` instead of root, which matches the repo’s configured Gitea UID/GID and avoids Gitea refusing to run admin commands as root. The bootstrap script now uses valid `login_name` values when creating and editing the service user, matching the repo’s own seeding path and the checked-in Gitea API schema.

The SSM fallback path in `infra/apply-all.sh` was also refactored. Instead of embedding Python inside shell to render env files and generate remote command payloads, the Bun bootstrap script now owns those responsibilities directly. It can render Docker env files from SSM JSON, emit the remote SSM command list, and mint a PAT without attempting to write to SSM itself. The actual `aws ssm put-parameter` write now happens on the EC2 host, not inside the `oven/bun:1` container, which fixes the missing-`aws` failure.

Finally, the remote bootstrap path now repairs host-side config drift that previously broke unrelated services after token bootstrap succeeded. In particular, it rewrites `/opt/bindersnap/Caddyfile.prod` from the repo copy before the final compose bring-up so existing instances with a bad file type do not fail when `caddy` starts.

## User impact

Before this change, `bun run tf:apply` could fail even after successfully authenticating to Gitea and minting a PAT, leaving production only partially bootstrapped and requiring manual host surgery. The flow was especially brittle on previously provisioned instances where first-boot assumptions no longer held.

After this change, the same command can bootstrap the production service token on both fresh and already-running instances with much better failure isolation and host repair behavior.

## Root causes addressed

The fixes in this PR address multiple concrete failures discovered during production bootstrap debugging:

- EC2 instance role could read SSM but could not write back the minted service token.
- Existing instances did not necessarily have the first-boot helper scripts installed.
- `docker exec` invoked `gitea admin user ...` as root, which Gitea rejects.
- The admin-user PATCH sent an empty `login_name`, which Gitea rejects.
- The Bun container attempted to execute `aws`, but `oven/bun:1` does not include the AWS CLI.
- Existing host state could leave `/opt/bindersnap/Caddyfile.prod` as the wrong type and break `caddy` startup.

## Validation

I validated the final state with focused shell and unit checks:

- `bash -n infra/apply-all.sh`
- rendered `bash -n` for `infra/compute/user-data.sh.tftpl`
- `bun test scripts/bootstrap-gitea-service-account.test.ts scripts/ssm-parameter-store.test.ts`

These checks cover the Terraform/SSM contract, the bootstrap script behavior, the remote command generation, and the user-data env bootstrap path.
