### PR TITLE
Issue #185: prefill Stripe Checkout email and reuse customer

### DIFF
--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -8,7 +8,9 @@ import { SubscriptionStore, subscriptionStore } from "./subscriptions";
 
 type MockedFetchCall = {
   path: string;
+  method: string;
   idempotencyKey: string | null;
+  body: string | null;
 };
 
 const originalFetch = globalThis.fetch;
@@ -18,6 +20,7 @@ const originalStripePriceId = config.stripePriceId;
 const originalSessionsDbPath = config.sessionsDbPath;
 
 let fetchCalls: MockedFetchCall[] = [];
+let userEmailsByToken = new Map<string, string>();
 
 beforeEach(() => {
   config.apiPort = 0;
@@ -32,12 +35,53 @@ beforeEach(() => {
     new SubscriptionStore(config.sessionsDbPath);
 
   fetchCalls = [];
+  userEmailsByToken = new Map();
   globalThis.fetch = (async (input, init) => {
-    const url = new URL(typeof input === "string" ? input : input.url);
+    const requestUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const url = new URL(requestUrl);
+    const headers = new Headers(init?.headers);
+    const body =
+      typeof init?.body === "string"
+        ? init.body
+        : init?.body instanceof URLSearchParams
+          ? init.body.toString()
+          : null;
+
     fetchCalls.push({
       path: url.pathname,
-      idempotencyKey: new Headers(init?.headers).get("Idempotency-Key") ?? null,
+      method: init?.method ?? "GET",
+      idempotencyKey: headers.get("Idempotency-Key") ?? null,
+      body,
     });
+
+    if (url.pathname === "/api/v1/user") {
+      const authHeader = headers.get("Authorization") ?? "";
+      const token = authHeader.startsWith("token ")
+        ? authHeader.slice("token ".length)
+        : "";
+      const email = userEmailsByToken.get(token);
+
+      if (!email) {
+        return new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      }
+
+      return new Response(JSON.stringify({ email }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
 
     const responseUrl = url.pathname.includes("billing_portal")
       ? "https://billing.stripe.com/p/session/test_123"
@@ -60,17 +104,35 @@ afterEach(() => {
   config.sessionsDbPath = originalSessionsDbPath;
 });
 
-function seedSession(username: string): string {
+function seedSession(
+  username: string,
+  options?: {
+    email?: string;
+  },
+): string {
   const sessionId = `sess_${randomUUID()}`;
+  const giteaToken = `gitea_token_${randomUUID()}`;
+  const email =
+    options?.email ?? `${username.toLowerCase()}@${config.emailDomain}`;
+
+  userEmailsByToken.set(giteaToken, email);
   sessionStore.put({
     id: sessionId,
     username,
-    giteaToken: "gitea_token_test",
+    giteaToken,
     giteaTokenName: "bindersnap-test-token",
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
   });
   return sessionId;
+}
+
+function getFetchCallsByPath(path: string): MockedFetchCall[] {
+  return fetchCalls.filter((call) => call.path === path);
+}
+
+function getPostedFormBody(call: MockedFetchCall): URLSearchParams {
+  return new URLSearchParams(call.body ?? "");
 }
 
 function makeBillingRequest(pathname: string, sessionId: string): Request {
@@ -99,18 +161,77 @@ describe("billing Stripe idempotency", () => {
 
       expect(first.status).toBe(200);
       expect(second.status).toBe(200);
-      expect(fetchCalls).toHaveLength(2);
-      expect(fetchCalls[0]?.path).toBe("/v1/checkout/sessions");
-      expect(fetchCalls[1]?.path).toBe("/v1/checkout/sessions");
-      expect(fetchCalls[0]?.idempotencyKey).toMatch(
+      const checkoutCalls = getFetchCallsByPath("/v1/checkout/sessions");
+      expect(checkoutCalls).toHaveLength(2);
+      expect(checkoutCalls[0]?.idempotencyKey).toMatch(
         /^checkout-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
       );
-      expect(fetchCalls[1]?.idempotencyKey).toMatch(
+      expect(checkoutCalls[1]?.idempotencyKey).toMatch(
         /^checkout-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
       );
-      expect(fetchCalls[0]?.idempotencyKey).not.toBe(
-        fetchCalls[1]?.idempotencyKey,
+      expect(checkoutCalls[0]?.idempotencyKey).not.toBe(
+        checkoutCalls[1]?.idempotencyKey,
       );
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("checkout includes customer_email and bindersnap username metadata when no subscription exists", async () => {
+    const server = createApiServer();
+    const username = `checkout-metadata-${randomUUID()}`;
+    const email = `${username}@${config.emailDomain}`;
+    const sessionId = seedSession(username, { email });
+
+    try {
+      const response = await server.fetch(
+        makeBillingRequest("/api/app/billing/checkout", sessionId),
+      );
+
+      expect(response.status).toBe(200);
+      const checkoutCalls = getFetchCallsByPath("/v1/checkout/sessions");
+      expect(checkoutCalls).toHaveLength(1);
+
+      const form = getPostedFormBody(checkoutCalls[0]!);
+      expect(form.get("customer_email")).toBe(email);
+      expect(form.get("metadata[bindersnap_username]")).toBe(username);
+      expect(form.get("customer")).toBeNull();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("checkout reuses an existing stripe customer id when a subscription row exists", async () => {
+    const server = createApiServer();
+    const username = `checkout-customer-${randomUUID()}`;
+    const email = `${username}@${config.emailDomain}`;
+    const existingCustomerId = "cus_existing_123";
+    const sessionId = seedSession(username, { email });
+
+    subscriptionStore.upsert({
+      username,
+      stripeCustomerId: existingCustomerId,
+      stripeSubscriptionId: "sub_existing_123",
+      status: "incomplete",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+      updatedAt: Date.now(),
+    });
+
+    try {
+      const response = await server.fetch(
+        makeBillingRequest("/api/app/billing/checkout", sessionId),
+      );
+
+      expect(response.status).toBe(200);
+      const checkoutCalls = getFetchCallsByPath("/v1/checkout/sessions");
+      expect(checkoutCalls).toHaveLength(1);
+
+      const form = getPostedFormBody(checkoutCalls[0]!);
+      expect(form.get("customer")).toBe(existingCustomerId);
+      expect(form.get("customer_email")).toBeNull();
+      expect(form.get("metadata[bindersnap_username]")).toBe(username);
     } finally {
       server.stop(true);
     }
@@ -142,17 +263,16 @@ describe("billing Stripe idempotency", () => {
 
       expect(first.status).toBe(200);
       expect(second.status).toBe(200);
-      expect(fetchCalls).toHaveLength(2);
-      expect(fetchCalls[0]?.path).toBe("/v1/billing_portal/sessions");
-      expect(fetchCalls[1]?.path).toBe("/v1/billing_portal/sessions");
-      expect(fetchCalls[0]?.idempotencyKey).toMatch(
+      const portalCalls = getFetchCallsByPath("/v1/billing_portal/sessions");
+      expect(portalCalls).toHaveLength(2);
+      expect(portalCalls[0]?.idempotencyKey).toMatch(
         /^portal-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
       );
-      expect(fetchCalls[1]?.idempotencyKey).toMatch(
+      expect(portalCalls[1]?.idempotencyKey).toMatch(
         /^portal-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
       );
-      expect(fetchCalls[0]?.idempotencyKey).not.toBe(
-        fetchCalls[1]?.idempotencyKey,
+      expect(portalCalls[0]?.idempotencyKey).not.toBe(
+        portalCalls[1]?.idempotencyKey,
       );
     } finally {
       server.stop(true);

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -1000,6 +1000,46 @@ async function verifyUserCredentials(
     : null;
 }
 
+type GiteaCurrentUserRecord = {
+  email?: unknown;
+};
+
+async function fetchSessionUserEmail(
+  session: SessionRecord,
+): Promise<string | null> {
+  const response = await giteaFetch("/api/v1/user", {
+    method: "GET",
+    headers: {
+      Authorization: buildTokenAuthHeader(session.giteaToken),
+      Accept: "application/json",
+    },
+  }).catch(() => null);
+
+  if (!response) {
+    logger.warn("Unable to reach Gitea for billing email lookup", {
+      username: session.username,
+    });
+    return null;
+  }
+
+  if (!response.ok) {
+    logger.warn("Gitea billing email lookup failed", {
+      username: session.username,
+      status: response.status,
+    });
+    return null;
+  }
+
+  const payload = (await response
+    .json()
+    .catch(() => null)) as GiteaCurrentUserRecord | null;
+  const email =
+    typeof payload?.email === "string"
+      ? payload.email.trim().toLowerCase()
+      : "";
+  return looksLikeEmailAddress(email) ? email : null;
+}
+
 type GiteaEmailRecord = {
   email?: unknown;
   username?: unknown;
@@ -2656,14 +2696,24 @@ async function handleBillingCheckout(
     return json(503, { error: "Billing not configured." }, baseHeaders);
   }
 
+  const existingSubscription = subscriptionStore.getByUsername(
+    auth.session.username,
+  );
+  const userEmail = await fetchSessionUserEmail(auth.session);
   const body = new URLSearchParams({
     mode: "subscription",
     "line_items[0][price]": config.stripePriceId,
     "line_items[0][quantity]": "1",
     client_reference_id: auth.session.username,
+    "metadata[bindersnap_username]": auth.session.username,
     success_url: `${config.appOrigin}/billing?checkout=success`,
     cancel_url: `${config.appOrigin}/billing`,
   });
+  if (existingSubscription?.stripeCustomerId) {
+    body.set("customer", existingSubscription.stripeCustomerId);
+  } else if (userEmail) {
+    body.set("customer_email", userEmail);
+  }
 
   const resp = await stripeFetch("/v1/checkout/sessions", body, {
     "Idempotency-Key": createStripeRequestIdempotencyKey("checkout"),

--- a/tests/stripe-subscription.pw.ts
+++ b/tests/stripe-subscription.pw.ts
@@ -22,7 +22,7 @@
  *   SKIP_STACK=1 bun run test:integration -- tests/stripe-subscription.pw.ts
  */
 
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 import { resolveStripeWebhookSecret } from "./stripe-runtime";
 import { STRIPE_API_VERSION } from "../services/api/stripe/api-version";
 
@@ -240,12 +240,11 @@ async function cancelSubscriptionsForEmail(email: string): Promise<void> {
   }
 }
 
-async function fillVisibleInputAcrossFrames(
+async function waitForVisibleInputAcrossFrames(
   page: Page,
   selectors: string[],
-  value: string,
   options: { required?: boolean; timeoutMs?: number } = {},
-): Promise<boolean> {
+): Promise<Locator | null> {
   const startedAt = Date.now();
   const timeoutMs = options.timeoutMs ?? 15_000;
 
@@ -258,8 +257,7 @@ async function fillVisibleInputAcrossFrames(
           continue;
         }
 
-        await field.fill(value);
-        return true;
+        return field;
       }
     }
 
@@ -272,7 +270,22 @@ async function fillVisibleInputAcrossFrames(
     );
   }
 
-  return false;
+  return null;
+}
+
+async function fillVisibleInputAcrossFrames(
+  page: Page,
+  selectors: string[],
+  value: string,
+  options: { required?: boolean; timeoutMs?: number } = {},
+): Promise<boolean> {
+  const field = await waitForVisibleInputAcrossFrames(page, selectors, options);
+  if (!field) {
+    return false;
+  }
+
+  await field.fill(value);
+  return true;
 }
 
 async function completeHostedStripeCheckout(
@@ -282,12 +295,28 @@ async function completeHostedStripeCheckout(
   await page.waitForURL(/checkout\.stripe\.com/, { timeout: 30_000 });
 
   // Email field is type="text" with autocomplete="email" on Stripe Hosted Checkout.
-  await fillVisibleInputAcrossFrames(
+  const emailField = await waitForVisibleInputAcrossFrames(
     page,
     ['input[autocomplete="email"]', 'input[type="email"]', "#email"],
-    email,
     { required: true },
   );
+  if (!emailField) {
+    throw new Error("Stripe Hosted Checkout email field was not rendered");
+  }
+  let prefilledEmail = "";
+  const emailPrefillDeadline = Date.now() + 5_000;
+  while (Date.now() < emailPrefillDeadline) {
+    prefilledEmail = (await emailField.inputValue().catch(() => "")).trim();
+    if (prefilledEmail !== "") {
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+
+  if (prefilledEmail === "") {
+    await emailField.fill(email);
+  }
+  await expect(emailField).toHaveValue(email);
 
   // The Card radio is visually hidden under a custom overlay in older Stripe
   // Checkout. Force-click by ID to expand the card form.

--- a/tests/stripe-subscription.pw.ts
+++ b/tests/stripe-subscription.pw.ts
@@ -273,6 +273,33 @@ async function waitForVisibleInputAcrossFrames(
   return null;
 }
 
+async function waitForVisibleTextAcrossFrames(
+  page: Page,
+  text: string,
+  options: { required?: boolean; timeoutMs?: number } = {},
+): Promise<Locator | null> {
+  const startedAt = Date.now();
+  const timeoutMs = options.timeoutMs ?? 15_000;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    for (const frame of page.frames()) {
+      const value = frame.getByText(text, { exact: true }).first();
+      const visible = await value.isVisible().catch(() => false);
+      if (visible) {
+        return value;
+      }
+    }
+
+    await page.waitForTimeout(250);
+  }
+
+  if (options.required) {
+    throw new Error(`Could not find visible text in Stripe Checkout: ${text}`);
+  }
+
+  return null;
+}
+
 async function fillVisibleInputAcrossFrames(
   page: Page,
   selectors: string[],
@@ -294,29 +321,35 @@ async function completeHostedStripeCheckout(
 ): Promise<void> {
   await page.waitForURL(/checkout\.stripe\.com/, { timeout: 30_000 });
 
-  // Email field is type="text" with autocomplete="email" on Stripe Hosted Checkout.
+  // When Checkout receives customer_email or a Customer with a valid email,
+  // Stripe may render the contact email as a locked value instead of an input.
   const emailField = await waitForVisibleInputAcrossFrames(
     page,
     ['input[autocomplete="email"]', 'input[type="email"]', "#email"],
-    { required: true },
+    { timeoutMs: 5_000 },
   );
-  if (!emailField) {
-    throw new Error("Stripe Hosted Checkout email field was not rendered");
-  }
-  let prefilledEmail = "";
-  const emailPrefillDeadline = Date.now() + 5_000;
-  while (Date.now() < emailPrefillDeadline) {
-    prefilledEmail = (await emailField.inputValue().catch(() => "")).trim();
-    if (prefilledEmail !== "") {
-      break;
+  if (emailField) {
+    let prefilledEmail = "";
+    const emailPrefillDeadline = Date.now() + 5_000;
+    while (Date.now() < emailPrefillDeadline) {
+      prefilledEmail = (await emailField.inputValue().catch(() => "")).trim();
+      if (prefilledEmail !== "") {
+        break;
+      }
+      await page.waitForTimeout(250);
     }
-    await page.waitForTimeout(250);
-  }
 
-  if (prefilledEmail === "") {
-    await emailField.fill(email);
+    if (prefilledEmail === "") {
+      await emailField.fill(email);
+    }
+    await expect(emailField).toHaveValue(email);
+  } else {
+    const lockedEmail = await waitForVisibleTextAcrossFrames(page, email, {
+      required: true,
+      timeoutMs: 5_000,
+    });
+    await expect(lockedEmail).toBeVisible();
   }
-  await expect(emailField).toHaveValue(email);
 
   // The Card radio is visually hidden under a custom overlay in older Stripe
   // Checkout. Force-click by ID to expand the card form.


### PR DESCRIPTION
## Summary
- fetch the signed-in user's email from Gitea on the server before creating a Stripe Checkout Session
- attach `metadata[bindersnap_username]` to every checkout session and prefer `customer=` when an existing `stripe_customer_id` is already stored for the username
- expand API unit coverage for both the `customer_email` path and the customer-reuse path, and tighten the hosted Checkout spec to verify email prefill before falling back to typing

## Testing
- `bun test services/api/server.test.ts`
- `bunx prettier --check services/api/server.ts services/api/server.test.ts tests/stripe-subscription.pw.ts`
- `bunx playwright test --config=playwright.config.ts tests/stripe-subscription.pw.ts --list`

## Workflow Evidence
- Issue read method: `mcp__MCP_DOCKER__.issue_read` on `#185`
- Branch creation method: `mcp__MCP_DOCKER__.create_branch` created `codex/issue-185-stripe-customer-reuse` from `development/stripe-paywall`
- Commit SHAs: `7514ae5989e0e134ceaa93199510f63c65165d52`, `b7992ffcedf4aef89df3497be0d6564de2f61466`, `f88a2c35ae9e6abefb45b4027b27e9d97ee76f4e`
- PR creation method: `mcp__MCP_DOCKER__.create_pull_request`
- Fallback used: local git branch/commit/push was blocked by filesystem lock creation (`fatal: cannot lock ref 'refs/heads/codex/issue-185-stripe-customer-reuse': Unable to create '/Users/davidgray/git/bindersnap-editor-demo/.git/refs/heads/codex/issue-185-stripe-customer-reuse.lock': Operation not permitted` and `fatal: Unable to create '/Users/davidgray/git/bindersnap-editor-demo/.git/index.lock': Operation not permitted`). To publish the already-verified local edits, I used the authenticated GitHub CLI contents API fallback via `gh api repos/davidgraymi/bindersnap-editor-demo/contents/<path> --method PUT --input <payload>` for each changed file.