### PR TITLE
fix(stripe): webhook event idempotency and out-of-order protection

### DIFF
--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -2458,7 +2458,11 @@ async function handleStripeWebhook(
     return json(200, { received: true }, baseHeaders);
   }
 
-  if (customerId && eventCreated !== undefined && webhookEventStore.isOutOfOrder(customerId, eventCreated)) {
+  if (
+    customerId &&
+    eventCreated !== undefined &&
+    webhookEventStore.isOutOfOrder(customerId, eventCreated)
+  ) {
     logger.info("Out-of-order webhook event — skipping", {
       eventId,
       type,

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -3,7 +3,11 @@ import { randomUUID } from "crypto";
 import { config, type SessionCookieSameSite } from "./config";
 import { logger } from "./logger";
 import { sessionStore, type SessionRecord } from "./sessions";
-import { subscriptionStore, hasActiveSubscription } from "./subscriptions";
+import {
+  subscriptionStore,
+  hasActiveSubscription,
+  webhookEventStore,
+} from "./subscriptions";
 import { verifyStripeSignature } from "./stripe/webhook";
 import {
   STRIPE_API_VERSION,
@@ -2440,11 +2444,37 @@ async function handleStripeWebhook(
   }
 
   const type = event.type as string | undefined;
+  const eventId = event.id as string | undefined;
+  const eventCreated = event.created as number | undefined;
   const data = (event.data as Record<string, unknown> | undefined)?.object as
     | Record<string, unknown>
     | undefined;
+  const customerId = data?.customer as string | undefined;
 
-  logger.info("Stripe webhook received", { type });
+  logger.info("Stripe webhook received", { type, eventId });
+
+  if (eventId && webhookEventStore.isProcessed(eventId)) {
+    logger.info("Duplicate webhook event — skipping", { eventId, type });
+    return json(200, { received: true }, baseHeaders);
+  }
+
+  if (customerId && eventCreated !== undefined && webhookEventStore.isOutOfOrder(customerId, eventCreated)) {
+    logger.info("Out-of-order webhook event — skipping", {
+      eventId,
+      type,
+      customerId,
+      eventCreated,
+    });
+    if (eventId) {
+      webhookEventStore.markProcessed(
+        eventId,
+        type ?? "unknown",
+        customerId,
+        eventCreated,
+      );
+    }
+    return json(200, { received: true }, baseHeaders);
+  }
 
   if (type === "checkout.session.completed" && data) {
     const username = data.client_reference_id as string | undefined;
@@ -2541,6 +2571,15 @@ async function handleStripeWebhook(
         );
       }
     }
+  }
+
+  if (eventId) {
+    webhookEventStore.markProcessed(
+      eventId,
+      type ?? "unknown",
+      customerId ?? null,
+      eventCreated ?? 0,
+    );
   }
 
   return json(200, { received: true }, baseHeaders);

--- a/services/api/stripe/webhook-idempotency.test.ts
+++ b/services/api/stripe/webhook-idempotency.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "bun:test";
+import { WebhookEventStore, SubscriptionStore } from "../subscriptions";
+
+const TEST_DB = ":memory:";
+
+function makeWebhookStore() {
+  return new WebhookEventStore(TEST_DB);
+}
+
+function makeSubStore() {
+  return new SubscriptionStore(TEST_DB);
+}
+
+const NOW = Math.floor(Date.now() / 1000);
+const CUSTOMER = "cus_test123";
+
+describe("WebhookEventStore — idempotency", () => {
+  it("isProcessed returns false for unknown event", () => {
+    const store = makeWebhookStore();
+    expect(store.isProcessed("evt_new")).toBe(false);
+  });
+
+  it("isProcessed returns true after markProcessed", () => {
+    const store = makeWebhookStore();
+    store.markProcessed("evt_1", "checkout.session.completed", CUSTOMER, NOW);
+    expect(store.isProcessed("evt_1")).toBe(true);
+  });
+
+  it("markProcessed is idempotent — second call does not throw", () => {
+    const store = makeWebhookStore();
+    store.markProcessed("evt_dup", "customer.subscription.updated", CUSTOMER, NOW);
+    expect(() =>
+      store.markProcessed("evt_dup", "customer.subscription.updated", CUSTOMER, NOW),
+    ).not.toThrow();
+    expect(store.isProcessed("evt_dup")).toBe(true);
+  });
+
+  it("different event IDs are independent", () => {
+    const store = makeWebhookStore();
+    store.markProcessed("evt_a", "invoice.payment_failed", CUSTOMER, NOW);
+    expect(store.isProcessed("evt_a")).toBe(true);
+    expect(store.isProcessed("evt_b")).toBe(false);
+  });
+
+  it("null customerId is accepted", () => {
+    const store = makeWebhookStore();
+    store.markProcessed("evt_no_cust", "checkout.session.completed", null, NOW);
+    expect(store.isProcessed("evt_no_cust")).toBe(true);
+  });
+});
+
+describe("WebhookEventStore — out-of-order protection", () => {
+  it("isOutOfOrder returns false when no prior state for customer", () => {
+    const store = makeWebhookStore();
+    expect(store.isOutOfOrder(CUSTOMER, NOW)).toBe(false);
+  });
+
+  it("isOutOfOrder returns false when event is newer than recorded", () => {
+    const store = makeWebhookStore();
+    store.markProcessed("evt_first", "customer.subscription.updated", CUSTOMER, NOW);
+    expect(store.isOutOfOrder(CUSTOMER, NOW + 1)).toBe(false);
+  });
+
+  it("isOutOfOrder returns false when event is same timestamp as recorded", () => {
+    const store = makeWebhookStore();
+    store.markProcessed("evt_same", "customer.subscription.updated", CUSTOMER, NOW);
+    expect(store.isOutOfOrder(CUSTOMER, NOW)).toBe(false);
+  });
+
+  it("isOutOfOrder returns true when event is strictly older than recorded", () => {
+    const store = makeWebhookStore();
+    store.markProcessed("evt_newer", "customer.subscription.updated", CUSTOMER, NOW + 10);
+    expect(store.isOutOfOrder(CUSTOMER, NOW + 5)).toBe(true);
+  });
+
+  it("last_event_created_at advances to MAX — older event does not roll it back", () => {
+    const store = makeWebhookStore();
+    store.markProcessed("evt_t10", "customer.subscription.updated", CUSTOMER, NOW + 10);
+    store.markProcessed("evt_t5", "invoice.payment_failed", CUSTOMER, NOW + 5);
+    // After inserting an older event, the newer timestamp is preserved
+    expect(store.isOutOfOrder(CUSTOMER, NOW + 8)).toBe(true);
+  });
+
+  it("different customers have independent state", () => {
+    const store = makeWebhookStore();
+    const cust1 = "cus_aaa";
+    const cust2 = "cus_bbb";
+    store.markProcessed("evt_c1", "customer.subscription.updated", cust1, NOW + 100);
+    // cust2 has no state yet
+    expect(store.isOutOfOrder(cust2, NOW)).toBe(false);
+    // cust1 would reject an older event
+    expect(store.isOutOfOrder(cust1, NOW)).toBe(true);
+  });
+});
+
+describe("Webhook idempotency — duplicate delivery produces single side effect", () => {
+  it("processing same checkout.session.completed twice leaves one subscription record", () => {
+    const subStore = makeSubStore();
+    const whStore = makeWebhookStore();
+    const EVENT_ID = "evt_checkout_dup";
+
+    function processCheckout() {
+      if (whStore.isProcessed(EVENT_ID)) return false;
+      subStore.upsert({
+        username: "alice",
+        stripeCustomerId: CUSTOMER,
+        stripeSubscriptionId: "sub_1",
+        status: "active",
+        currentPeriodEnd: NOW + 30 * 86400,
+        updatedAt: Date.now(),
+      });
+      whStore.markProcessed(EVENT_ID, "checkout.session.completed", CUSTOMER, NOW);
+      return true;
+    }
+
+    const first = processCheckout();
+    const second = processCheckout();
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(subStore.getByUsername("alice")?.status).toBe("active");
+  });
+});
+
+describe("Webhook out-of-order — past_due-after-active stays active", () => {
+  it("late-arriving past_due event after active is rejected; state remains active", () => {
+    const subStore = makeSubStore();
+    const whStore = makeWebhookStore();
+
+    const T_ACTIVE = NOW + 100;
+    const T_PAST_DUE = NOW + 50; // earlier timestamp — arrives second (late)
+
+    // 1. Process the active event (arrives first, as expected)
+    subStore.upsert({
+      username: "bob",
+      stripeCustomerId: CUSTOMER,
+      stripeSubscriptionId: "sub_2",
+      status: "active",
+      currentPeriodEnd: NOW + 30 * 86400,
+      updatedAt: Date.now(),
+    });
+    whStore.markProcessed(
+      "evt_active",
+      "customer.subscription.updated",
+      CUSTOMER,
+      T_ACTIVE,
+    );
+
+    // 2. Out-of-order past_due arrives — should be rejected
+    const isOOO = whStore.isOutOfOrder(CUSTOMER, T_PAST_DUE);
+    expect(isOOO).toBe(true);
+
+    if (!isOOO) {
+      // Would have executed side effect (not reached in this test)
+      const record = subStore.getByUsername("bob")!;
+      subStore.upsert({ ...record, status: "past_due", updatedAt: Date.now() });
+    }
+
+    // State must remain active
+    expect(subStore.getByUsername("bob")?.status).toBe("active");
+  });
+});

--- a/services/api/stripe/webhook-idempotency.test.ts
+++ b/services/api/stripe/webhook-idempotency.test.ts
@@ -28,9 +28,19 @@ describe("WebhookEventStore — idempotency", () => {
 
   it("markProcessed is idempotent — second call does not throw", () => {
     const store = makeWebhookStore();
-    store.markProcessed("evt_dup", "customer.subscription.updated", CUSTOMER, NOW);
+    store.markProcessed(
+      "evt_dup",
+      "customer.subscription.updated",
+      CUSTOMER,
+      NOW,
+    );
     expect(() =>
-      store.markProcessed("evt_dup", "customer.subscription.updated", CUSTOMER, NOW),
+      store.markProcessed(
+        "evt_dup",
+        "customer.subscription.updated",
+        CUSTOMER,
+        NOW,
+      ),
     ).not.toThrow();
     expect(store.isProcessed("evt_dup")).toBe(true);
   });
@@ -57,25 +67,45 @@ describe("WebhookEventStore — out-of-order protection", () => {
 
   it("isOutOfOrder returns false when event is newer than recorded", () => {
     const store = makeWebhookStore();
-    store.markProcessed("evt_first", "customer.subscription.updated", CUSTOMER, NOW);
+    store.markProcessed(
+      "evt_first",
+      "customer.subscription.updated",
+      CUSTOMER,
+      NOW,
+    );
     expect(store.isOutOfOrder(CUSTOMER, NOW + 1)).toBe(false);
   });
 
   it("isOutOfOrder returns false when event is same timestamp as recorded", () => {
     const store = makeWebhookStore();
-    store.markProcessed("evt_same", "customer.subscription.updated", CUSTOMER, NOW);
+    store.markProcessed(
+      "evt_same",
+      "customer.subscription.updated",
+      CUSTOMER,
+      NOW,
+    );
     expect(store.isOutOfOrder(CUSTOMER, NOW)).toBe(false);
   });
 
   it("isOutOfOrder returns true when event is strictly older than recorded", () => {
     const store = makeWebhookStore();
-    store.markProcessed("evt_newer", "customer.subscription.updated", CUSTOMER, NOW + 10);
+    store.markProcessed(
+      "evt_newer",
+      "customer.subscription.updated",
+      CUSTOMER,
+      NOW + 10,
+    );
     expect(store.isOutOfOrder(CUSTOMER, NOW + 5)).toBe(true);
   });
 
   it("last_event_created_at advances to MAX — older event does not roll it back", () => {
     const store = makeWebhookStore();
-    store.markProcessed("evt_t10", "customer.subscription.updated", CUSTOMER, NOW + 10);
+    store.markProcessed(
+      "evt_t10",
+      "customer.subscription.updated",
+      CUSTOMER,
+      NOW + 10,
+    );
     store.markProcessed("evt_t5", "invoice.payment_failed", CUSTOMER, NOW + 5);
     // After inserting an older event, the newer timestamp is preserved
     expect(store.isOutOfOrder(CUSTOMER, NOW + 8)).toBe(true);
@@ -85,7 +115,12 @@ describe("WebhookEventStore — out-of-order protection", () => {
     const store = makeWebhookStore();
     const cust1 = "cus_aaa";
     const cust2 = "cus_bbb";
-    store.markProcessed("evt_c1", "customer.subscription.updated", cust1, NOW + 100);
+    store.markProcessed(
+      "evt_c1",
+      "customer.subscription.updated",
+      cust1,
+      NOW + 100,
+    );
     // cust2 has no state yet
     expect(store.isOutOfOrder(cust2, NOW)).toBe(false);
     // cust1 would reject an older event
@@ -109,7 +144,12 @@ describe("Webhook idempotency — duplicate delivery produces single side effect
         currentPeriodEnd: NOW + 30 * 86400,
         updatedAt: Date.now(),
       });
-      whStore.markProcessed(EVENT_ID, "checkout.session.completed", CUSTOMER, NOW);
+      whStore.markProcessed(
+        EVENT_ID,
+        "checkout.session.completed",
+        CUSTOMER,
+        NOW,
+      );
       return true;
     }
 

--- a/services/api/subscriptions.ts
+++ b/services/api/subscriptions.ts
@@ -115,18 +115,20 @@ export class WebhookEventStore {
 
   isProcessed(eventId: string): boolean {
     const row = this.db
-      .query<{ event_id: string }, [string]>(
-        "SELECT event_id FROM processed_webhook_events WHERE event_id = ?",
-      )
+      .query<
+        { event_id: string },
+        [string]
+      >("SELECT event_id FROM processed_webhook_events WHERE event_id = ?")
       .get(eventId);
     return row !== null;
   }
 
   isOutOfOrder(customerId: string, eventCreated: number): boolean {
     const row = this.db
-      .query<{ last_event_created_at: number }, [string]>(
-        "SELECT last_event_created_at FROM webhook_customer_state WHERE customer_id = ?",
-      )
+      .query<
+        { last_event_created_at: number },
+        [string]
+      >("SELECT last_event_created_at FROM webhook_customer_state WHERE customer_id = ?")
       .get(customerId);
     if (!row) return false;
     return eventCreated < row.last_event_created_at;
@@ -139,10 +141,7 @@ export class WebhookEventStore {
     eventCreated: number,
   ): void {
     this.db
-      .query<
-        void,
-        [string, string, string | null, number, number]
-      >(
+      .query<void, [string, string, string | null, number, number]>(
         `INSERT OR IGNORE INTO processed_webhook_events (event_id, event_type, customer_id, created_at, processed_at)
          VALUES (?, ?, ?, ?, ?)`,
       )

--- a/services/api/subscriptions.ts
+++ b/services/api/subscriptions.ts
@@ -92,6 +92,105 @@ export class SubscriptionStore {
   }
 }
 
+export class WebhookEventStore {
+  private db: Database;
+
+  constructor(path: string = config.sessionsDbPath) {
+    this.db = new Database(path);
+    this.db.exec("PRAGMA journal_mode=WAL");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS processed_webhook_events (
+        event_id TEXT PRIMARY KEY,
+        event_type TEXT NOT NULL,
+        customer_id TEXT,
+        created_at INTEGER NOT NULL,
+        processed_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS webhook_customer_state (
+        customer_id TEXT PRIMARY KEY,
+        last_event_created_at INTEGER NOT NULL
+      );
+    `);
+  }
+
+  isProcessed(eventId: string): boolean {
+    const row = this.db
+      .query<{ event_id: string }, [string]>(
+        "SELECT event_id FROM processed_webhook_events WHERE event_id = ?",
+      )
+      .get(eventId);
+    return row !== null;
+  }
+
+  isOutOfOrder(customerId: string, eventCreated: number): boolean {
+    const row = this.db
+      .query<{ last_event_created_at: number }, [string]>(
+        "SELECT last_event_created_at FROM webhook_customer_state WHERE customer_id = ?",
+      )
+      .get(customerId);
+    if (!row) return false;
+    return eventCreated < row.last_event_created_at;
+  }
+
+  markProcessed(
+    eventId: string,
+    eventType: string,
+    customerId: string | null,
+    eventCreated: number,
+  ): void {
+    this.db
+      .query<
+        void,
+        [string, string, string | null, number, number]
+      >(
+        `INSERT OR IGNORE INTO processed_webhook_events (event_id, event_type, customer_id, created_at, processed_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(eventId, eventType, customerId, eventCreated, Date.now());
+
+    if (customerId !== null) {
+      this.db
+        .query<void, [string, number]>(
+          `INSERT INTO webhook_customer_state (customer_id, last_event_created_at)
+           VALUES (?, ?)
+           ON CONFLICT(customer_id) DO UPDATE SET
+             last_event_created_at = MAX(last_event_created_at, excluded.last_event_created_at)`,
+        )
+        .run(customerId, eventCreated);
+    }
+  }
+}
+
+class LazyWebhookEventStore {
+  private _store: WebhookEventStore | null = null;
+
+  private get store(): WebhookEventStore {
+    if (!this._store) {
+      this._store = new WebhookEventStore();
+    }
+    return this._store;
+  }
+
+  isProcessed(eventId: string): boolean {
+    return this.store.isProcessed(eventId);
+  }
+
+  isOutOfOrder(customerId: string, eventCreated: number): boolean {
+    return this.store.isOutOfOrder(customerId, eventCreated);
+  }
+
+  markProcessed(
+    eventId: string,
+    eventType: string,
+    customerId: string | null,
+    eventCreated: number,
+  ): void {
+    this.store.markProcessed(eventId, eventType, customerId, eventCreated);
+  }
+}
+
+export const webhookEventStore = new LazyWebhookEventStore();
+
 class LazySubscriptionStore {
   private _store: SubscriptionStore | null = null;
 


### PR DESCRIPTION
## Summary

Closes #180.

- **Idempotency ledger**: new `processed_webhook_events` SQLite table (keyed by `event_id`) — duplicate Stripe deliveries are detected and returned 200 no-op without re-executing side effects.
- **Out-of-order protection**: new `webhook_customer_state` table tracks `last_event_created_at` per `customer_id`. Events with a `created` timestamp strictly older than the recorded value are skipped (prevents a late-arriving `past_due` from overwriting an already-`active` state).
- Both rejected paths still call `markProcessed` so future Stripe retries of the same event are also suppressed.

## Changed files

| File | Change |
|---|---|
| `services/api/subscriptions.ts` | Added `WebhookEventStore` class + `LazyWebhookEventStore` singleton export |
| `services/api/server.ts` | Import `webhookEventStore`; add idempotency + out-of-order guards in `handleStripeWebhook` before event dispatch; call `markProcessed` on successful processing |
| `services/api/stripe/webhook-idempotency.test.ts` | 13 new tests covering idempotency, out-of-order, duplicate delivery single-side-effect, and the concrete past_due-after-active scenario |

## Test results

```
73 pass / 0 fail (all ops tests)
13 new tests all pass
```

## Workflow evidence

- Issue read via `mcp__MCP_DOCKER__issue_read` (method: get, issue #180)
- Branch created locally with `git checkout -b fix/180-webhook-idempotency`
- Pushed via `git push -u origin fix/180-webhook-idempotency`
- PR created via `mcp__MCP_DOCKER__create_pull_request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)