### PR TITLE
Stripe webhook 5xx monitoring and runbook (#189)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -76,6 +76,13 @@ services:
     depends_on:
       gitea:
         condition: service_healthy
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: /bindersnap/api
+        awslogs-region: "${AWS_REGION:-us-east-1}"
+        awslogs-stream-prefix: api
+        awslogs-create-group: "true"
     environment:
       - API_PORT=8787
       - PORT=8787

--- a/docs/ops/runbook-stripe-webhook-5xx.md
+++ b/docs/ops/runbook-stripe-webhook-5xx.md
@@ -34,12 +34,14 @@ Note the `event_type` and `error` fields — these point directly to the cause.
 **Symptom**: `error` field contains a Stripe API error (rate limit, network timeout, invalid API key).
 
 **Check**:
+
 ```
 # On the EC2 host
 docker logs bindersnap-api-prod --since 30m | grep stripe_webhook_5xx
 ```
 
 **Actions**:
+
 - If transient (timeout, 503 from Stripe): wait for Stripe to retry automatically.
 - If `Authentication` error: verify `STRIPE_SECRET_KEY` in SSM (`/bindersnap/prod/stripe_secret_key`) matches the live key in the Stripe dashboard.
 - If `No such subscription` from Stripe: the subscription may have been deleted on the Stripe side. Check Stripe Dashboard → Subscriptions for `subscriptionId` from the log.
@@ -49,6 +51,7 @@ docker logs bindersnap-api-prod --since 30m | grep stripe_webhook_5xx
 **Symptom**: no `error` field, or a JavaScript stack trace.
 
 **Check**: look for log lines immediately before the `stripe_webhook_5xx` entry:
+
 ```
 fields @timestamp, level, message, error
 | filter @timestamp between <start> and <end>

--- a/docs/ops/runbook-stripe-webhook-5xx.md
+++ b/docs/ops/runbook-stripe-webhook-5xx.md
@@ -1,0 +1,98 @@
+# Runbook: Stripe Webhook 5xx Alert
+
+**Alarm**: `bindersnap-stripe-webhook-5xx`  
+**Trigger**: ≥1 `stripe_webhook_5xx` log line in any 5-minute window  
+**Severity**: Medium — Stripe will retry, but repeated failures block subscription state updates
+
+---
+
+## What triggered this alert
+
+The API returned HTTP 500 from `POST /stripe/webhook`. Stripe treats 5xx as a signal to retry (up to 3 days with exponential back-off), so no event is permanently lost. However, if the underlying cause persists, subscription activations or status changes will be delayed.
+
+---
+
+## Step 1 — Find the failing event(s)
+
+Query CloudWatch Logs Insights on log group `/bindersnap/api`:
+
+```
+fields @timestamp, event_id, event_type, customer_id, error, username, subscriptionId
+| filter stripe_webhook_5xx = 1
+| sort @timestamp desc
+| limit 20
+```
+
+Note the `event_type` and `error` fields — these point directly to the cause.
+
+---
+
+## Step 2 — Common causes and fixes
+
+### `checkout.session.completed` → Stripe API call failed
+
+**Symptom**: `error` field contains a Stripe API error (rate limit, network timeout, invalid API key).
+
+**Check**:
+```
+# On the EC2 host
+docker logs bindersnap-api-prod --since 30m | grep stripe_webhook_5xx
+```
+
+**Actions**:
+- If transient (timeout, 503 from Stripe): wait for Stripe to retry automatically.
+- If `Authentication` error: verify `STRIPE_SECRET_KEY` in SSM (`/bindersnap/prod/stripe_secret_key`) matches the live key in the Stripe dashboard.
+- If `No such subscription` from Stripe: the subscription may have been deleted on the Stripe side. Check Stripe Dashboard → Subscriptions for `subscriptionId` from the log.
+
+### Unexpected panic / unhandled error
+
+**Symptom**: no `error` field, or a JavaScript stack trace.
+
+**Check**: look for log lines immediately before the `stripe_webhook_5xx` entry:
+```
+fields @timestamp, level, message, error
+| filter @timestamp between <start> and <end>
+| sort @timestamp asc
+```
+
+**Action**: file a bug with the full log context.
+
+---
+
+## Step 3 — Check Stripe retry queue
+
+1. Open [Stripe Dashboard → Developers → Webhooks](https://dashboard.stripe.com/webhooks).
+2. Select the endpoint for `api.bindersnap.com/stripe/webhook`.
+3. Under **Recent deliveries**, find the failing event and confirm Stripe is scheduling retries.
+4. If Stripe has already exhausted retries (unlikely under 24 h), use **Resend** to replay the event once the underlying fix is in.
+
+---
+
+## Step 4 — Manual subscription reconciliation (if needed)
+
+If a user reports they paid but their account is not active, reconcile manually via the Stripe Dashboard:
+
+1. Find the customer in Stripe → copy `customer_id`.
+2. Verify the subscription is `active` in Stripe.
+3. SSH to the EC2 host (or use SSM Session Manager) and run:
+
+```bash
+docker exec bindersnap-api-prod \
+  bun run /app/scripts/reconcile-subscription.ts --customer <customer_id>
+```
+
+_(Script must be authored before use; if not present, update the subscription row directly in SQLite as a last resort — see `docs/ops/deploy.md` for DB access instructions.)_
+
+---
+
+## Step 5 — Resolve the alarm
+
+The alarm auto-resolves when no `stripe_webhook_5xx` lines appear for one 5-minute evaluation period. If you have fixed the underlying issue and want to suppress further pages, use the AWS console to temporarily set the alarm to **OK** state.
+
+---
+
+## Escalation
+
+- **Stripe retries will cover up to 3 days** — no immediate data loss for a short outage.
+- If the error persists >30 minutes during business hours, escalate to @davidgraymi.
+- If `STRIPE_SECRET_KEY` is suspected compromised, rotate immediately in Stripe Dashboard and update SSM before restarting the API container.

--- a/infra/monitoring/main.tf
+++ b/infra/monitoring/main.tf
@@ -50,6 +50,12 @@ variable "alert_email" {
   }
 }
 
+variable "api_log_group_name" {
+  description = "CloudWatch Logs log group for the API container (must match docker-compose awslogs-group)"
+  type        = string
+  default     = "/bindersnap/api"
+}
+
 locals {
   alerts_topic_name      = "${var.project}-alerts"
   email_subscription     = var.alert_email != null && trimspace(var.alert_email) != ""
@@ -154,6 +160,49 @@ resource "aws_cloudwatch_metric_alarm" "mem_high" {
   tags = local.common_tags
 }
 
+# API log group — owned here so retention and tags are consistent.
+# The docker-compose awslogs driver will also create it if missing, but
+# Terraform ownership lets us set retention and prevent accidental deletion.
+resource "aws_cloudwatch_log_group" "api" {
+  name              = var.api_log_group_name
+  retention_in_days = 30
+
+  tags = local.common_tags
+}
+
+# Count structured log lines that carry stripe_webhook_5xx=true.
+# The API emits these before every 500 return from the /stripe/webhook handler.
+resource "aws_cloudwatch_log_metric_filter" "stripe_webhook_5xx" {
+  name           = "${var.project}-stripe-webhook-5xx"
+  log_group_name = aws_cloudwatch_log_group.api.name
+  pattern        = "{ $.stripe_webhook_5xx = true }"
+
+  metric_transformation {
+    name          = "StripeWebhook5xxCount"
+    namespace     = "Bindersnap"
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+# Alert as soon as a single 5xx is emitted within any 5-minute window.
+resource "aws_cloudwatch_metric_alarm" "stripe_webhook_5xx" {
+  alarm_name          = "${var.project}-stripe-webhook-5xx"
+  alarm_description   = "Alert on any 5xx response from POST /stripe/webhook in a 5-minute window"
+  namespace           = "Bindersnap"
+  metric_name         = "StripeWebhook5xxCount"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  tags = local.common_tags
+}
+
 output "disk_high_alarm_name" {
   description = "CloudWatch alarm name for disk usage"
   value       = aws_cloudwatch_metric_alarm.disk_high.alarm_name
@@ -182,4 +231,14 @@ output "cpu_warning_alarm_name" {
 output "alerts_email_subscription_arn" {
   description = "SNS email subscription ARN, if an email address was provided"
   value       = try(aws_sns_topic_subscription.email[0].arn, null)
+}
+
+output "api_log_group_name" {
+  description = "CloudWatch Logs log group for the API container"
+  value       = aws_cloudwatch_log_group.api.name
+}
+
+output "stripe_webhook_5xx_alarm_name" {
+  description = "CloudWatch alarm name for Stripe webhook 5xx responses"
+  value       = aws_cloudwatch_metric_alarm.stripe_webhook_5xx.alarm_name
 }

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -2529,6 +2529,10 @@ async function handleStripeWebhook(
         logger.error(
           "Could not fetch subscription details from Stripe — returning 500 so Stripe retries",
           {
+            stripe_webhook_5xx: true,
+            event_id: eventId,
+            event_type: type,
+            customer_id: customerId ?? null,
             username,
             subscriptionId,
             error: err instanceof Error ? err.message : String(err),
@@ -2862,12 +2866,21 @@ export function createApiServer() {
       if (pathname === "/stripe/webhook" && method === "POST") {
         const response = await handleStripeWebhook(req, baseHeaders);
         const durationMs = Date.now() - startMs;
-        logger.info("Response sent", {
-          method,
-          path: pathname,
-          status: response.status,
-          durationMs,
-        });
+        if (response.status >= 500) {
+          logger.error("Response sent with 5xx status", {
+            method,
+            path: pathname,
+            status: response.status,
+            durationMs,
+          });
+        } else {
+          logger.info("Response sent", {
+            method,
+            path: pathname,
+            status: response.status,
+            durationMs,
+          });
+        }
         return response;
       }
 


### PR DESCRIPTION
## Summary

Closes #189

- **Structured log**: every 500 return from `POST /stripe/webhook` now emits a `logger.error` line with `stripe_webhook_5xx: true`, `event_id`, `event_type`, and `customer_id` — giving CloudWatch metric filters and Logs Insights a precise, queryable signal
- **Dispatch fix**: the `/stripe/webhook` early-return path previously always logged at `info` level regardless of status; it now logs at `error` level for 5xx
- **Log shipping**: added `awslogs` driver to the `api` service in `docker-compose.prod.yml` so container stdout flows to CloudWatch Logs `/bindersnap/api`
- **Terraform** (`infra/monitoring/main.tf`): adds `aws_cloudwatch_log_group`, a JSON metric filter on `stripe_webhook_5xx`, and a CloudWatch alarm (`bindersnap-stripe-webhook-5xx`) that fires on >0 counts in any 5-minute window → SNS `bindersnap-alerts`
- **Runbook**: `docs/ops/runbook-stripe-webhook-5xx.md` — step-by-step triage from alarm → CW Insights query → common causes → manual reconciliation fallback

## Workflow evidence

- Issue read: `mcp__github__issue_read` (issue #189)
- Branch created: `mcp__github__create_branch` → `feature/stripe-webhook-5xx-monitoring` from `development/stripe-paywall` (SHA `bb282de`)
- Commit SHA: `ae2ecf3`
- Tests: `bun run test:ops` — 85 pass, 0 fail
- PR created: `mcp__github__create_pull_request`

## Test plan

- [ ] `bun run test:ops` passes (85 tests)
- [ ] `terraform plan` in `infra/monitoring/` shows the new log group, metric filter, and alarm with no unexpected diffs
- [ ] After `terraform apply`, confirm `bindersnap-stripe-webhook-5xx` alarm appears in CloudWatch console
- [ ] Force a test 500 (stub Stripe SDK to throw) and verify `stripe_webhook_5xx=true` appears in `/bindersnap/api` log group within ~1 minute

🤖 Generated with [Claude Code](https://claude.com/claude-code)