### PR TITLE
Push tagged containers and deploy to EC2 when changed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "services/api/**"
     tags:
-      - "*"
+      - "v[0-9]*"
   workflow_dispatch:
     inputs:
       api_tag:
@@ -60,15 +62,51 @@ jobs:
   build-api:
     name: Build API Image
     needs: test
+    if: "!startsWith(github.ref, 'refs/tags/')"
     permissions:
       contents: read
       packages: write
     uses: ./.github/workflows/build-api.yml
 
+  retag:
+    name: Tag API Image
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Normalize image owner
+        run: echo "IMAGE_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - name: Extract semver from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create version tag from commit SHA
+        run: |
+          docker buildx imagetools create \
+            --tag "ghcr.io/${IMAGE_OWNER}/bindersnap-api:${VERSION}" \
+            "ghcr.io/${IMAGE_OWNER}/bindersnap-api:${GITHUB_SHA}"
+
+      - name: Inspect published manifest
+        run: docker buildx imagetools inspect "ghcr.io/${IMAGE_OWNER}/bindersnap-api:${VERSION}"
+
   deploy:
     name: Deploy
     runs-on: ubuntu-24.04
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+    if: "!startsWith(github.ref, 'refs/tags/')"
     needs:
       - build-api
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

Previously the EC2 instance did not receive the updated images until I deployed a tag. Switching that to deploy when a PR goes to main.