### PR TITLE
Handle SPA 402 billing redirects

### DIFF
--- a/apps/app/App.test.ts
+++ b/apps/app/App.test.ts
@@ -323,6 +323,46 @@ test("App redirects signed-in users to billing when the billing status fetch rej
   }
 });
 
+test("App redirects signed-in users to billing when the payment required handler fires", async () => {
+  mockFetchSessionUser.mockImplementation(async () => ({
+    user: { username: "alice", fullName: "Alice Example" },
+    token: "session-token",
+  }));
+  mockFetchBillingStatus.mockImplementation(async () => ({
+    status: "active",
+    currentPeriodEnd: null,
+    cancelAtPeriodEnd: false,
+    cancelAt: null,
+  }));
+
+  const { App } = await import("./App");
+  const { notifyPaymentRequired } = await import("./paymentRequired");
+  const { container, unmount } = mountApp(App);
+
+  try {
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="app-shell"]'),
+      ).not.toBeNull();
+    });
+
+    notifyPaymentRequired();
+
+    await waitFor(() => {
+      const billingPage = container.querySelector<HTMLElement>(
+        '[data-testid="billing-page"]',
+      );
+
+      expect(window.location.pathname).toBe("/billing");
+      expect(billingPage?.dataset.subscriptionStatus).toBe("none");
+      expect(billingPage?.dataset.hasBillingStatusError).toBe("false");
+      expect(container.querySelector('[data-testid="app-shell"]')).toBeNull();
+    });
+  } finally {
+    unmount();
+  }
+});
+
 test("resolveGiteaTokenScopes includes all required write scopes by default", () => {
   expect(resolveGiteaTokenScopes()).toEqual([
     "write:user",

--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -23,6 +23,7 @@ import {
   signup,
   storeToken,
 } from "./api";
+import { usePaymentRequiredHandler } from "./paymentRequired";
 import {
   asShellRoute,
   getRoute,
@@ -279,6 +280,18 @@ export function App() {
   const [currentPeriodEnd, setCurrentPeriodEnd] = useState<number | null>(null);
   const [cancelAtPeriodEnd, setCancelAtPeriodEnd] = useState(false);
   const [cancelAt, setCancelAt] = useState<number | null>(null);
+  const handlePaymentRequired = useCallback(() => {
+    if (!user) {
+      return;
+    }
+
+    setSubscriptionStatus("none");
+    setHasBillingStatusError(false);
+    setCurrentPeriodEnd(null);
+    setCancelAtPeriodEnd(false);
+    setCancelAt(null);
+    navigateTo({ kind: "billing" }, true);
+  }, [user]);
 
   const refreshSession = useCallback(async () => {
     setIsCheckingSession(true);
@@ -347,6 +360,8 @@ export function App() {
       window.removeEventListener("popstate", handlePopState);
     };
   }, []);
+
+  usePaymentRequiredHandler(handlePaymentRequired);
 
   useEffect(() => {
     if (route.kind === "callback") {

--- a/apps/app/api.test.ts
+++ b/apps/app/api.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "bun:test";
+
+function runApiCheck(script: string) {
+  const result = Bun.spawnSync({
+    cmd: ["bun", "-e", script],
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    exitCode: result.exitCode,
+    stdout: new TextDecoder().decode(result.stdout).trim(),
+    stderr: new TextDecoder().decode(result.stderr).trim(),
+  };
+}
+
+test("getWorkspaceDocuments redirects to billing after a 402 response", () => {
+  const result = runApiCheck(`
+    import { JSDOM } from "jsdom";
+    import { getWorkspaceDocuments } from "./apps/app/api.ts";
+    import { registerPaymentRequiredHandler } from "./apps/app/paymentRequired.ts";
+
+    const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+      url: "https://bindersnap.com/documents",
+    });
+
+    Object.assign(globalThis, {
+      window: dom.window,
+      document: dom.window.document,
+      location: dom.window.location,
+      history: dom.window.history,
+      PopStateEvent: dom.window.PopStateEvent,
+      fetch: async () =>
+        new Response(JSON.stringify({ error: "Billing required." }), {
+          status: 402,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }),
+    });
+
+    let handlerCalls = 0;
+    const unregister = registerPaymentRequiredHandler(() => {
+      handlerCalls += 1;
+      window.history.replaceState({}, "", "/billing");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    try {
+      await getWorkspaceDocuments();
+      console.error("expected getWorkspaceDocuments to reject");
+      process.exit(1);
+    } catch (error) {
+      if (!(error instanceof Error) || error.message !== "Billing required.") {
+        console.error("unexpected error", error);
+        process.exit(1);
+      }
+    } finally {
+      unregister();
+    }
+
+    if (handlerCalls !== 1) {
+      console.error("expected handlerCalls=1 but got", handlerCalls);
+      process.exit(1);
+    }
+
+    if (window.location.pathname !== "/billing") {
+      console.error("expected redirect to /billing but got", window.location.pathname);
+      process.exit(1);
+    }
+  `);
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+});
+
+test("fetchBillingStatus ignores 402 interception for billing endpoints", () => {
+  const result = runApiCheck(`
+    import { JSDOM } from "jsdom";
+    import { fetchBillingStatus } from "./apps/app/api.ts";
+    import { registerPaymentRequiredHandler } from "./apps/app/paymentRequired.ts";
+
+    const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+      url: "https://bindersnap.com/documents",
+    });
+
+    Object.assign(globalThis, {
+      window: dom.window,
+      document: dom.window.document,
+      location: dom.window.location,
+      history: dom.window.history,
+      PopStateEvent: dom.window.PopStateEvent,
+      fetch: async () =>
+        new Response(JSON.stringify({ status: "past_due" }), {
+          status: 402,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }),
+    });
+
+    let handlerCalls = 0;
+    const unregister = registerPaymentRequiredHandler(() => {
+      handlerCalls += 1;
+    });
+
+    const billing = await fetchBillingStatus();
+    unregister();
+
+    if (handlerCalls !== 0) {
+      console.error("expected handlerCalls=0 but got", handlerCalls);
+      process.exit(1);
+    }
+
+    if (window.location.pathname !== "/documents") {
+      console.error("unexpected redirect to", window.location.pathname);
+      process.exit(1);
+    }
+
+    if (billing.status !== "past_due") {
+      console.error("expected status past_due but got", billing.status);
+      process.exit(1);
+    }
+  `);
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+});

--- a/apps/app/api.ts
+++ b/apps/app/api.ts
@@ -16,6 +16,10 @@ import type {
   UploadValidationResult,
 } from "../../packages/gitea-client/uploads";
 import { validateUploadFile as validateUploadFileWithClient } from "../../packages/gitea-client/uploads";
+import {
+  notifyPaymentRequired,
+  shouldInterceptPaymentRequired,
+} from "./paymentRequired";
 
 // Bun's bundler (`bun build --env='BUN_PUBLIC_*'`) replaces
 // process.env.BUN_PUBLIC_API_BASE_URL with a literal string at compile time.
@@ -158,15 +162,32 @@ function parseSessionAuthState(payload: unknown): SessionAuthState {
   };
 }
 
+function maybeHandlePaymentRequired(path: string, response: Response): void {
+  if (response.status === 402 && shouldInterceptPaymentRequired(path)) {
+    notifyPaymentRequired();
+  }
+}
+
+async function fetchApi(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const response = await fetch(resolveApiUrl(path), {
+    credentials: "include",
+    ...init,
+  });
+
+  maybeHandlePaymentRequired(path, response);
+
+  return response;
+}
+
 async function requestJson<T>(
   path: string,
   init: RequestInit = {},
   fallbackError = "Request failed.",
 ): Promise<T> {
-  const response = await fetch(resolveApiUrl(path), {
-    credentials: "include",
-    ...init,
-  });
+  const response = await fetchApi(path, init);
 
   const payload = (await response.json().catch(() => null)) as unknown;
   if (!response.ok) {
@@ -418,18 +439,13 @@ export async function downloadDocument(
   repo: string,
   ref: string,
 ): Promise<Blob> {
-  const response = await fetch(
-    resolveApiUrl(
-      `/api/app/documents/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/download?ref=${encodeURIComponent(ref)}`,
-    ),
-    {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        Accept: "*/*",
-      },
+  const path = `/api/app/documents/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/download?ref=${encodeURIComponent(ref)}`;
+  const response = await fetchApi(path, {
+    method: "GET",
+    headers: {
+      Accept: "*/*",
     },
-  );
+  });
 
   if (!response.ok) {
     const payload = (await response.json().catch(() => null)) as unknown;
@@ -529,8 +545,7 @@ export async function fetchBillingStatus(): Promise<{
   cancelAtPeriodEnd: boolean;
   cancelAt: number | null;
 }> {
-  const response = await fetch(resolveApiUrl("/api/app/billing/status"), {
-    credentials: "include",
+  const response = await fetchApi("/api/app/billing/status", {
     headers: { Accept: "application/json" },
   });
   if (response.status === 401 || response.status === 404) {

--- a/apps/app/paymentRequired.ts
+++ b/apps/app/paymentRequired.ts
@@ -1,0 +1,27 @@
+import { useLayoutEffect } from "react";
+
+const paymentRequiredHandlers = new Set<() => void>();
+
+export function registerPaymentRequiredHandler(
+  handler: () => void,
+): () => void {
+  paymentRequiredHandlers.add(handler);
+
+  return () => {
+    paymentRequiredHandlers.delete(handler);
+  };
+}
+
+export function notifyPaymentRequired(): void {
+  for (const handler of paymentRequiredHandlers) {
+    handler();
+  }
+}
+
+export function shouldInterceptPaymentRequired(path: string): boolean {
+  return !(path === "/api/app/billing" || path.startsWith("/api/app/billing/"));
+}
+
+export function usePaymentRequiredHandler(handler: () => void): void {
+  useLayoutEffect(() => registerPaymentRequiredHandler(handler), [handler]);
+}


### PR DESCRIPTION
Closes #184.

## Summary
- add a small paywall event bridge so the SPA can react to `402 Payment Required` responses in one place
- intercept `402` in `apps/app/api.ts` for `requestJson` and raw document/billing fetches while skipping `/api/app/billing/*` endpoints to avoid loops
- register the handler in `App` so mid-session paywall changes set `subscriptionStatus` to `none` and move the user to `/billing`
- add app coverage for the registered handler and isolated API transport checks for the documents and billing-status paths

## Verification
- `bun test apps/app/App.test.ts apps/app/api.test.ts`
- `bun test apps/app`
- `bun run build`

## Workflow Evidence
- Issue read method: `mcp__MCP_DOCKER__.issue_read(method=get)` for issue `#184`
- Branch creation method: local git `git checkout -b codex/issue-184-402-interceptor` from `development/stripe-paywall`
- Commit SHA: `93e51ce`
- PR creation method: `mcp__MCP_DOCKER__.create_pull_request`
- Fallbacks used: none