### PR TITLE
Issue #187: reconcile missed Stripe subscription rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ hosted Checkout coverage when those Stripe test values are present. You only
 need to set `STRIPE_WEBHOOK_SECRET` yourself when you want to exercise the
 billing flow outside Playwright, for example with a manual `bun run up` session.
 
+If a Stripe subscription exists but the local subscription row is missing, you
+can rebuild it from Stripe with:
+
+```bash
+bun run reconcile:stripe-customer -- --username alice
+bun run reconcile:stripe-customer -- --customer cus_123
+```
+
 ## Environment Variables
 
 This is the complete environment variable reference used by repo code, scripts, compose wiring, or tests.

--- a/docs/payments-plan.md
+++ b/docs/payments-plan.md
@@ -186,7 +186,8 @@ if (pathname === "/stripe/webhook" && method === "POST") {
 - Verify signature with `verifyStripeSignature(rawBody, req.headers.get("stripe-signature") ?? "", stripeWebhookSecret)`
 - Parse event: `JSON.parse(rawBody)`
 - Handle `checkout.session.completed`: read `client_reference_id` (username), `customer`, `subscription` → fetch `GET /v1/subscriptions/{id}` → upsert record
-- Handle `customer.subscription.updated` / `customer.subscription.deleted`: look up by `customer` → update status
+- Handle `customer.subscription.updated` / `customer.subscription.deleted`: look up by `customer`; if missing locally, fetch the Stripe customer and recover via `metadata.bindersnap_username`, then upsert from the webhook subscription payload
+- Recovery script: `bun run reconcile:stripe-customer -- --username <name>` or `--customer <cus_...>` rebuilds a row directly from Stripe for operator backfills
 
 `handleBillingStatus(req, baseHeaders)` — `GET /api/app/billing/status`:
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format:check": "bunx prettier --check \"**/*.{js,ts,jsx,tsx,html,css,json,yml,yaml,md}\" --ignore-path .gitignore --ignore-path .prettierignore",
     "generate:api": "bun run scripts/generate-gitea-api.ts",
     "lighthouse": "bun run build && sh -c 'python3 -m http.server 4173 --directory dist >/dev/null 2>&1 & SERVER_PID=$!; sleep 1; bunx lighthouse http://localhost:4173 --output=json --output-path=./lighthouse.json --quiet --chrome-flags=\"--headless --no-sandbox --disable-gpu\" --no-enable-error-reporting; kill $SERVER_PID' && bun run summarize",
+    "reconcile:stripe-customer": "bun scripts/reconcile-stripe-customer.ts",
     "serve": "bun run serve:app",
     "serve:app": "NODE_ENV=production bun server.ts",
     "serve:api": "NODE_ENV=production bun services/api/server.ts",

--- a/scripts/reconcile-stripe-customer.ts
+++ b/scripts/reconcile-stripe-customer.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+
+import { config } from "../services/api/config";
+import { STRIPE_API_VERSION } from "../services/api/stripe/api-version";
+import {
+  reconcileStripeCustomerByCustomerId,
+  reconcileStripeCustomerByUsername,
+  type StripeFetch,
+} from "../services/api/stripe/reconcile";
+import { subscriptionStore } from "../services/api/subscriptions";
+
+type ReconcileArgs = {
+  username: string | null;
+  customerId: string | null;
+};
+
+type ReconcileStripeCustomerStore = Pick<typeof subscriptionStore, "upsert">;
+
+type RunReconcileStripeCustomerCliOptions = {
+  stripeFetch?: StripeFetch;
+  store?: ReconcileStripeCustomerStore;
+  writeStdout?: (output: string) => void;
+};
+
+function parseArgs(argv: string[]): ReconcileArgs {
+  let username: string | null = null;
+  let customerId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--username") {
+      const value = argv[index + 1]?.trim();
+      if (!value) {
+        throw new Error("Missing value for --username.");
+      }
+      username = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--customer") {
+      const value = argv[index + 1]?.trim();
+      if (!value) {
+        throw new Error("Missing value for --customer.");
+      }
+      customerId = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if ((username ? 1 : 0) + (customerId ? 1 : 0) !== 1) {
+    throw new Error(
+      "Pass exactly one of --username <value> or --customer <value>.",
+    );
+  }
+
+  return { username, customerId };
+}
+
+async function defaultStripeFetch(
+  path: string,
+  body?: URLSearchParams,
+  extraHeaders?: Record<string, string>,
+): Promise<Response> {
+  return fetch(`https://api.stripe.com${path}`, {
+    method: body ? "POST" : "GET",
+    headers: {
+      Authorization: `Bearer ${config.stripeSecretKey}`,
+      "Stripe-Version": STRIPE_API_VERSION,
+      ...(body ? { "Content-Type": "application/x-www-form-urlencoded" } : {}),
+      ...extraHeaders,
+    },
+    body,
+  });
+}
+
+export async function runReconcileStripeCustomerCli(
+  argv = process.argv.slice(2),
+  options: RunReconcileStripeCustomerCliOptions = {},
+): Promise<void> {
+  const stripeFetch = options.stripeFetch ?? defaultStripeFetch;
+  if (!options.stripeFetch && !config.stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required.");
+  }
+
+  const args = parseArgs(argv);
+  const result = args.username
+    ? await reconcileStripeCustomerByUsername(stripeFetch, args.username)
+    : await reconcileStripeCustomerByCustomerId(stripeFetch, args.customerId!);
+
+  if (!result) {
+    throw new Error(
+      "Unable to rebuild the subscription row from Stripe. Check that the customer exists, has metadata.bindersnap_username, and has at least one subscription.",
+    );
+  }
+
+  const store = options.store ?? subscriptionStore;
+  store.upsert(result.record);
+
+  const writeStdout =
+    options.writeStdout ?? ((output: string) => process.stdout.write(output));
+  writeStdout(
+    JSON.stringify(
+      {
+        ok: true,
+        username: result.record.username,
+        stripeCustomerId: result.record.stripeCustomerId,
+        stripeSubscriptionId: result.record.stripeSubscriptionId,
+        status: result.record.status,
+        currentPeriodEnd: result.record.currentPeriodEnd,
+        cancelAtPeriodEnd: result.record.cancelAtPeriodEnd,
+        cancelAt: result.record.cancelAt,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+if (import.meta.main) {
+  runReconcileStripeCustomerCli().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  });
+}

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -49,6 +49,16 @@ Production-style run:
 bun run serve:api
 ```
 
+## Billing recovery
+
+Rebuild a missing subscription row from Stripe when a prior
+`checkout.session.completed` webhook was missed:
+
+```bash
+bun run reconcile:stripe-customer -- --username alice
+bun run reconcile:stripe-customer -- --customer cus_123
+```
+
 ## MVP tradeoffs
 
 - Sessions are stored in a local SQLite database and are not shared across multiple API instances.

--- a/services/api/reconcile-stripe-customer.test.ts
+++ b/services/api/reconcile-stripe-customer.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "crypto";
+
+import { runReconcileStripeCustomerCli } from "../../scripts/reconcile-stripe-customer";
+import { SubscriptionStore } from "./subscriptions";
+
+type MockedStripeResponse = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
+let fetchCalls: string[] = [];
+let stdoutChunks: string[] = [];
+let stripeResponses = new Map<string, MockedStripeResponse>();
+let testStore: SubscriptionStore;
+
+beforeEach(() => {
+  fetchCalls = [];
+  stdoutChunks = [];
+  stripeResponses = new Map();
+  testStore = new SubscriptionStore(
+    `/tmp/bindersnap-reconcile-test-${randomUUID()}.sqlite`,
+  );
+});
+
+afterEach(() => {});
+
+function mockStripeResponse(
+  pathWithSearch: string,
+  body: Record<string, unknown>,
+  status = 200,
+): void {
+  stripeResponses.set(pathWithSearch, { status, body });
+}
+
+async function stripeFetch(input: string | URL | Request): Promise<Response> {
+  const requestUrl =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+  const key = requestUrl.startsWith("http")
+    ? (() => {
+        const url = new URL(requestUrl);
+        return `${url.pathname}${url.search}`;
+      })()
+    : requestUrl;
+
+  fetchCalls.push(key);
+
+  const pathname = key.split("?")[0] ?? key;
+  const response = stripeResponses.get(key) ?? stripeResponses.get(pathname);
+  if (!response) {
+    return new Response(JSON.stringify({ error: { message: "Not found" } }), {
+      status: 404,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  return new Response(JSON.stringify(response.body), {
+    status: response.status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+describe("runReconcileStripeCustomerCli", () => {
+  test("rebuilds a subscription row from --customer", async () => {
+    const username = `customer-reconcile-${randomUUID()}`;
+    const customerId = `cus_${randomUUID()}`;
+    const subscriptionId = `sub_${randomUUID()}`;
+    const currentPeriodEnd = Math.floor(Date.now() / 1000) + 3_600;
+
+    mockStripeResponse(`/v1/customers/${customerId}`, {
+      id: customerId,
+      metadata: {
+        bindersnap_username: username,
+      },
+    });
+    mockStripeResponse(
+      `/v1/subscriptions?customer=${encodeURIComponent(customerId)}&status=all&limit=1`,
+      {
+        data: [
+          {
+            id: subscriptionId,
+            status: "active",
+            current_period_end: currentPeriodEnd,
+            cancel_at_period_end: false,
+            cancel_at: null,
+          },
+        ],
+      },
+    );
+
+    await runReconcileStripeCustomerCli(["--customer", customerId], {
+      stripeFetch,
+      store: testStore,
+      writeStdout: (output) => {
+        stdoutChunks.push(output);
+      },
+    });
+
+    expect(fetchCalls).toEqual([
+      `/v1/customers/${customerId}`,
+      `/v1/subscriptions?customer=${encodeURIComponent(customerId)}&status=all&limit=1`,
+    ]);
+    expect(testStore.getByUsername(username)).toEqual({
+      username,
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscriptionId,
+      status: "active",
+      currentPeriodEnd,
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+      updatedAt: expect.any(Number),
+    });
+    expect(stdoutChunks.join("")).toContain(`"username": "${username}"`);
+  });
+
+  test("rebuilds a subscription row from --username", async () => {
+    const username = `username-reconcile-${randomUUID()}`;
+    const customerId = `cus_${randomUUID()}`;
+    const subscriptionId = `sub_${randomUUID()}`;
+    const currentPeriodEnd = Math.floor(Date.now() / 1000) + 1_800;
+    mockStripeResponse("/v1/customers/search", {
+      data: [
+        {
+          id: customerId,
+          metadata: {
+            bindersnap_username: username,
+          },
+        },
+      ],
+    });
+    mockStripeResponse(
+      `/v1/subscriptions?customer=${encodeURIComponent(customerId)}&status=all&limit=1`,
+      {
+        data: [
+          {
+            id: subscriptionId,
+            status: "trialing",
+            current_period_end: currentPeriodEnd,
+            cancel_at_period_end: true,
+            cancel_at: currentPeriodEnd + 600,
+          },
+        ],
+      },
+    );
+
+    await runReconcileStripeCustomerCli(["--username", username], {
+      stripeFetch,
+      store: testStore,
+      writeStdout: (output) => {
+        stdoutChunks.push(output);
+      },
+    });
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(fetchCalls[0]).toContain("/v1/customers/search?query=");
+    expect(fetchCalls[0]).toContain(username);
+    expect(fetchCalls[1]).toBe(
+      `/v1/subscriptions?customer=${encodeURIComponent(customerId)}&status=all&limit=1`,
+    );
+    expect(testStore.getByUsername(username)).toEqual({
+      username,
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscriptionId,
+      status: "trialing",
+      currentPeriodEnd,
+      cancelAtPeriodEnd: true,
+      cancelAt: currentPeriodEnd + 600,
+      updatedAt: expect.any(Number),
+    });
+    expect(stdoutChunks.join("")).toContain(
+      `"stripeCustomerId": "${customerId}"`,
+    );
+  });
+});

--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -437,7 +437,9 @@ describe("billing Stripe webhook recovery", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(1);
+      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(
+        1,
+      );
       expect(subscriptionStore.getByUsername(username)).toEqual({
         username,
         stripeCustomerId: customerId,
@@ -486,7 +488,9 @@ describe("billing Stripe webhook recovery", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(1);
+      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(
+        1,
+      );
       expect(subscriptionStore.getByUsername(username)).toEqual({
         username,
         stripeCustomerId: customerId,
@@ -531,7 +535,9 @@ describe("billing Stripe webhook recovery", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(1);
+      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(
+        1,
+      );
       expect(subscriptionStore.getByCustomerId(customerId)).toBeNull();
     } finally {
       server.stop(true);

--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -4,7 +4,12 @@ import { randomUUID } from "crypto";
 import { config } from "./config";
 import { createApiServer } from "./server";
 import { SessionStore, sessionStore } from "./sessions";
-import { SubscriptionStore, subscriptionStore } from "./subscriptions";
+import {
+  SubscriptionStore,
+  subscriptionStore,
+  WebhookEventStore,
+  webhookEventStore,
+} from "./subscriptions";
 
 type MockedFetchCall = {
   path: string;
@@ -13,18 +18,27 @@ type MockedFetchCall = {
   body: string | null;
 };
 
+type MockedStripeResource = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
 const originalFetch = globalThis.fetch;
 const originalApiPort = config.apiPort;
 const originalStripeSecretKey = config.stripeSecretKey;
+const originalStripeWebhookSecret = config.stripeWebhookSecret;
 const originalStripePriceId = config.stripePriceId;
 const originalSessionsDbPath = config.sessionsDbPath;
 
 let fetchCalls: MockedFetchCall[] = [];
 let userEmailsByToken = new Map<string, string>();
+let stripeSubscriptionsById = new Map<string, MockedStripeResource>();
+let stripeCustomersById = new Map<string, MockedStripeResource>();
 
 beforeEach(() => {
   config.apiPort = 0;
   config.stripeSecretKey = "sk_test_bindersnap";
+  config.stripeWebhookSecret = "whsec_test_bindersnap";
   config.stripePriceId = "price_test_bindersnap";
   config.sessionsDbPath = `/tmp/bindersnap-server-test-${randomUUID()}.sqlite`;
 
@@ -33,9 +47,13 @@ beforeEach(() => {
   );
   (subscriptionStore as { _store: SubscriptionStore | null })._store =
     new SubscriptionStore(config.sessionsDbPath);
+  (webhookEventStore as { _store: WebhookEventStore | null })._store =
+    new WebhookEventStore(config.sessionsDbPath);
 
   fetchCalls = [];
   userEmailsByToken = new Map();
+  stripeSubscriptionsById = new Map();
+  stripeCustomersById = new Map();
   globalThis.fetch = (async (input, init) => {
     const requestUrl =
       typeof input === "string"
@@ -83,6 +101,48 @@ beforeEach(() => {
       });
     }
 
+    if (url.pathname.startsWith("/v1/subscriptions/")) {
+      const subscriptionId = url.pathname.slice("/v1/subscriptions/".length);
+      const subscription = stripeSubscriptionsById.get(subscriptionId);
+
+      if (!subscription) {
+        return new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      }
+
+      return new Response(JSON.stringify(subscription.body), {
+        status: subscription.status,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
+
+    if (url.pathname.startsWith("/v1/customers/")) {
+      const customerId = url.pathname.slice("/v1/customers/".length);
+      const customer = stripeCustomersById.get(customerId);
+
+      if (!customer) {
+        return new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      }
+
+      return new Response(JSON.stringify(customer.body), {
+        status: customer.status,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
+
     const responseUrl = url.pathname.includes("billing_portal")
       ? "https://billing.stripe.com/p/session/test_123"
       : "https://checkout.stripe.com/c/pay/test_123";
@@ -100,6 +160,7 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
   config.apiPort = originalApiPort;
   config.stripeSecretKey = originalStripeSecretKey;
+  config.stripeWebhookSecret = originalStripeWebhookSecret;
   config.stripePriceId = originalStripePriceId;
   config.sessionsDbPath = originalSessionsDbPath;
 });
@@ -135,6 +196,22 @@ function getPostedFormBody(call: MockedFetchCall): URLSearchParams {
   return new URLSearchParams(call.body ?? "");
 }
 
+function mockStripeSubscription(
+  id: string,
+  body: Record<string, unknown>,
+  status = 200,
+): void {
+  stripeSubscriptionsById.set(id, { status, body });
+}
+
+function mockStripeCustomer(
+  id: string,
+  body: Record<string, unknown>,
+  status = 200,
+): void {
+  stripeCustomersById.set(id, { status, body });
+}
+
 function makeBillingRequest(pathname: string, sessionId: string): Request {
   return new Request(`http://localhost${pathname}`, {
     method: "POST",
@@ -142,6 +219,51 @@ function makeBillingRequest(pathname: string, sessionId: string): Request {
       Origin: config.appOrigin,
       Cookie: `${config.sessionCookieName}=${sessionId}`,
     },
+  });
+}
+
+async function signStripeWebhookBody(
+  body: string,
+  secret: string,
+  timestamp: number,
+): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signatureBuffer = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`${timestamp}.${body}`),
+  );
+
+  return Array.from(new Uint8Array(signatureBuffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function makeStripeWebhookRequest(
+  event: Record<string, unknown>,
+): Promise<Request> {
+  const rawBody = JSON.stringify(event);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signature = await signStripeWebhookBody(
+    rawBody,
+    config.stripeWebhookSecret,
+    timestamp,
+  );
+
+  return new Request("http://localhost/stripe/webhook", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "stripe-signature": `t=${timestamp},v1=${signature}`,
+    },
+    body: rawBody,
   });
 }
 
@@ -274,6 +396,143 @@ describe("billing Stripe idempotency", () => {
       expect(portalCalls[0]?.idempotencyKey).not.toBe(
         portalCalls[1]?.idempotencyKey,
       );
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+describe("billing Stripe webhook recovery", () => {
+  test("customer.subscription.updated recovers a missing subscription row from customer metadata", async () => {
+    const server = createApiServer();
+    const username = `recovery-${randomUUID()}`;
+    const customerId = `cus_${randomUUID()}`;
+    const subscriptionId = `sub_${randomUUID()}`;
+    const currentPeriodEnd = Math.floor(Date.now() / 1000) + 3_600;
+
+    mockStripeCustomer(customerId, {
+      id: customerId,
+      metadata: {
+        bindersnap_username: username,
+      },
+    });
+
+    try {
+      const response = await server.fetch(
+        await makeStripeWebhookRequest({
+          id: `evt_${randomUUID()}`,
+          type: "customer.subscription.updated",
+          created: Math.floor(Date.now() / 1000),
+          data: {
+            object: {
+              id: subscriptionId,
+              customer: customerId,
+              status: "active",
+              current_period_end: currentPeriodEnd,
+              cancel_at_period_end: false,
+              cancel_at: null,
+            },
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(1);
+      expect(subscriptionStore.getByUsername(username)).toEqual({
+        username,
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: subscriptionId,
+        status: "active",
+        currentPeriodEnd,
+        cancelAtPeriodEnd: false,
+        cancelAt: null,
+        updatedAt: expect.any(Number),
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("customer.subscription.deleted recovers a missing subscription row from customer metadata", async () => {
+    const server = createApiServer();
+    const username = `recovery-deleted-${randomUUID()}`;
+    const customerId = `cus_${randomUUID()}`;
+    const subscriptionId = `sub_${randomUUID()}`;
+    const cancelAt = Math.floor(Date.now() / 1000) + 600;
+
+    mockStripeCustomer(customerId, {
+      id: customerId,
+      metadata: {
+        bindersnap_username: username,
+      },
+    });
+
+    try {
+      const response = await server.fetch(
+        await makeStripeWebhookRequest({
+          id: `evt_${randomUUID()}`,
+          type: "customer.subscription.deleted",
+          created: Math.floor(Date.now() / 1000),
+          data: {
+            object: {
+              id: subscriptionId,
+              customer: customerId,
+              status: "canceled",
+              cancel_at_period_end: true,
+              cancel_at: cancelAt,
+            },
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(1);
+      expect(subscriptionStore.getByUsername(username)).toEqual({
+        username,
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: subscriptionId,
+        status: "canceled",
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: true,
+        cancelAt,
+        updatedAt: expect.any(Number),
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("customer.subscription.updated does not recover when customer metadata omits the bindersnap username", async () => {
+    const server = createApiServer();
+    const customerId = `cus_${randomUUID()}`;
+
+    mockStripeCustomer(customerId, {
+      id: customerId,
+      metadata: {},
+    });
+
+    try {
+      const response = await server.fetch(
+        await makeStripeWebhookRequest({
+          id: `evt_${randomUUID()}`,
+          type: "customer.subscription.updated",
+          created: Math.floor(Date.now() / 1000),
+          data: {
+            object: {
+              id: `sub_${randomUUID()}`,
+              customer: customerId,
+              status: "active",
+              current_period_end: Math.floor(Date.now() / 1000) + 1_800,
+              cancel_at_period_end: false,
+              cancel_at: null,
+            },
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(1);
+      expect(subscriptionStore.getByCustomerId(customerId)).toBeNull();
     } finally {
       server.stop(true);
     }

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -14,6 +14,10 @@ import {
   extractCurrentPeriodEnd,
 } from "./stripe/api-version";
 import {
+  buildStripeSubscriptionRecord,
+  reconcileStripeCustomerByCustomerId,
+} from "./stripe/reconcile";
+import {
   createGiteaClient,
   GiteaApiError,
   unwrap,
@@ -2537,19 +2541,9 @@ async function handleStripeWebhook(
       const subResp = await stripeFetch(`/v1/subscriptions/${subscriptionId}`);
       if (subResp.ok) {
         const sub = (await subResp.json()) as Record<string, unknown>;
-        subscriptionStore.upsert({
-          username,
-          stripeCustomerId: customerId,
-          stripeSubscriptionId: subscriptionId,
-          status: (sub.status as string) ?? "active",
-          // Newer API versions (>= 2025-04-30) moved current_period_end onto
-          // items.data[0]; for trialing subscriptions Stripe omits it entirely
-          // and trial_end carries the same timestamp. Try all three.
-          currentPeriodEnd:
-            extractCurrentPeriodEnd(sub) ??
-            (typeof sub.trial_end === "number" ? sub.trial_end : null),
-          updatedAt: Date.now(),
-        });
+        subscriptionStore.upsert(
+          buildStripeSubscriptionRecord(username, customerId, sub),
+        );
         logger.info("Subscription activated", { username, status: sub.status });
       } else {
         logger.error(
@@ -2592,6 +2586,36 @@ async function handleStripeWebhook(
           customer: customerId,
           status: data.status,
         });
+      } else {
+        const reconciled = await reconcileStripeCustomerByCustomerId(
+          stripeFetch,
+          customerId,
+          {
+            subscription: data,
+            now: Date.now(),
+          },
+        );
+        if (reconciled) {
+          subscriptionStore.upsert(reconciled.record);
+          logger.info(
+            "Reconciled missing subscription row from Stripe customer metadata",
+            {
+              customer: customerId,
+              username: reconciled.record.username,
+              subscriptionId: reconciled.record.stripeSubscriptionId,
+              eventType: type,
+            },
+          );
+        } else {
+          logger.warn(
+            "Stripe subscription webhook could not reconcile missing local record",
+            {
+              customer: customerId,
+              subscriptionId,
+              eventType: type,
+            },
+          );
+        }
       }
     }
   } else if (type === "invoice.payment_failed" && data) {

--- a/services/api/stripe/reconcile.ts
+++ b/services/api/stripe/reconcile.ts
@@ -1,0 +1,205 @@
+import type { SubscriptionRecord } from "../subscriptions";
+import { extractCurrentPeriodEnd } from "./api-version";
+
+type StripeObject = Record<string, unknown>;
+
+export type StripeFetch = (
+  path: string,
+  body?: URLSearchParams,
+  extraHeaders?: Record<string, string>,
+) => Promise<Response>;
+
+export interface StripeReconciliationResult {
+  customer: StripeObject;
+  subscription: StripeObject;
+  record: SubscriptionRecord;
+}
+
+function readStripeObject(value: unknown): StripeObject | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as StripeObject)
+    : null;
+}
+
+function readString(
+  object: StripeObject | null | undefined,
+  key: string,
+): string | null {
+  const value = object?.[key];
+  return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+function readStripeArray(
+  object: StripeObject | null | undefined,
+  key: string,
+): StripeObject[] {
+  const value = object?.[key];
+  return Array.isArray(value)
+    ? value
+        .map((entry) => readStripeObject(entry))
+        .filter((entry): entry is StripeObject => entry !== null)
+    : [];
+}
+
+function getStripeErrorMessage(payload: StripeObject | null): string | null {
+  const error = readStripeObject(payload?.error);
+  return readString(error, "message");
+}
+
+async function parseStripeJson(
+  response: Response,
+  path: string,
+): Promise<StripeObject> {
+  const payload = readStripeObject(await response.json().catch(() => null));
+  if (!response.ok) {
+    const message =
+      getStripeErrorMessage(payload) ??
+      `Stripe request failed with status ${response.status}.`;
+    throw new Error(
+      `Stripe GET ${path} failed (${response.status}): ${message}`,
+    );
+  }
+
+  return payload ?? {};
+}
+
+function escapeStripeSearchString(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("'", "\\'");
+}
+
+async function fetchStripeCustomer(
+  stripeFetch: StripeFetch,
+  customerId: string,
+): Promise<StripeObject | null> {
+  const customer = await parseStripeJson(
+    await stripeFetch(`/v1/customers/${encodeURIComponent(customerId)}`),
+    `/v1/customers/${customerId}`,
+  );
+
+  return readString(customer, "id") ? customer : null;
+}
+
+async function fetchStripeCustomerByUsername(
+  stripeFetch: StripeFetch,
+  username: string,
+): Promise<StripeObject | null> {
+  const query = encodeURIComponent(
+    `metadata['bindersnap_username']:'${escapeStripeSearchString(username)}'`,
+  );
+  const payload = await parseStripeJson(
+    await stripeFetch(`/v1/customers/search?query=${query}&limit=1`),
+    `/v1/customers/search?query=${query}&limit=1`,
+  );
+
+  return readStripeArray(payload, "data")[0] ?? null;
+}
+
+async function fetchLatestStripeSubscription(
+  stripeFetch: StripeFetch,
+  customerId: string,
+): Promise<StripeObject | null> {
+  const path = `/v1/subscriptions?customer=${encodeURIComponent(customerId)}&status=all&limit=1`;
+  const payload = await parseStripeJson(await stripeFetch(path), path);
+  return readStripeArray(payload, "data")[0] ?? null;
+}
+
+export function getBindersnapUsernameFromStripeCustomer(
+  customer: StripeObject | null | undefined,
+): string | null {
+  const metadata = readStripeObject(customer?.metadata);
+  return readString(metadata, "bindersnap_username");
+}
+
+export function buildStripeSubscriptionRecord(
+  username: string,
+  customerId: string,
+  subscription: StripeObject,
+  now = Date.now(),
+): SubscriptionRecord {
+  const subscriptionId = readString(subscription, "id");
+  if (!subscriptionId) {
+    throw new Error("Stripe subscription payload is missing id.");
+  }
+
+  return {
+    username,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    status: readString(subscription, "status") ?? "active",
+    currentPeriodEnd:
+      extractCurrentPeriodEnd(subscription) ??
+      (typeof subscription.trial_end === "number"
+        ? subscription.trial_end
+        : null),
+    cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
+    cancelAt:
+      typeof subscription.cancel_at === "number"
+        ? subscription.cancel_at
+        : null,
+    updatedAt: now,
+  };
+}
+
+export async function reconcileStripeCustomerByCustomerId(
+  stripeFetch: StripeFetch,
+  customerId: string,
+  options?: {
+    subscription?: StripeObject | null;
+    now?: number;
+  },
+): Promise<StripeReconciliationResult | null> {
+  const customer = await fetchStripeCustomer(stripeFetch, customerId);
+  const username = getBindersnapUsernameFromStripeCustomer(customer);
+  if (!customer || !username) {
+    return null;
+  }
+
+  const subscription =
+    options?.subscription ??
+    (await fetchLatestStripeSubscription(stripeFetch, customerId));
+  if (!subscription) {
+    return null;
+  }
+
+  return {
+    customer,
+    subscription,
+    record: buildStripeSubscriptionRecord(
+      username,
+      customerId,
+      subscription,
+      options?.now,
+    ),
+  };
+}
+
+export async function reconcileStripeCustomerByUsername(
+  stripeFetch: StripeFetch,
+  username: string,
+  now = Date.now(),
+): Promise<StripeReconciliationResult | null> {
+  const customer = await fetchStripeCustomerByUsername(stripeFetch, username);
+  const customerId = readString(customer, "id");
+  if (!customer || !customerId) {
+    return null;
+  }
+
+  const subscription = await fetchLatestStripeSubscription(
+    stripeFetch,
+    customerId,
+  );
+  if (!subscription) {
+    return null;
+  }
+
+  return {
+    customer,
+    subscription,
+    record: buildStripeSubscriptionRecord(
+      username,
+      customerId,
+      subscription,
+      now,
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
- add shared Stripe reconciliation helpers plus a recovery path in `handleStripeWebhook` when `customer.subscription.updated` or `customer.subscription.deleted` arrives before `checkout.session.completed`
- add `bun run reconcile:stripe-customer -- --username <name>` / `--customer <cus_...>` for operator backfills and document the flow in the repo, API, and payments plan docs
- extend API tests to cover webhook recovery and the CLI reconciliation flows, including test isolation for the script path

## Testing
- `bun test services/api/server.test.ts services/api/reconcile-stripe-customer.test.ts`
- `bun test services/api scripts`

## Workflow Evidence
- issue read method: `mcp__github__.issue_read` for `#187`
- branch creation method: `mcp__github__.create_branch` from `development/stripe-paywall` to `codex/issue-187-reconcile-missed-webhooks`
- branch head commit SHA: `108471e5e817279c59f375208fba1c347f1d6659`
- PR creation method: `mcp__github__.create_pull_request`
- fallback used: local git branch/commit workflow was blocked by sandboxed `.git` writes with `fatal: Unable to create '/Users/davidgray/git/bindersnap-editor-demo/.git/index.lock': Operation not permitted`; remote file updates were applied with `gh api "repos/$owner/$repo/contents/$file?ref=$branch" --jq .sha` and `gh api -X PUT "repos/$owner/$repo/contents/$file" -f message="Issue #187: reconcile missed Stripe subscription rows" -f content="$content" -f branch="$branch" [-f sha="$sha"]`
