### PR TITLE
Improve checkout-success polling: exponential backoff + 5-min background retry (#191)

### DIFF
--- a/apps/app/components/BillingPage.test.ts
+++ b/apps/app/components/BillingPage.test.ts
@@ -1,0 +1,58 @@
+import { expect, test, mock } from "bun:test";
+import {
+  VISIBLE_POLLING_DELAYS_MS,
+  BACKGROUND_POLL_INTERVAL_MS,
+  BACKGROUND_POLL_WINDOW_MS,
+  runBackgroundPoll,
+} from "./BillingPage";
+
+test("visible polling schedule has 10 entries", () => {
+  expect(VISIBLE_POLLING_DELAYS_MS.length).toBe(10);
+});
+
+test("visible polling schedule starts at 1s and caps at 8s", () => {
+  expect(VISIBLE_POLLING_DELAYS_MS[0]).toBe(1000);
+  expect(VISIBLE_POLLING_DELAYS_MS[VISIBLE_POLLING_DELAYS_MS.length - 1]).toBe(
+    8000,
+  );
+  expect(Math.max(...VISIBLE_POLLING_DELAYS_MS)).toBe(8000);
+});
+
+test("visible polling schedule total is ~63s", () => {
+  const total = VISIBLE_POLLING_DELAYS_MS.reduce(
+    (sum, delay) => sum + delay,
+    0,
+  );
+  expect(total).toBe(63000);
+});
+
+test("background polling interval is 8s", () => {
+  expect(BACKGROUND_POLL_INTERVAL_MS).toBe(8000);
+});
+
+test("background polling window is 5 minutes", () => {
+  expect(BACKGROUND_POLL_WINDOW_MS).toBe(300000);
+});
+
+test("long-tail path: visible phase exhausted then background activation triggers callback", async () => {
+  let callCount = 0;
+  const mockFetch = mock(() => {
+    callCount++;
+    if (callCount <= 10) {
+      return Promise.resolve({ status: "none" });
+    }
+    return Promise.resolve({ status: "active" });
+  });
+
+  let confirmedCalled = false;
+  const mockOnConfirmed = mock(() => {
+    confirmedCalled = true;
+  });
+
+  await runBackgroundPoll(mockFetch, mockOnConfirmed, 10, 1000);
+
+  expect(confirmedCalled).toBe(true);
+  expect(callCount).toBeGreaterThanOrEqual(11);
+  expect(mockFetch).toHaveBeenCalled();
+  expect(mockOnConfirmed).toHaveBeenCalled();
+});

--- a/apps/app/components/BillingPage.test.ts
+++ b/apps/app/components/BillingPage.test.ts
@@ -4,7 +4,7 @@ import {
   BACKGROUND_POLL_INTERVAL_MS,
   BACKGROUND_POLL_WINDOW_MS,
   runBackgroundPoll,
-} from "./BillingPage";
+} from "./checkoutPolling";
 
 test("visible polling schedule has 10 entries", () => {
   expect(VISIBLE_POLLING_DELAYS_MS.length).toBe(10);

--- a/apps/app/components/BillingPage.tsx
+++ b/apps/app/components/BillingPage.tsx
@@ -2,6 +2,42 @@ import { useEffect, useRef, useState } from "react";
 import { BindersnapLogoMark } from "./BindersnapLogoMark";
 import { fetchBillingStatus } from "../api";
 
+export const VISIBLE_POLLING_DELAYS_MS = [
+  1000, 2000, 4000, 8000, 8000, 8000, 8000, 8000, 8000, 8000,
+];
+
+export const BACKGROUND_POLL_INTERVAL_MS = 8000;
+
+export const BACKGROUND_POLL_WINDOW_MS = 300000;
+
+export async function runBackgroundPoll(
+  fetchFn: () => Promise<{ status: string }>,
+  onConfirmed: () => void,
+  intervalMs: number,
+  windowMs: number,
+): Promise<void> {
+  const startTime = Date.now();
+  const maxAttempts = Math.floor(windowMs / intervalMs);
+
+  for (let i = 0; i < maxAttempts; i++) {
+    if (Date.now() - startTime >= windowMs) {
+      break;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+
+    try {
+      const result = await fetchFn();
+      if (result.status === "active" || result.status === "trialing") {
+        onConfirmed();
+        return;
+      }
+    } catch {
+      // continue polling
+    }
+  }
+}
+
 interface BillingPageProps {
   subscriptionStatus: "active" | "none" | "loading";
   hasBillingStatusError: boolean;
@@ -48,37 +84,53 @@ export function BillingPage({
     }
 
     setIsPolling(true);
-    let retries = 0;
-    const maxRetries = 10;
 
-    const poll = async () => {
-      if (!isMounted.current) {
-        return;
-      }
-
-      try {
-        const billing = await fetchBillingStatus();
-        if (billing.status === "active" || billing.status === "trialing") {
-          if (isMounted.current) {
-            setIsPolling(false);
-            onSubscriptionConfirmed();
-          }
+    const runVisiblePolling = async () => {
+      for (let i = 0; i < VISIBLE_POLLING_DELAYS_MS.length; i++) {
+        if (!isMounted.current) {
           return;
         }
-      } catch {
-        // continue polling
+
+        await new Promise((resolve) =>
+          setTimeout(resolve, VISIBLE_POLLING_DELAYS_MS[i]),
+        );
+
+        if (!isMounted.current) {
+          return;
+        }
+
+        try {
+          const billing = await fetchBillingStatus();
+          if (billing.status === "active" || billing.status === "trialing") {
+            if (isMounted.current) {
+              setIsPolling(false);
+              onSubscriptionConfirmed();
+            }
+            return;
+          }
+        } catch {
+          // continue polling
+        }
       }
 
-      retries += 1;
-      if (retries < maxRetries && isMounted.current) {
-        setTimeout(() => void poll(), 2000);
-      } else if (isMounted.current) {
+      if (isMounted.current) {
         setIsPolling(false);
         setPollingFailed(true);
+
+        void runBackgroundPoll(
+          fetchBillingStatus,
+          () => {
+            if (isMounted.current) {
+              onSubscriptionConfirmed();
+            }
+          },
+          BACKGROUND_POLL_INTERVAL_MS,
+          BACKGROUND_POLL_WINDOW_MS,
+        );
       }
     };
 
-    setTimeout(() => void poll(), 2000);
+    void runVisiblePolling();
   }, [onSubscriptionConfirmed]);
 
   if (isPolling) {
@@ -122,17 +174,10 @@ export function BillingPage({
             <div className="bs-eyebrow">Bindersnap Pro</div>
             <h1>Activation is taking longer than expected</h1>
             <p style={{ color: "var(--bs-text-muted)" }}>
-              Your payment was received but workspace activation is taking
-              longer than expected. Please refresh in a moment, or contact
-              support if this persists.
+              Your payment was received. Activation can occasionally take up to
+              5 minutes — we&apos;re still checking in the background and will
+              redirect you automatically when your workspace is ready.
             </p>
-            <button
-              className="bs-btn bs-btn-primary"
-              type="button"
-              onClick={() => window.location.reload()}
-            >
-              Refresh
-            </button>
           </div>
         </div>
       </section>

--- a/apps/app/components/BillingPage.tsx
+++ b/apps/app/components/BillingPage.tsx
@@ -1,42 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { BindersnapLogoMark } from "./BindersnapLogoMark";
 import { fetchBillingStatus } from "../api";
-
-export const VISIBLE_POLLING_DELAYS_MS = [
-  1000, 2000, 4000, 8000, 8000, 8000, 8000, 8000, 8000, 8000,
-];
-
-export const BACKGROUND_POLL_INTERVAL_MS = 8000;
-
-export const BACKGROUND_POLL_WINDOW_MS = 300000;
-
-export async function runBackgroundPoll(
-  fetchFn: () => Promise<{ status: string }>,
-  onConfirmed: () => void,
-  intervalMs: number,
-  windowMs: number,
-): Promise<void> {
-  const startTime = Date.now();
-  const maxAttempts = Math.floor(windowMs / intervalMs);
-
-  for (let i = 0; i < maxAttempts; i++) {
-    if (Date.now() - startTime >= windowMs) {
-      break;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
-
-    try {
-      const result = await fetchFn();
-      if (result.status === "active" || result.status === "trialing") {
-        onConfirmed();
-        return;
-      }
-    } catch {
-      // continue polling
-    }
-  }
-}
+import {
+  VISIBLE_POLLING_DELAYS_MS,
+  BACKGROUND_POLL_INTERVAL_MS,
+  BACKGROUND_POLL_WINDOW_MS,
+  runBackgroundPoll,
+} from "./checkoutPolling";
 
 interface BillingPageProps {
   subscriptionStatus: "active" | "none" | "loading";

--- a/apps/app/components/checkoutPolling.ts
+++ b/apps/app/components/checkoutPolling.ts
@@ -1,0 +1,35 @@
+export const VISIBLE_POLLING_DELAYS_MS = [
+  1000, 2000, 4000, 8000, 8000, 8000, 8000, 8000, 8000, 8000,
+];
+
+export const BACKGROUND_POLL_INTERVAL_MS = 8000;
+
+export const BACKGROUND_POLL_WINDOW_MS = 300000;
+
+export async function runBackgroundPoll(
+  fetchFn: () => Promise<{ status: string }>,
+  onConfirmed: () => void,
+  intervalMs: number,
+  windowMs: number,
+): Promise<void> {
+  const startTime = Date.now();
+  const maxAttempts = Math.floor(windowMs / intervalMs);
+
+  for (let i = 0; i < maxAttempts; i++) {
+    if (Date.now() - startTime >= windowMs) {
+      break;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+
+    try {
+      const result = await fetchFn();
+      if (result.status === "active" || result.status === "trialing") {
+        onConfirmed();
+        return;
+      }
+    } catch {
+      // continue polling
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces fixed 10× 2s polling (20s total) with exponential backoff `[1, 2, 4, 8, 8, 8, 8, 8, 8, 8]`s (~63s visible phase)
- After visible phase exhausts, starts silent background polling at 8s intervals for up to 5 minutes; auto-redirects on activation
- Updates "taking longer" copy to reflect background polling; removes stale Refresh button
- Adds 6 unit tests covering schedule shape, constants, and long-tail activation path — all pass

## Workflow evidence

- Issue read: `mcp__github__issue_read` — issue #191
- Branch: `feat/checkout-polling-191`
- Commit: `fc0893c`
- PR creation: `mcp__github__create_pull_request`

Closes #191