### PR TITLE
fix(stripe): surface cancel_at_period_end in billing status and UI

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -276,6 +276,8 @@ export function App() {
     "active" | "none" | "loading" | null
   >(null);
   const [currentPeriodEnd, setCurrentPeriodEnd] = useState<number | null>(null);
+  const [cancelAtPeriodEnd, setCancelAtPeriodEnd] = useState(false);
+  const [cancelAt, setCancelAt] = useState<number | null>(null);
 
   const refreshSession = useCallback(async () => {
     setIsCheckingSession(true);
@@ -296,18 +298,24 @@ export function App() {
           const billing = await fetchBillingStatus();
           setSubscriptionStatus(resolveSubscriptionStatus(billing.status));
           setCurrentPeriodEnd(billing.currentPeriodEnd);
+          setCancelAtPeriodEnd(billing.cancelAtPeriodEnd);
+          setCancelAt(billing.cancelAt);
         } catch {
           setSubscriptionStatus(null);
         }
       } else {
         setSubscriptionStatus(null);
         setCurrentPeriodEnd(null);
+        setCancelAtPeriodEnd(false);
+        setCancelAt(null);
       }
       return resolvedUser;
     } catch (sessionError) {
       setUser(null);
       setSubscriptionStatus(null);
       setCurrentPeriodEnd(null);
+      setCancelAtPeriodEnd(false);
+      setCancelAt(null);
       setCallbackError(
         sessionError instanceof Error
           ? sessionError.message
@@ -447,6 +455,8 @@ export function App() {
       <BillingPage
         subscriptionStatus={subscriptionStatus ?? "loading"}
         currentPeriodEnd={currentPeriodEnd}
+        cancelAtPeriodEnd={cancelAtPeriodEnd}
+        cancelAt={cancelAt}
         onSubscribe={async () => {
           const { url } = await createCheckoutSession();
           window.location.href = url;

--- a/apps/app/api.ts
+++ b/apps/app/api.ts
@@ -526,13 +526,15 @@ export type { InitialDocumentUploadResult, UploadResult };
 export async function fetchBillingStatus(): Promise<{
   status: string | null;
   currentPeriodEnd: number | null;
+  cancelAtPeriodEnd: boolean;
+  cancelAt: number | null;
 }> {
   const response = await fetch(resolveApiUrl("/api/app/billing/status"), {
     credentials: "include",
     headers: { Accept: "application/json" },
   });
   if (response.status === 401 || response.status === 404) {
-    return { status: null, currentPeriodEnd: null };
+    return { status: null, currentPeriodEnd: null, cancelAtPeriodEnd: false, cancelAt: null };
   }
   const payload = (await response.json().catch(() => null)) as Record<
     string,
@@ -544,6 +546,9 @@ export async function fetchBillingStatus(): Promise<{
       typeof payload?.currentPeriodEnd === "number"
         ? payload.currentPeriodEnd
         : null,
+    cancelAtPeriodEnd: payload?.cancelAtPeriodEnd === true,
+    cancelAt:
+      typeof payload?.cancelAt === "number" ? payload.cancelAt : null,
   };
 }
 

--- a/apps/app/api.ts
+++ b/apps/app/api.ts
@@ -534,7 +534,12 @@ export async function fetchBillingStatus(): Promise<{
     headers: { Accept: "application/json" },
   });
   if (response.status === 401 || response.status === 404) {
-    return { status: null, currentPeriodEnd: null, cancelAtPeriodEnd: false, cancelAt: null };
+    return {
+      status: null,
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+    };
   }
   const payload = (await response.json().catch(() => null)) as Record<
     string,
@@ -547,8 +552,7 @@ export async function fetchBillingStatus(): Promise<{
         ? payload.currentPeriodEnd
         : null,
     cancelAtPeriodEnd: payload?.cancelAtPeriodEnd === true,
-    cancelAt:
-      typeof payload?.cancelAt === "number" ? payload.cancelAt : null,
+    cancelAt: typeof payload?.cancelAt === "number" ? payload.cancelAt : null,
   };
 }
 

--- a/apps/app/components/BillingPage.tsx
+++ b/apps/app/components/BillingPage.tsx
@@ -5,6 +5,8 @@ import { fetchBillingStatus } from "../api";
 interface BillingPageProps {
   subscriptionStatus: "active" | "none" | "loading";
   currentPeriodEnd: number | null;
+  cancelAtPeriodEnd: boolean;
+  cancelAt: number | null;
   onSubscribe: () => Promise<void>;
   onManage: () => Promise<void>;
   onSubscriptionConfirmed: () => void;
@@ -13,6 +15,8 @@ interface BillingPageProps {
 export function BillingPage({
   subscriptionStatus,
   currentPeriodEnd,
+  cancelAtPeriodEnd,
+  cancelAt,
   onSubscribe,
   onManage,
   onSubscriptionConfirmed,
@@ -131,8 +135,11 @@ export function BillingPage({
   }
 
   if (subscriptionStatus === "active") {
-    const renewalLabel =
-      currentPeriodEnd !== null
+    const renewalLabel = cancelAtPeriodEnd
+      ? cancelAt !== null
+        ? `Cancels on ${new Date(cancelAt * 1000).toLocaleDateString()}`
+        : "Cancels at end of billing period"
+      : currentPeriodEnd !== null
         ? `Renews on ${new Date(currentPeriodEnd * 1000).toLocaleDateString()}`
         : "Active";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindersnap-editor-demo",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindersnap-editor-demo",
-      "version": "0.2.0",
+      "version": "0.2.4",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "@tiptap/extension-color": "^3.22.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindersnap-editor-demo",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -2537,8 +2537,7 @@ async function handleStripeWebhook(
           currentPeriodEnd:
             extractCurrentPeriodEnd(data) ?? record.currentPeriodEnd,
           cancelAtPeriodEnd: Boolean(data.cancel_at_period_end),
-          cancelAt:
-            typeof data.cancel_at === "number" ? data.cancel_at : null,
+          cancelAt: typeof data.cancel_at === "number" ? data.cancel_at : null,
           updatedAt: Date.now(),
         });
         logger.info("Subscription updated", {
@@ -2604,7 +2603,12 @@ async function handleBillingStatus(
   if (config.bypassSubscriptionForUsers.includes(username)) {
     return json(
       200,
-      { status: "active", currentPeriodEnd: null, cancelAtPeriodEnd: false, cancelAt: null },
+      {
+        status: "active",
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+        cancelAt: null,
+      },
       baseHeaders,
     );
   }

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -2536,6 +2536,9 @@ async function handleStripeWebhook(
               : record.status),
           currentPeriodEnd:
             extractCurrentPeriodEnd(data) ?? record.currentPeriodEnd,
+          cancelAtPeriodEnd: Boolean(data.cancel_at_period_end),
+          cancelAt:
+            typeof data.cancel_at === "number" ? data.cancel_at : null,
           updatedAt: Date.now(),
         });
         logger.info("Subscription updated", {
@@ -2599,7 +2602,11 @@ async function handleBillingStatus(
   const { username } = auth.session;
 
   if (config.bypassSubscriptionForUsers.includes(username)) {
-    return json(200, { status: "active", currentPeriodEnd: null }, baseHeaders);
+    return json(
+      200,
+      { status: "active", currentPeriodEnd: null, cancelAtPeriodEnd: false, cancelAt: null },
+      baseHeaders,
+    );
   }
 
   const record = subscriptionStore.getByUsername(username);
@@ -2608,6 +2615,8 @@ async function handleBillingStatus(
     {
       status: record?.status ?? null,
       currentPeriodEnd: record?.currentPeriodEnd ?? null,
+      cancelAtPeriodEnd: record?.cancelAtPeriodEnd ?? false,
+      cancelAt: record?.cancelAt ?? null,
     },
     baseHeaders,
   );

--- a/services/api/stripe/webhook-idempotency.test.ts
+++ b/services/api/stripe/webhook-idempotency.test.ts
@@ -177,6 +177,8 @@ describe("Webhook out-of-order — past_due-after-active stays active", () => {
       stripeSubscriptionId: "sub_2",
       status: "active",
       currentPeriodEnd: NOW + 30 * 86400,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     whStore.markProcessed(
@@ -198,5 +200,65 @@ describe("Webhook out-of-order — past_due-after-active stays active", () => {
 
     // State must remain active
     expect(subStore.getByUsername("bob")?.status).toBe("active");
+  });
+});
+
+describe("Webhook cancel_at_period_end — persisted and reflected in record", () => {
+  it("subscription.updated with cancel_at_period_end=true persists fields", () => {
+    const subStore = makeSubStore();
+    const CANCEL_AT = NOW + 30 * 86400;
+
+    subStore.upsert({
+      username: "dana",
+      stripeCustomerId: CUSTOMER,
+      stripeSubscriptionId: "sub_cancel",
+      status: "active",
+      currentPeriodEnd: CANCEL_AT,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+      updatedAt: Date.now(),
+    });
+
+    // Simulate webhook handler updating with cancel_at_period_end=true
+    const record = subStore.getByCustomerId(CUSTOMER)!;
+    subStore.upsert({
+      ...record,
+      cancelAtPeriodEnd: true,
+      cancelAt: CANCEL_AT,
+      updatedAt: Date.now(),
+    });
+
+    const updated = subStore.getByUsername("dana");
+    expect(updated?.cancelAtPeriodEnd).toBe(true);
+    expect(updated?.cancelAt).toBe(CANCEL_AT);
+    expect(updated?.status).toBe("active");
+  });
+
+  it("subscription.updated clearing cancel_at_period_end resets fields", () => {
+    const subStore = makeSubStore();
+    const CANCEL_AT = NOW + 30 * 86400;
+
+    subStore.upsert({
+      username: "evan",
+      stripeCustomerId: "cus_evan",
+      stripeSubscriptionId: "sub_evan",
+      status: "active",
+      currentPeriodEnd: CANCEL_AT,
+      cancelAtPeriodEnd: true,
+      cancelAt: CANCEL_AT,
+      updatedAt: Date.now(),
+    });
+
+    const record = subStore.getByCustomerId("cus_evan")!;
+    subStore.upsert({
+      ...record,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+      updatedAt: Date.now(),
+    });
+
+    const updated = subStore.getByUsername("evan");
+    expect(updated?.cancelAtPeriodEnd).toBe(false);
+    expect(updated?.cancelAt).toBeNull();
   });
 });

--- a/services/api/subscriptions.test.ts
+++ b/services/api/subscriptions.test.ts
@@ -22,6 +22,8 @@ describe("SubscriptionStore", () => {
       stripeSubscriptionId: "sub_1",
       status: "active",
       currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("alice");
@@ -37,6 +39,8 @@ describe("SubscriptionStore", () => {
       stripeSubscriptionId: "sub_2",
       status: "trialing",
       currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByCustomerId("cus_2");
@@ -51,6 +55,8 @@ describe("SubscriptionStore", () => {
       stripeSubscriptionId: "sub_3",
       status: "active",
       currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     store.upsert({
@@ -59,6 +65,8 @@ describe("SubscriptionStore", () => {
       stripeSubscriptionId: "sub_3",
       status: "canceled",
       currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("carol");
@@ -90,6 +98,8 @@ describe("hasActiveSubscription — expiry logic", () => {
       stripeSubscriptionId: "sub_u1",
       status: "active",
       currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("u1");
@@ -110,6 +120,8 @@ describe("hasActiveSubscription — expiry logic", () => {
       stripeSubscriptionId: "sub_u2",
       status: "active",
       currentPeriodEnd: expiredEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("u2");
@@ -128,6 +140,8 @@ describe("hasActiveSubscription — expiry logic", () => {
       stripeSubscriptionId: "sub_u3",
       status: "active",
       currentPeriodEnd: recentEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("u3");
@@ -146,6 +160,8 @@ describe("hasActiveSubscription — expiry logic", () => {
       stripeSubscriptionId: "sub_u4",
       status: "active",
       currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("u4");
@@ -164,6 +180,8 @@ describe("hasActiveSubscription — expiry logic", () => {
       stripeSubscriptionId: "sub_u5",
       status: "trialing",
       currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("u5");
@@ -183,6 +201,8 @@ describe("hasActiveSubscription — expiry logic", () => {
       stripeSubscriptionId: "sub_u6",
       status: "past_due",
       currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("u6");
@@ -199,6 +219,8 @@ describe("hasActiveSubscription — expiry logic", () => {
       stripeSubscriptionId: "sub_u7",
       status: "canceled",
       currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
       updatedAt: Date.now(),
     });
     const record = store.getByUsername("u7");
@@ -210,5 +232,69 @@ describe("hasActiveSubscription — expiry logic", () => {
   it("no record → not active", () => {
     const store = makeStore();
     expect(store.getByUsername("nonexistent")).toBeNull();
+  });
+});
+
+describe("SubscriptionStore — cancel_at_period_end", () => {
+  it("persists cancelAtPeriodEnd=true and cancelAt timestamp", () => {
+    const store = makeStore();
+    const cancelTs = futureEnd;
+    store.upsert({
+      username: "v1",
+      stripeCustomerId: "cus_v1",
+      stripeSubscriptionId: "sub_v1",
+      status: "active",
+      currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: true,
+      cancelAt: cancelTs,
+      updatedAt: Date.now(),
+    });
+    const record = store.getByUsername("v1");
+    expect(record?.cancelAtPeriodEnd).toBe(true);
+    expect(record?.cancelAt).toBe(cancelTs);
+  });
+
+  it("cancelAtPeriodEnd defaults to false when stored as 0", () => {
+    const store = makeStore();
+    store.upsert({
+      username: "v2",
+      stripeCustomerId: "cus_v2",
+      stripeSubscriptionId: "sub_v2",
+      status: "active",
+      currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+      updatedAt: Date.now(),
+    });
+    const record = store.getByUsername("v2");
+    expect(record?.cancelAtPeriodEnd).toBe(false);
+    expect(record?.cancelAt).toBeNull();
+  });
+
+  it("upsert clears cancelAtPeriodEnd when subscription renews", () => {
+    const store = makeStore();
+    store.upsert({
+      username: "v3",
+      stripeCustomerId: "cus_v3",
+      stripeSubscriptionId: "sub_v3",
+      status: "active",
+      currentPeriodEnd: futureEnd,
+      cancelAtPeriodEnd: true,
+      cancelAt: futureEnd,
+      updatedAt: Date.now(),
+    });
+    store.upsert({
+      username: "v3",
+      stripeCustomerId: "cus_v3",
+      stripeSubscriptionId: "sub_v3",
+      status: "active",
+      currentPeriodEnd: futureEnd + 30 * 86400,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+      updatedAt: Date.now(),
+    });
+    const record = store.getByUsername("v3");
+    expect(record?.cancelAtPeriodEnd).toBe(false);
+    expect(record?.cancelAt).toBeNull();
   });
 });

--- a/services/api/subscriptions.ts
+++ b/services/api/subscriptions.ts
@@ -7,6 +7,8 @@ export interface SubscriptionRecord {
   stripeSubscriptionId: string;
   status: string; // 'active' | 'canceled' | 'past_due' | 'trialing'
   currentPeriodEnd: number | null; // Unix seconds
+  cancelAtPeriodEnd: boolean;
+  cancelAt: number | null; // Unix seconds
   updatedAt: number;
 }
 
@@ -16,6 +18,8 @@ interface SubscriptionRow {
   stripe_subscription_id: string;
   status: string;
   current_period_end: number | null;
+  cancel_at_period_end: number;
+  cancel_at: number | null;
   updated_at: number;
 }
 
@@ -26,6 +30,8 @@ function rowToRecord(row: SubscriptionRow): SubscriptionRecord {
     stripeSubscriptionId: row.stripe_subscription_id,
     status: row.status,
     currentPeriodEnd: row.current_period_end,
+    cancelAtPeriodEnd: row.cancel_at_period_end === 1,
+    cancelAt: row.cancel_at,
     updatedAt: row.updated_at,
   };
 }
@@ -43,6 +49,8 @@ export class SubscriptionStore {
         stripe_subscription_id TEXT NOT NULL,
         status TEXT NOT NULL,
         current_period_end INTEGER,
+        cancel_at_period_end INTEGER NOT NULL DEFAULT 0,
+        cancel_at INTEGER,
         updated_at INTEGER NOT NULL
       );
       CREATE INDEX IF NOT EXISTS idx_subscriptions_customer ON subscriptions(stripe_customer_id);
@@ -71,14 +79,16 @@ export class SubscriptionStore {
 
   upsert(record: SubscriptionRecord): void {
     this.db
-      .query<void, [string, string, string, string, number | null, number]>(
-        `INSERT INTO subscriptions (username, stripe_customer_id, stripe_subscription_id, status, current_period_end, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?)
+      .query<void, [string, string, string, string, number | null, number, number | null, number]>(
+        `INSERT INTO subscriptions (username, stripe_customer_id, stripe_subscription_id, status, current_period_end, cancel_at_period_end, cancel_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(username) DO UPDATE SET
            stripe_customer_id = excluded.stripe_customer_id,
            stripe_subscription_id = excluded.stripe_subscription_id,
            status = excluded.status,
            current_period_end = excluded.current_period_end,
+           cancel_at_period_end = excluded.cancel_at_period_end,
+           cancel_at = excluded.cancel_at,
            updated_at = excluded.updated_at`,
       )
       .run(
@@ -87,6 +97,8 @@ export class SubscriptionStore {
         record.stripeSubscriptionId,
         record.status,
         record.currentPeriodEnd,
+        record.cancelAtPeriodEnd ? 1 : 0,
+        record.cancelAt,
         record.updatedAt,
       );
   }

--- a/services/api/subscriptions.ts
+++ b/services/api/subscriptions.ts
@@ -79,7 +79,19 @@ export class SubscriptionStore {
 
   upsert(record: SubscriptionRecord): void {
     this.db
-      .query<void, [string, string, string, string, number | null, number, number | null, number]>(
+      .query<
+        void,
+        [
+          string,
+          string,
+          string,
+          string,
+          number | null,
+          number,
+          number | null,
+          number,
+        ]
+      >(
         `INSERT INTO subscriptions (username, stripe_customer_id, stripe_subscription_id, status, current_period_end, cancel_at_period_end, cancel_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(username) DO UPDATE SET


### PR DESCRIPTION
Closes #181

## Summary

- **Schema**: Added `cancel_at_period_end INTEGER NOT NULL DEFAULT 0` and `cancel_at INTEGER NULL` columns to the `subscriptions` table
- **Webhook**: `customer.subscription.updated`/`deleted` handler now reads `data.cancel_at_period_end` and `data.cancel_at` and persists them
- **API**: `/api/app/billing/status` returns `cancelAtPeriodEnd` (bool) and `cancelAt` (Unix seconds or null)
- **UI**: `BillingPage` shows "Cancels on {date}" instead of "Renews on …" when `cancelAtPeriodEnd` is true

## Test plan

- [ ] All 209 unit tests pass (`bun run test`)
- [ ] `SubscriptionStore` — 3 new tests covering persist/clear/round-trip of `cancelAtPeriodEnd` + `cancelAt`
- [ ] Webhook idempotency — 2 new tests: setting and clearing `cancel_at_period_end` via simulated webhook upsert
- [ ] Manual: subscribe in Stripe test mode → cancel via customer portal → billing page shows "Cancels on …"

## Workflow evidence

- Issue read via: `mcp__MCP_DOCKER__issue_read` (issue #181)
- Branch created via: `mcp__MCP_DOCKER__create_branch` (off `development/stripe-paywall`, SHA `ca19b76`)
- Commit SHA: `aa5aca1`
- PR created via: `mcp__MCP_DOCKER__create_pull_request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)