### PR TITLE
Treat billing-status fetch failures as unpaid

### DIFF
--- a/apps/app/App.test.ts
+++ b/apps/app/App.test.ts
@@ -97,9 +97,7 @@ let originalHistory: typeof globalThis.history | undefined;
 let originalHTMLElement: typeof globalThis.HTMLElement | undefined;
 let originalElement: typeof globalThis.Element | undefined;
 let originalNode: typeof globalThis.Node | undefined;
-let originalMutationObserver:
-  | typeof globalThis.MutationObserver
-  | undefined;
+let originalMutationObserver: typeof globalThis.MutationObserver | undefined;
 let originalPopStateEvent: typeof globalThis.PopStateEvent | undefined;
 let originalEvent: typeof globalThis.Event | undefined;
 let originalRequestAnimationFrame:

--- a/apps/app/App.test.ts
+++ b/apps/app/App.test.ts
@@ -1,15 +1,328 @@
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { createElement } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { JSDOM } from "jsdom";
 
-import { resolveSubscriptionStatus } from "./App";
 import { resolveSignupPrefill } from "./authIntent";
 import { resolveGiteaTokenScopes } from "./giteaTokenScopes";
 
-test("resolveSubscriptionStatus treats missing or inactive billing records as unpaid", () => {
+const mockClearToken = mock(() => {});
+const mockCreateCheckoutSession = mock(async () => ({
+  url: "https://example.com/checkout",
+}));
+const mockCreatePortalSession = mock(async () => ({
+  url: "https://example.com/portal",
+}));
+const mockFetchBillingStatus = mock(async () => ({
+  status: "active",
+  currentPeriodEnd: null,
+  cancelAtPeriodEnd: false,
+  cancelAt: null,
+}));
+const mockFetchSessionUser = mock(async () => ({
+  user: null,
+  token: null,
+}));
+const mockLogin = mock(async () => ({
+  user: null,
+  token: null,
+}));
+const mockLogoutSession = mock(async () => {});
+const mockSignup = mock(async () => ({
+  user: null,
+  token: null,
+}));
+const mockStoreToken = mock(() => {});
+
+mock.module("./api", () => ({
+  clearToken: mockClearToken,
+  createCheckoutSession: mockCreateCheckoutSession,
+  createPortalSession: mockCreatePortalSession,
+  fetchBillingStatus: mockFetchBillingStatus,
+  fetchSessionUser: mockFetchSessionUser,
+  login: mockLogin,
+  logoutSession: mockLogoutSession,
+  signup: mockSignup,
+  storeToken: mockStoreToken,
+}));
+
+mock.module("./components/AppShell", () => ({
+  AppShell: ({ route }: { route: { kind: string } }) =>
+    createElement(
+      "div",
+      {
+        "data-testid": "app-shell",
+        "data-route-kind": route.kind,
+      },
+      `workspace:${route.kind}`,
+    ),
+}));
+
+mock.module("./components/BillingPage", () => ({
+  BillingPage: ({
+    subscriptionStatus,
+    hasBillingStatusError,
+  }: {
+    subscriptionStatus: string;
+    hasBillingStatusError: boolean;
+  }) =>
+    createElement(
+      "div",
+      {
+        "data-testid": "billing-page",
+        "data-subscription-status": subscriptionStatus,
+        "data-has-billing-status-error": hasBillingStatusError
+          ? "true"
+          : "false",
+      },
+      `billing:${subscriptionStatus}`,
+    ),
+}));
+
+mock.module("./components/BindersnapLogoMark", () => ({
+  BindersnapLogoMark: () =>
+    createElement("div", { "data-testid": "logo-mark" }),
+}));
+
+mock.module("./components/LandingPage", () => ({
+  LandingPage: () => createElement("div", { "data-testid": "landing-page" }),
+}));
+
+let originalWindow: typeof globalThis.window | undefined;
+let originalDocument: typeof globalThis.document | undefined;
+let originalNavigator: typeof globalThis.navigator | undefined;
+let originalLocation: typeof globalThis.location | undefined;
+let originalHistory: typeof globalThis.history | undefined;
+let originalHTMLElement: typeof globalThis.HTMLElement | undefined;
+let originalElement: typeof globalThis.Element | undefined;
+let originalNode: typeof globalThis.Node | undefined;
+let originalMutationObserver:
+  | typeof globalThis.MutationObserver
+  | undefined;
+let originalPopStateEvent: typeof globalThis.PopStateEvent | undefined;
+let originalEvent: typeof globalThis.Event | undefined;
+let originalRequestAnimationFrame:
+  | typeof globalThis.requestAnimationFrame
+  | undefined;
+let originalCancelAnimationFrame:
+  | typeof globalThis.cancelAnimationFrame
+  | undefined;
+
+function installDom(pathname = "/") {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: `https://bindersnap.com${pathname}`,
+  });
+
+  for (const [key, value] of Object.entries({
+    window: dom.window,
+    document: dom.window.document,
+    navigator: dom.window.navigator,
+    location: dom.window.location,
+    history: dom.window.history,
+    HTMLElement: dom.window.HTMLElement,
+    Element: dom.window.Element,
+    Node: dom.window.Node,
+    MutationObserver: dom.window.MutationObserver,
+    PopStateEvent: dom.window.PopStateEvent,
+    Event: dom.window.Event,
+    requestAnimationFrame: (callback: FrameRequestCallback) =>
+      setTimeout(() => callback(0), 0),
+    cancelAnimationFrame: (handle: number) => clearTimeout(handle),
+  })) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+    });
+  }
+
+  return dom;
+}
+
+function mountApp(App: () => JSX.Element) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+
+  flushSync(() => {
+    root.render(createElement(App));
+  });
+
+  const unmount = () => {
+    flushSync(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
+
+  return { container, unmount };
+}
+
+async function waitFor(assertion: () => void, timeoutMs = 750) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  throw lastError;
+}
+
+beforeEach(() => {
+  originalWindow = globalThis.window;
+  originalDocument = globalThis.document;
+  originalNavigator = globalThis.navigator;
+  originalLocation = globalThis.location;
+  originalHistory = globalThis.history;
+  originalHTMLElement = globalThis.HTMLElement;
+  originalElement = globalThis.Element;
+  originalNode = globalThis.Node;
+  originalMutationObserver = globalThis.MutationObserver;
+  originalPopStateEvent = globalThis.PopStateEvent;
+  originalEvent = globalThis.Event;
+  originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  installDom();
+
+  mockClearToken.mockReset();
+  mockCreateCheckoutSession.mockReset();
+  mockCreatePortalSession.mockReset();
+  mockFetchBillingStatus.mockReset();
+  mockFetchSessionUser.mockReset();
+  mockLogin.mockReset();
+  mockLogoutSession.mockReset();
+  mockSignup.mockReset();
+  mockStoreToken.mockReset();
+
+  mockCreateCheckoutSession.mockImplementation(async () => ({
+    url: "https://example.com/checkout",
+  }));
+  mockCreatePortalSession.mockImplementation(async () => ({
+    url: "https://example.com/portal",
+  }));
+  mockFetchBillingStatus.mockImplementation(async () => ({
+    status: "active",
+    currentPeriodEnd: null,
+    cancelAtPeriodEnd: false,
+    cancelAt: null,
+  }));
+  mockFetchSessionUser.mockImplementation(async () => ({
+    user: null,
+    token: null,
+  }));
+  mockLogin.mockImplementation(async () => ({
+    user: null,
+    token: null,
+  }));
+  mockLogoutSession.mockImplementation(async () => {});
+  mockSignup.mockImplementation(async () => ({
+    user: null,
+    token: null,
+  }));
+});
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: originalDocument,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: originalNavigator,
+  });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+  Object.defineProperty(globalThis, "history", {
+    configurable: true,
+    value: originalHistory,
+  });
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: originalHTMLElement,
+  });
+  Object.defineProperty(globalThis, "Element", {
+    configurable: true,
+    value: originalElement,
+  });
+  Object.defineProperty(globalThis, "Node", {
+    configurable: true,
+    value: originalNode,
+  });
+  Object.defineProperty(globalThis, "MutationObserver", {
+    configurable: true,
+    value: originalMutationObserver,
+  });
+  Object.defineProperty(globalThis, "PopStateEvent", {
+    configurable: true,
+    value: originalPopStateEvent,
+  });
+  Object.defineProperty(globalThis, "Event", {
+    configurable: true,
+    value: originalEvent,
+  });
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: originalRequestAnimationFrame,
+  });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    value: originalCancelAnimationFrame,
+  });
+});
+
+test("resolveSubscriptionStatus treats missing or inactive billing records as unpaid", async () => {
+  const { resolveSubscriptionStatus } = await import("./App");
+
   expect(resolveSubscriptionStatus("active")).toBe("active");
   expect(resolveSubscriptionStatus("trialing")).toBe("active");
   expect(resolveSubscriptionStatus(null)).toBe("none");
   expect(resolveSubscriptionStatus("past_due")).toBe("none");
   expect(resolveSubscriptionStatus("canceled")).toBe("none");
+});
+
+test("App redirects signed-in users to billing when the billing status fetch rejects", async () => {
+  mockFetchSessionUser.mockImplementation(async () => ({
+    user: { username: "alice", fullName: "Alice Example" },
+    token: "session-token",
+  }));
+  mockFetchBillingStatus.mockImplementation(async () => {
+    throw new Error("billing service unavailable");
+  });
+
+  const { App } = await import("./App");
+  const { container, unmount } = mountApp(App);
+
+  try {
+    await waitFor(() => {
+      const billingPage = container.querySelector<HTMLElement>(
+        '[data-testid="billing-page"]',
+      );
+
+      expect(window.location.pathname).toBe("/billing");
+      expect(billingPage?.dataset.subscriptionStatus).toBe("none");
+      expect(billingPage?.dataset.hasBillingStatusError).toBe("true");
+      expect(container.querySelector('[data-testid="app-shell"]')).toBeNull();
+    });
+  } finally {
+    unmount();
+  }
 });
 
 test("resolveGiteaTokenScopes includes all required write scopes by default", () => {

--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -275,6 +275,7 @@ export function App() {
   const [subscriptionStatus, setSubscriptionStatus] = useState<
     "active" | "none" | "loading" | null
   >(null);
+  const [hasBillingStatusError, setHasBillingStatusError] = useState(false);
   const [currentPeriodEnd, setCurrentPeriodEnd] = useState<number | null>(null);
   const [cancelAtPeriodEnd, setCancelAtPeriodEnd] = useState(false);
   const [cancelAt, setCancelAt] = useState<number | null>(null);
@@ -294,17 +295,24 @@ export function App() {
       setCallbackError(null);
       if (resolvedUser) {
         setSubscriptionStatus("loading");
+        setHasBillingStatusError(false);
         try {
           const billing = await fetchBillingStatus();
           setSubscriptionStatus(resolveSubscriptionStatus(billing.status));
+          setHasBillingStatusError(false);
           setCurrentPeriodEnd(billing.currentPeriodEnd);
           setCancelAtPeriodEnd(billing.cancelAtPeriodEnd);
           setCancelAt(billing.cancelAt);
         } catch {
-          setSubscriptionStatus(null);
+          setSubscriptionStatus("none");
+          setHasBillingStatusError(true);
+          setCurrentPeriodEnd(null);
+          setCancelAtPeriodEnd(false);
+          setCancelAt(null);
         }
       } else {
         setSubscriptionStatus(null);
+        setHasBillingStatusError(false);
         setCurrentPeriodEnd(null);
         setCancelAtPeriodEnd(false);
         setCancelAt(null);
@@ -313,6 +321,7 @@ export function App() {
     } catch (sessionError) {
       setUser(null);
       setSubscriptionStatus(null);
+      setHasBillingStatusError(false);
       setCurrentPeriodEnd(null);
       setCancelAtPeriodEnd(false);
       setCancelAt(null);
@@ -399,6 +408,10 @@ export function App() {
       return "callback";
     }
 
+    if (user && subscriptionStatus === "none") {
+      return "billing";
+    }
+
     if (route.kind === "home") {
       return user ? "app" : "landing";
     }
@@ -412,7 +425,7 @@ export function App() {
     }
 
     return user ? "app" : "login";
-  }, [isCheckingSession, route, user]);
+  }, [isCheckingSession, route, subscriptionStatus, user]);
 
   useEffect(() => {
     document.body.setAttribute("data-app-view", view);
@@ -454,6 +467,7 @@ export function App() {
     return (
       <BillingPage
         subscriptionStatus={subscriptionStatus ?? "loading"}
+        hasBillingStatusError={hasBillingStatusError}
         currentPeriodEnd={currentPeriodEnd}
         cancelAtPeriodEnd={cancelAtPeriodEnd}
         cancelAt={cancelAt}
@@ -467,7 +481,11 @@ export function App() {
         }}
         onSubscriptionConfirmed={() => {
           setSubscriptionStatus("active");
+          setHasBillingStatusError(false);
           navigateTo({ kind: "home" }, true);
+        }}
+        onRetryBillingStatus={async () => {
+          await refreshSession();
         }}
       />
     );

--- a/apps/app/components/BillingPage.tsx
+++ b/apps/app/components/BillingPage.tsx
@@ -4,27 +4,32 @@ import { fetchBillingStatus } from "../api";
 
 interface BillingPageProps {
   subscriptionStatus: "active" | "none" | "loading";
+  hasBillingStatusError: boolean;
   currentPeriodEnd: number | null;
   cancelAtPeriodEnd: boolean;
   cancelAt: number | null;
   onSubscribe: () => Promise<void>;
   onManage: () => Promise<void>;
   onSubscriptionConfirmed: () => void;
+  onRetryBillingStatus: () => Promise<void>;
 }
 
 export function BillingPage({
   subscriptionStatus,
+  hasBillingStatusError,
   currentPeriodEnd,
   cancelAtPeriodEnd,
   cancelAt,
   onSubscribe,
   onManage,
   onSubscriptionConfirmed,
+  onRetryBillingStatus,
 }: BillingPageProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isPolling, setIsPolling] = useState(false);
   const [pollingFailed, setPollingFailed] = useState(false);
+  const [isRetryingBillingStatus, setIsRetryingBillingStatus] = useState(false);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -216,11 +221,61 @@ export function BillingPage({
         <div className="app-login-panel bs-card">
           <div className="bs-eyebrow">Bindersnap Pro</div>
           <h1>Start your subscription</h1>
+          {hasBillingStatusError ? (
+            <div
+              role="status"
+              style={{
+                display: "grid",
+                gap: "var(--brand-space-3)",
+                marginBottom: "var(--brand-space-4)",
+                padding: "var(--brand-space-4)",
+                borderRadius: "var(--brand-radius-lg)",
+                border: "1px solid var(--bs-rule)",
+                background: "var(--bs-surface-2)",
+                color: "var(--bs-text-secondary)",
+              }}
+            >
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "var(--brand-text-sm)",
+                }}
+              >
+                We couldn&apos;t verify your billing status. Please retry before
+                you continue.
+              </p>
+              <div>
+                <button
+                  className="bs-btn bs-btn-secondary"
+                  type="button"
+                  disabled={isRetryingBillingStatus}
+                  onClick={async () => {
+                    setIsRetryingBillingStatus(true);
+                    try {
+                      await onRetryBillingStatus();
+                    } finally {
+                      if (isMounted.current) {
+                        setIsRetryingBillingStatus(false);
+                      }
+                    }
+                  }}
+                >
+                  {isRetryingBillingStatus
+                    ? "Retrying…"
+                    : "Retry billing check"}
+                </button>
+              </div>
+            </div>
+          ) : null}
           <p style={{ color: "var(--bs-text-muted)" }}>$100 / month</p>
           <button
             className="bs-btn bs-btn-primary"
             type="button"
-            disabled={isSubmitting || subscriptionStatus === "loading"}
+            disabled={
+              isSubmitting ||
+              isRetryingBillingStatus ||
+              subscriptionStatus === "loading"
+            }
             onClick={async () => {
               setIsSubmitting(true);
               setError(null);


### PR DESCRIPTION
## Summary
- treat `fetchBillingStatus()` failures as unpaid so authenticated users are routed to `/billing` instead of falling into a 402 dead-end
- surface a non-fatal billing-status retry banner on the billing page and allow users to retry the status check before checkout
- add a focused `App` regression test for the rejected billing-status path

## Testing
- `bun test apps/app/App.test.ts`
- `bun test apps/app`
- `git diff --check -- apps/app/App.tsx apps/app/components/BillingPage.tsx apps/app/App.test.ts`

## Workflow Evidence
- Issue read: `issue_read` (`get`) on #183
- Branch creation: `create_branch` from `development/stripe-paywall`
- Commit SHA: `56f1b7cc65ae1c6b23ae80c32afa4f91f9c5f050`
- PR creation: `create_pull_request`
- Fallbacks used: none

Closes #183