### PR TITLE
fix(stripe): pin webhook API version and add items[].current_period_end fallback (#179)

### DIFF
--- a/docs/payments-plan.md
+++ b/docs/payments-plan.md
@@ -41,6 +41,11 @@ Do in Stripe Dashboard / CLI:
 2. Enable **Customer Portal**: Dashboard → Settings → Billing → Customer Portal
 3. `stripe listen --forward-to localhost:8787/stripe/webhook --print-secret` → copy **webhook secret** (`whsec_...`)
 4. Note **Secret Key** (`sk_test_...`) and **Publishable Key** (`pk_test_...`)
+5. **Pin the webhook endpoint API version to `2024-06-20` in BOTH test and live mode.**
+   - Dashboard → Developers → Webhooks → (your endpoint) → ⋯ → **Update API version** → select `2024-06-20`.
+   - Repeat for the live-mode endpoint when going to production.
+   - Why: Stripe API versions ≥ `2025-04-30` move `current_period_end` off `Subscription` onto `subscription.items.data[0]`. The webhook payload shape is determined by the **endpoint's** configured version, not by request headers. If the endpoint runs a newer version than the server expects, `currentPeriodEnd` would be missed on every `customer.subscription.updated` and the 3-day expiry guard in `subscriptions.ts` would revoke access from valid paying customers after one billing cycle. The server reads both shapes defensively (see `services/api/stripe/api-version.ts`), but pinning the endpoint keeps the contract explicit.
+   - The pinned version is centralized as `STRIPE_API_VERSION` in `services/api/stripe/api-version.ts`. If you change it, update the dashboard endpoints in the same change.
 
 ---
 

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -6,6 +6,10 @@ import { sessionStore, type SessionRecord } from "./sessions";
 import { subscriptionStore, hasActiveSubscription } from "./subscriptions";
 import { verifyStripeSignature } from "./stripe/webhook";
 import {
+  STRIPE_API_VERSION,
+  extractCurrentPeriodEnd,
+} from "./stripe/api-version";
+import {
   createGiteaClient,
   GiteaApiError,
   unwrap,
@@ -558,7 +562,7 @@ async function stripeFetch(
     method: body ? "POST" : "GET",
     headers: {
       Authorization: `Bearer ${config.stripeSecretKey}`,
-      "Stripe-Version": "2024-06-20",
+      "Stripe-Version": STRIPE_API_VERSION,
       ...(body ? { "Content-Type": "application/x-www-form-urlencoded" } : {}),
       ...extraHeaders,
     },
@@ -2456,14 +2460,12 @@ async function handleStripeWebhook(
           stripeCustomerId: customerId,
           stripeSubscriptionId: subscriptionId,
           status: (sub.status as string) ?? "active",
-          // Stripe omits current_period_end for trialing subscriptions in
-          // newer API versions; fall back to trial_end (same value).
+          // Newer API versions (>= 2025-04-30) moved current_period_end onto
+          // items.data[0]; for trialing subscriptions Stripe omits it entirely
+          // and trial_end carries the same timestamp. Try all three.
           currentPeriodEnd:
-            typeof sub.current_period_end === "number"
-              ? sub.current_period_end
-              : typeof sub.trial_end === "number"
-                ? sub.trial_end
-                : null,
+            extractCurrentPeriodEnd(sub) ??
+            (typeof sub.trial_end === "number" ? sub.trial_end : null),
           updatedAt: Date.now(),
         });
         logger.info("Subscription activated", { username, status: sub.status });
@@ -2499,9 +2501,7 @@ async function handleStripeWebhook(
               ? "canceled"
               : record.status),
           currentPeriodEnd:
-            typeof data.current_period_end === "number"
-              ? data.current_period_end
-              : record.currentPeriodEnd,
+            extractCurrentPeriodEnd(data) ?? record.currentPeriodEnd,
           updatedAt: Date.now(),
         });
         logger.info("Subscription updated", {

--- a/services/api/stripe/api-version.test.ts
+++ b/services/api/stripe/api-version.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { STRIPE_API_VERSION, extractCurrentPeriodEnd } from "./api-version";
+
+describe("STRIPE_API_VERSION", () => {
+  it("is pinned to 2024-06-20", () => {
+    // If this changes, update the webhook endpoint API version in the Stripe
+    // Dashboard (test + live) AND docs/payments-plan.md in the same change.
+    expect(STRIPE_API_VERSION).toBe("2024-06-20");
+  });
+});
+
+describe("extractCurrentPeriodEnd", () => {
+  it("reads top-level current_period_end on legacy/pinned API shapes", () => {
+    expect(extractCurrentPeriodEnd({ current_period_end: 1_700_000_000 })).toBe(
+      1_700_000_000,
+    );
+  });
+
+  it("falls back to items.data[0].current_period_end on newer API shapes", () => {
+    // Stripe API >= 2025-04-30: field moved off Subscription onto items.
+    const newShape = {
+      id: "sub_test",
+      status: "active",
+      items: {
+        data: [{ current_period_end: 1_800_000_000, id: "si_test" }],
+      },
+    };
+    expect(extractCurrentPeriodEnd(newShape)).toBe(1_800_000_000);
+  });
+
+  it("prefers top-level field when both are present", () => {
+    const data = {
+      current_period_end: 1_700_000_000,
+      items: { data: [{ current_period_end: 1_800_000_000 }] },
+    };
+    expect(extractCurrentPeriodEnd(data)).toBe(1_700_000_000);
+  });
+
+  it("returns null when neither field is set", () => {
+    expect(extractCurrentPeriodEnd({ status: "trialing" })).toBeNull();
+    expect(extractCurrentPeriodEnd({ items: { data: [] } })).toBeNull();
+    expect(extractCurrentPeriodEnd(null)).toBeNull();
+    expect(extractCurrentPeriodEnd(undefined)).toBeNull();
+  });
+
+  it("ignores non-numeric values", () => {
+    expect(
+      extractCurrentPeriodEnd({ current_period_end: "1700000000" as unknown }),
+    ).toBeNull();
+  });
+});

--- a/services/api/stripe/api-version.ts
+++ b/services/api/stripe/api-version.ts
@@ -1,0 +1,36 @@
+/**
+ * Pinned Stripe API version for outbound requests AND for the webhook
+ * endpoint configured in the Stripe Dashboard.
+ *
+ * Why pinned: API versions >= 2025-04-30 moved `current_period_end` and
+ * `current_period_start` off `Subscription` and onto
+ * `subscription.items.data[0]`. A drift between this constant and the
+ * webhook endpoint's configured version would silently revoke access for
+ * paying customers after one billing cycle (see issue #179).
+ *
+ * The webhook endpoint API version must be set to this value in both
+ * test and live mode — see docs/payments-plan.md.
+ */
+export const STRIPE_API_VERSION = "2024-06-20";
+
+/**
+ * Read `current_period_end` from a Stripe Subscription (or
+ * checkout.session.completed → fetched Subscription) payload, falling
+ * back to `items.data[0].current_period_end` for newer API versions
+ * where the field moved.
+ */
+export function extractCurrentPeriodEnd(
+  data: Record<string, unknown> | null | undefined,
+): number | null {
+  if (!data) return null;
+  if (typeof data.current_period_end === "number") {
+    return data.current_period_end;
+  }
+  const items = data.items as Record<string, unknown> | undefined;
+  const itemsData = items?.data as Array<Record<string, unknown>> | undefined;
+  const first = itemsData?.[0];
+  if (first && typeof first.current_period_end === "number") {
+    return first.current_period_end;
+  }
+  return null;
+}

--- a/tests/stripe-subscription.pw.ts
+++ b/tests/stripe-subscription.pw.ts
@@ -24,6 +24,7 @@
 
 import { test, expect, type Page } from "@playwright/test";
 import { resolveStripeWebhookSecret } from "./stripe-runtime";
+import { STRIPE_API_VERSION } from "../services/api/stripe/api-version";
 
 // ---------------------------------------------------------------------------
 // Environment
@@ -114,6 +115,7 @@ async function stripeFetch(
     method: body ? "POST" : "GET",
     headers: {
       Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+      "Stripe-Version": STRIPE_API_VERSION,
       ...(body ? { "Content-Type": "application/x-www-form-urlencoded" } : {}),
     },
     body,
@@ -609,6 +611,58 @@ test.describe("Stripe subscription lifecycle", () => {
       const billing = await getBillingStatus(sessionCookie);
       expect(billing.status).toBe("active");
       expect(billing.currentPeriodEnd).toBe(renewedPeriodEnd);
+      expect(await getDocumentsHttpStatus(sessionCookie)).toBe(200);
+    } finally {
+      await cancelTestSubscription(subscriptionId);
+    }
+  });
+
+  test("customer.subscription.updated honors items[].current_period_end on newer Stripe API shapes", async () => {
+    // Regression for issue #179: Stripe API >= 2025-04-30 omits the top-level
+    // current_period_end and exposes it on items.data[0]. The webhook handler
+    // must read both shapes — otherwise a misconfigured webhook endpoint
+    // version would silently revoke access from valid paying customers after
+    // one billing cycle (the 3-day expiry guard in subscriptions.ts).
+    test.skip(!stripeFullyConfigured, "Stripe test credentials not configured");
+
+    const credentials = uniqueCredentials();
+    const sessionCookie = await signUpUser(credentials);
+    const { customerId, subscriptionId } =
+      await createTestCustomerAndSubscription(credentials.username);
+
+    try {
+      // Activate first via the normal checkout webhook path.
+      await postWebhook("checkout.session.completed", {
+        client_reference_id: credentials.username,
+        customer: customerId,
+        subscription: subscriptionId,
+      });
+      expect(await getDocumentsHttpStatus(sessionCookie)).toBe(200);
+
+      // Send a subscription.updated payload shaped like the new API:
+      // NO top-level current_period_end; only items.data[0].current_period_end.
+      const newShapePeriodEnd =
+        Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+      const updateResp = await postWebhook("customer.subscription.updated", {
+        id: subscriptionId,
+        customer: customerId,
+        status: "active",
+        items: {
+          data: [
+            {
+              id: "si_test_new_shape",
+              current_period_end: newShapePeriodEnd,
+            },
+          ],
+        },
+      });
+      expect(updateResp.ok).toBe(true);
+
+      const billing = await getBillingStatus(sessionCookie);
+      expect(billing.status).toBe("active");
+      // The handler must have picked up the nested period end, not the
+      // (stale) one stored at activation time.
+      expect(billing.currentPeriodEnd).toBe(newShapePeriodEnd);
       expect(await getDocumentsHttpStatus(sessionCookie)).toBe(200);
     } finally {
       await cancelTestSubscription(subscriptionId);


### PR DESCRIPTION
Closes #179.

## Summary
Stripe API versions ≥ `2025-04-30` moved `current_period_end` off `Subscription` and onto `subscription.items.data[0]`. Webhook payload shape is dictated by the **endpoint's** configured API version, not by request headers — so a misconfigured endpoint would silently revoke access from valid paying customers after one billing cycle (via the 3-day expiry guard in `subscriptions.ts`).

## Changes
- **New `services/api/stripe/api-version.ts`** — centralizes `STRIPE_API_VERSION = "2024-06-20"` and an `extractCurrentPeriodEnd(data)` helper that reads `data.current_period_end ?? data.items?.data?.[0]?.current_period_end`. Used by both the API server and the integration test helper.
- **`services/api/server.ts`** — outbound `stripeFetch` now references the constant; `handleStripeWebhook` uses the fallback helper for `checkout.session.completed` (the GET `/v1/subscriptions/{id}` response shape), `customer.subscription.updated`, and `customer.subscription.deleted`.
- **`tests/stripe-subscription.pw.ts`** — pins `Stripe-Version` on the test helper's outbound calls and adds a regression test that posts a `customer.subscription.updated` payload with **no top-level** `current_period_end` (only `items.data[0].current_period_end`); asserts the handler picks up the nested value rather than preserving the stale one.
- **`services/api/stripe/api-version.test.ts`** — unit tests for the helper (legacy shape, new shape, both-present, neither, non-numeric).
- **`docs/payments-plan.md`** — runbook step requiring the webhook endpoint API version be set to `2024-06-20` in both test and live mode, with rationale.

## Test plan
- [x] `bun test services/api/stripe/api-version.test.ts` — 6 pass
- [x] `bun run test:ops` — 60 pass
- [ ] Manual: verify in Stripe Dashboard that test + live webhook endpoints are pinned to `2024-06-20` (per the new runbook step) before live cutover
- [ ] Integration test (`tests/stripe-subscription.pw.ts`) requires real Stripe test credentials — runs in the existing CI pathway that already exercises this file

## Workflow evidence
- Issue read via MCP `issue_read` (#179)
- Branch created via local `git checkout -b` off `origin/development/stripe-paywall` (commit base: 23ebd4f); pushed via `git push`
- PR created via MCP `create_pull_request`
- Targets `development/stripe-paywall` per issue instructions (not `main`)
