### PR TITLE
Fix Stripe billing idempotency keys

### DIFF
--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "crypto";
+
+import { config } from "./config";
+import { createApiServer } from "./server";
+import { SessionStore, sessionStore } from "./sessions";
+import { SubscriptionStore, subscriptionStore } from "./subscriptions";
+
+type MockedFetchCall = {
+  path: string;
+  idempotencyKey: string | null;
+};
+
+const originalFetch = globalThis.fetch;
+const originalApiPort = config.apiPort;
+const originalStripeSecretKey = config.stripeSecretKey;
+const originalStripePriceId = config.stripePriceId;
+const originalSessionsDbPath = config.sessionsDbPath;
+
+let fetchCalls: MockedFetchCall[] = [];
+
+beforeEach(() => {
+  config.apiPort = 0;
+  config.stripeSecretKey = "sk_test_bindersnap";
+  config.stripePriceId = "price_test_bindersnap";
+  config.sessionsDbPath = `/tmp/bindersnap-server-test-${randomUUID()}.sqlite`;
+
+  (sessionStore as { _store: SessionStore | null })._store = new SessionStore(
+    config.sessionsDbPath,
+  );
+  (subscriptionStore as { _store: SubscriptionStore | null })._store =
+    new SubscriptionStore(config.sessionsDbPath);
+
+  fetchCalls = [];
+  globalThis.fetch = (async (input, init) => {
+    const url = new URL(typeof input === "string" ? input : input.url);
+    fetchCalls.push({
+      path: url.pathname,
+      idempotencyKey: new Headers(init?.headers).get("Idempotency-Key") ?? null,
+    });
+
+    const responseUrl = url.pathname.includes("billing_portal")
+      ? "https://billing.stripe.com/p/session/test_123"
+      : "https://checkout.stripe.com/c/pay/test_123";
+
+    return new Response(JSON.stringify({ url: responseUrl }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  config.apiPort = originalApiPort;
+  config.stripeSecretKey = originalStripeSecretKey;
+  config.stripePriceId = originalStripePriceId;
+  config.sessionsDbPath = originalSessionsDbPath;
+});
+
+function seedSession(username: string): string {
+  const sessionId = `sess_${randomUUID()}`;
+  sessionStore.put({
+    id: sessionId,
+    username,
+    giteaToken: "gitea_token_test",
+    giteaTokenName: "bindersnap-test-token",
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  });
+  return sessionId;
+}
+
+function makeBillingRequest(pathname: string, sessionId: string): Request {
+  return new Request(`http://localhost${pathname}`, {
+    method: "POST",
+    headers: {
+      Origin: config.appOrigin,
+      Cookie: `${config.sessionCookieName}=${sessionId}`,
+    },
+  });
+}
+
+describe("billing Stripe idempotency", () => {
+  test("checkout sends a unique Stripe Idempotency-Key per attempt", async () => {
+    const server = createApiServer();
+    const username = `checkout-${randomUUID()}`;
+    const sessionId = seedSession(username);
+
+    try {
+      const first = await server.fetch(
+        makeBillingRequest("/api/app/billing/checkout", sessionId),
+      );
+      const second = await server.fetch(
+        makeBillingRequest("/api/app/billing/checkout", sessionId),
+      );
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(fetchCalls).toHaveLength(2);
+      expect(fetchCalls[0]?.path).toBe("/v1/checkout/sessions");
+      expect(fetchCalls[1]?.path).toBe("/v1/checkout/sessions");
+      expect(fetchCalls[0]?.idempotencyKey).toMatch(
+        /^checkout-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+      expect(fetchCalls[1]?.idempotencyKey).toMatch(
+        /^checkout-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+      expect(fetchCalls[0]?.idempotencyKey).not.toBe(
+        fetchCalls[1]?.idempotencyKey,
+      );
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("portal sends a unique Stripe Idempotency-Key per attempt", async () => {
+    const server = createApiServer();
+    const username = `portal-${randomUUID()}`;
+    const sessionId = seedSession(username);
+
+    subscriptionStore.upsert({
+      username,
+      stripeCustomerId: "cus_test_123",
+      stripeSubscriptionId: "sub_test_123",
+      status: "active",
+      currentPeriodEnd: Math.floor(Date.now() / 1000) + 60_000,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+      updatedAt: Date.now(),
+    });
+
+    try {
+      const first = await server.fetch(
+        makeBillingRequest("/api/app/billing/portal", sessionId),
+      );
+      const second = await server.fetch(
+        makeBillingRequest("/api/app/billing/portal", sessionId),
+      );
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(fetchCalls).toHaveLength(2);
+      expect(fetchCalls[0]?.path).toBe("/v1/billing_portal/sessions");
+      expect(fetchCalls[1]?.path).toBe("/v1/billing_portal/sessions");
+      expect(fetchCalls[0]?.idempotencyKey).toMatch(
+        /^portal-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+      expect(fetchCalls[1]?.idempotencyKey).toMatch(
+        /^portal-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+      expect(fetchCalls[0]?.idempotencyKey).not.toBe(
+        fetchCalls[1]?.idempotencyKey,
+      );
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -574,6 +574,14 @@ async function stripeFetch(
   });
 }
 
+export function createStripeRequestIdempotencyKey(
+  flow: "checkout" | "portal",
+): string {
+  // Stripe's Idempotency-Key dedupes retries of the same logical request;
+  // consumeCheckoutRateLimit separately handles repeat user attempts.
+  return `${flow}-${randomUUID()}`;
+}
+
 function parsePositiveIntInput(
   value: string | number | null | undefined,
   fallback: number,
@@ -2657,9 +2665,8 @@ async function handleBillingCheckout(
     cancel_url: `${config.appOrigin}/billing`,
   });
 
-  const checkoutIdempotencyKey = `checkout-${auth.session.username}-${Math.floor(Date.now() / 60000)}`;
   const resp = await stripeFetch("/v1/checkout/sessions", body, {
-    "Idempotency-Key": checkoutIdempotencyKey,
+    "Idempotency-Key": createStripeRequestIdempotencyKey("checkout"),
   });
   if (!resp.ok) {
     const err = (await resp.json().catch(() => null)) as Record<
@@ -2726,9 +2733,8 @@ async function handleBillingPortal(
     return_url: `${config.appOrigin}/billing`,
   });
 
-  const portalIdempotencyKey = `portal-${auth.session.username}-${Math.floor(Date.now() / 60000)}`;
   const resp = await stripeFetch("/v1/billing_portal/sessions", body, {
-    "Idempotency-Key": portalIdempotencyKey,
+    "Idempotency-Key": createStripeRequestIdempotencyKey("portal"),
   });
   if (!resp.ok) {
     const err = (await resp.json().catch(() => null)) as Record<


### PR DESCRIPTION
## Summary
- replace minute-bucket Stripe idempotency keys with per-attempt UUID keys for checkout and billing portal flows
- document that Stripe idempotency is for retry dedupe while `consumeCheckoutRateLimit` handles repeat user attempts
- add endpoint-level API tests that assert checkout and portal each send a fresh `Idempotency-Key` on separate attempts

## Testing
- `bun test services/api`
- `bunx prettier --check services/api/server.ts services/api/server.test.ts`
- `git diff --check`

## Issue
Closes #182

## Workflow Evidence
- Issue read method: `mcp__MCP_DOCKER__.search_issues` with `repo:davidgraymi/bindersnap-editor-demo is:issue 182 in:number`
- Branch creation method: `mcp__MCP_DOCKER__.create_branch` from `development/stripe-paywall` to `codex/issue-182-stripe-idempotency`
- Commit SHA: `cb7a36a4ebcad49dbf4cf5927837b96b6a82b725`
- PR creation method: `mcp__MCP_DOCKER__.create_pull_request`
- Fallbacks used: none

## Notes
- I did not run the Stripe Playwright integration suite because `STRIPE_SECRET_KEY` / `STRIPE_PRICE_ID` are not configured in this workspace.