### PR TITLE
Add fine-grained document permissions (#206)

### DIFF
--- a/apps/app/api.ts
+++ b/apps/app/api.ts
@@ -116,6 +116,21 @@ export interface CollaboratorListPayload {
   currentUserPermission: RepoCollaboratorPermissionSummary | null;
 }
 
+export interface DocumentPermissionsPayload {
+  branchProtection: {
+    requiredApprovals: number;
+    enableApprovalsWhitelist: boolean;
+    approvalsWhitelistUsernames: string[];
+    approvalsWhitelistTeams: string[];
+    enableMergeWhitelist: boolean;
+    mergeWhitelistUsernames: string[];
+    mergeWhitelistTeams: string[];
+    blockOnRejectedReviews: boolean;
+  } | null;
+  isPrivate: boolean;
+  currentUserPermission?: RepoCollaboratorPermissionSummary | null;
+}
+
 export interface SearchUsersPayload {
   users: RepoUserSummary[];
   page: number;
@@ -908,6 +923,43 @@ export async function removeDocumentCollaborator(
       },
     },
     "Unable to remove collaborator.",
+  );
+}
+
+export async function getDocumentPermissions(
+  owner: string,
+  repo: string,
+): Promise<DocumentPermissionsPayload> {
+  return requestJson<DocumentPermissionsPayload>(
+    `/api/app/documents/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/permissions`,
+    { method: "GET", headers: { Accept: "application/json" } },
+    "Unable to load document permissions.",
+  );
+}
+
+export async function updateDocumentPermissions(
+  owner: string,
+  repo: string,
+  updates: {
+    requiredApprovals?: number;
+    enableApprovalsWhitelist?: boolean;
+    approvalsWhitelistUsernames?: string[];
+    enableMergeWhitelist?: boolean;
+    mergeWhitelistUsernames?: string[];
+    isPrivate?: boolean;
+  },
+): Promise<DocumentPermissionsPayload> {
+  return requestJson<DocumentPermissionsPayload>(
+    `/api/app/documents/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/permissions`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(updates),
+    },
+    "Unable to update document permissions.",
   );
 }
 

--- a/apps/app/api.ts
+++ b/apps/app/api.ts
@@ -128,6 +128,7 @@ export interface DocumentPermissionsPayload {
     blockOnRejectedReviews: boolean;
   } | null;
   isPrivate: boolean;
+  isInternal: boolean;
   currentUserPermission?: RepoCollaboratorPermissionSummary | null;
 }
 

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -1603,6 +1603,13 @@ input {
   color: var(--brand-green);
 }
 
+.perms-public-access-hint {
+  margin: var(--brand-space-4) 0 0;
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-muted);
+  line-height: var(--brand-leading-relaxed);
+}
+
 @media (max-width: 960px) {
   .collaborators-table-head,
   .collaborator-row {

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -1541,7 +1541,8 @@ input {
   border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-lg);
   cursor: pointer;
-  transition: background var(--brand-transition-fast),
+  transition:
+    background var(--brand-transition-fast),
     border-color var(--brand-transition-fast);
 }
 

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -1263,6 +1263,345 @@ input {
   color: var(--brand-coral-dark);
 }
 
+/* ── Document Permissions ───────────────────────────────────── */
+
+.perms-page {
+  display: grid;
+  gap: var(--brand-space-5);
+  align-content: start;
+}
+
+.perms-state-text {
+  color: var(--bs-text-muted);
+  font-size: var(--brand-text-sm);
+}
+
+.perms-notice {
+  padding: var(--brand-space-4) var(--brand-space-5);
+  background: var(--bs-surface-2);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-lg);
+  color: var(--bs-text-secondary);
+  font-size: var(--brand-text-sm);
+}
+
+.perms-notice--error {
+  border-color: var(--brand-coral-mid);
+  background: color-mix(in srgb, var(--brand-coral) 6%, var(--bs-surface-1));
+  display: grid;
+  gap: var(--brand-space-2);
+}
+
+.perms-notice--error p {
+  margin: 0;
+  color: var(--brand-coral-dark);
+}
+
+.perms-card {
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-xl);
+  overflow: hidden;
+}
+
+.perms-group {
+  padding: var(--brand-space-5) var(--brand-space-6);
+}
+
+.perms-group + .perms-group {
+  border-top: 1px solid var(--bs-rule);
+}
+
+.perms-group-heading {
+  margin: 0 0 var(--brand-space-4);
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wider);
+  text-transform: uppercase;
+  color: var(--bs-text-muted);
+}
+
+/* Row with label+hint on left, control on right */
+.perms-row--split {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--brand-space-5);
+  padding: var(--brand-space-3) 0;
+}
+
+.perms-row--split + .perms-row--split,
+.perms-row--split + .perms-row--sub,
+.perms-row--sub + .perms-row--split {
+  border-top: 1px solid var(--bs-rule-warm);
+}
+
+.perms-row-main {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  gap: var(--brand-space-1);
+}
+
+.perms-row-label {
+  font-family: var(--brand-font-sans);
+  font-size: var(--brand-text-sm);
+  font-weight: var(--brand-weight-medium);
+  color: var(--bs-text-secondary);
+  cursor: default;
+}
+
+.perms-row-hint {
+  margin: 0;
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-faint);
+  line-height: var(--brand-leading-relaxed);
+}
+
+.perms-number-input {
+  width: 72px;
+  text-align: center;
+  flex-shrink: 0;
+  padding: var(--brand-space-2) var(--brand-space-3);
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-md);
+  color: var(--bs-text-primary);
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-body);
+  box-sizing: border-box;
+}
+
+.perms-number-input:focus {
+  outline: 2px solid var(--brand-coral);
+  outline-offset: 1px;
+  border-color: var(--brand-coral);
+}
+
+.perms-number-input:disabled {
+  opacity: 0.5;
+}
+
+.perms-checkbox {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  accent-color: var(--brand-coral);
+  cursor: pointer;
+}
+
+.perms-checkbox:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+/* Sub-row for user pickers (no border-top — visually part of the row above) */
+.perms-row--sub {
+  display: grid;
+  gap: var(--brand-space-2);
+  padding: var(--brand-space-3) var(--brand-space-4);
+  background: var(--bs-surface-2);
+  border-radius: var(--brand-radius-md);
+  margin-top: var(--brand-space-1);
+}
+
+.perms-sub-label {
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-xs);
+  font-weight: var(--brand-weight-medium);
+  color: var(--bs-text-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--brand-tracking-wide);
+}
+
+/* User picker */
+.perms-picker {
+  display: grid;
+  gap: var(--brand-space-2);
+}
+
+.perms-picker-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--brand-space-2);
+}
+
+.perms-picker-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--brand-space-1);
+  padding: var(--brand-space-1) var(--brand-space-3);
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-full);
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-secondary);
+}
+
+.perms-picker-chip-remove {
+  appearance: none;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 15px;
+  line-height: 1;
+  color: var(--bs-text-muted);
+  display: flex;
+  align-items: center;
+}
+
+.perms-picker-chip-remove:hover {
+  color: var(--brand-coral);
+}
+
+.perms-picker-shell {
+  position: relative;
+}
+
+.perms-picker-input {
+  padding-top: var(--brand-space-2);
+  padding-bottom: var(--brand-space-2);
+  font-size: var(--brand-text-sm);
+}
+
+.perms-picker-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-lg);
+  box-shadow: var(--bs-shadow-md);
+  overflow: hidden;
+}
+
+.perms-picker-state {
+  padding: var(--brand-space-3) var(--brand-space-4);
+  margin: 0;
+  font-size: var(--brand-text-sm);
+  color: var(--bs-text-muted);
+}
+
+.perms-picker-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--brand-space-3);
+  width: 100%;
+  padding: var(--brand-space-3) var(--brand-space-4);
+  text-align: left;
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--bs-rule-warm);
+  cursor: pointer;
+}
+
+.perms-picker-result:first-child {
+  border-top: none;
+}
+
+.perms-picker-result:hover {
+  background: var(--bs-surface-2);
+}
+
+.perms-picker-result-name {
+  font-family: var(--brand-font-sans);
+  font-size: var(--brand-text-sm);
+  color: var(--bs-text-primary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.perms-picker-result-login {
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-muted);
+  flex-shrink: 0;
+}
+
+/* Visibility radio options */
+.perms-radio-group {
+  display: grid;
+  gap: var(--brand-space-2);
+}
+
+.perms-radio-option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--brand-space-3);
+  padding: var(--brand-space-3) var(--brand-space-4);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-lg);
+  cursor: pointer;
+  transition: background var(--brand-transition-fast),
+    border-color var(--brand-transition-fast);
+}
+
+.perms-radio-option:has(input:disabled) {
+  cursor: default;
+  opacity: 0.75;
+}
+
+.perms-radio-option--selected {
+  border-color: var(--brand-coral);
+  background: color-mix(in srgb, var(--brand-coral) 5%, var(--bs-surface-1));
+}
+
+.perms-radio-option input[type="radio"] {
+  flex-shrink: 0;
+  margin-top: 3px;
+  accent-color: var(--brand-coral);
+  width: 16px;
+  height: 16px;
+}
+
+.perms-radio-title {
+  font-size: var(--brand-text-sm);
+  font-weight: var(--brand-weight-medium);
+  color: var(--bs-text-primary);
+}
+
+.perms-radio-desc {
+  margin-top: var(--brand-space-1);
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-muted);
+}
+
+.perms-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--brand-space-4);
+  padding: var(--brand-space-4) var(--brand-space-6);
+  border-top: 1px solid var(--bs-rule);
+  background: var(--bs-surface-2);
+}
+
+.perms-footer-messages {
+  flex: 1;
+  min-width: 0;
+}
+
+.perms-save-error {
+  margin: 0;
+  font-size: var(--brand-text-sm);
+  color: var(--brand-coral-dark);
+}
+
+.perms-save-success {
+  margin: 0;
+  font-size: var(--brand-text-sm);
+  color: var(--brand-green);
+}
+
 @media (max-width: 960px) {
   .collaborators-table-head,
   .collaborator-row {

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -13,14 +13,15 @@ import {
   submitDocumentReview,
 } from "../api";
 import { DocumentCollaborators } from "./DocumentCollaborators";
+import { DocumentPermissions } from "./DocumentPermissions";
 import { UploadModal } from "./UploadModal";
 
 interface DocumentDetailProps {
   owner: string;
   repo: string;
   uploaderSlug: string;
-  activeView: "overview" | "collaborators";
-  onTabChange: (tab: "overview" | "collaborators") => void;
+  activeView: "overview" | "collaborators" | "permissions";
+  onTabChange: (tab: "overview" | "collaborators" | "permissions") => void;
   onBack: () => void;
 }
 
@@ -455,12 +456,29 @@ export function DocumentDetail({
           >
             Team
           </button>
+          <button
+            className={`document-detail-tab${activeView === "permissions" ? " document-detail-tab-active" : ""}`}
+            type="button"
+            role="tab"
+            aria-selected={activeView === "permissions"}
+            onClick={() => onTabChange("permissions")}
+          >
+            Permissions
+          </button>
         </div>
       </section>
 
       {activeView === "collaborators" ? (
         <div className="document-detail-tab-panel document-detail-tab-panel--collaborators">
           <DocumentCollaborators
+            owner={owner}
+            repo={repo}
+            currentUsername={uploaderSlug}
+          />
+        </div>
+      ) : activeView === "permissions" ? (
+        <div className="document-detail-tab-panel document-detail-tab-panel--permissions">
+          <DocumentPermissions
             owner={owner}
             repo={repo}
             currentUsername={uploaderSlug}

--- a/apps/app/components/DocumentPermissions.tsx
+++ b/apps/app/components/DocumentPermissions.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useState } from "react";
+import { getDocumentPermissions, updateDocumentPermissions } from "../api";
+import type { DocumentPermissionsPayload } from "../api";
+
+interface DocumentPermissionsProps {
+  owner: string;
+  repo: string;
+  currentUsername: string;
+}
+
+function parseUsernameList(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((u) => u.trim())
+    .filter(Boolean);
+}
+
+export function DocumentPermissions({
+  owner,
+  repo,
+  currentUsername,
+}: DocumentPermissionsProps) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const [requiredApprovals, setRequiredApprovals] = useState(1);
+  const [enableApprovalsWhitelist, setEnableApprovalsWhitelist] =
+    useState(false);
+  const [approvalsWhitelistInput, setApprovalsWhitelistInput] = useState("");
+  const [enableMergeWhitelist, setEnableMergeWhitelist] = useState(false);
+  const [mergeWhitelistInput, setMergeWhitelistInput] = useState("");
+  const [isPrivate, setIsPrivate] = useState(true);
+
+  const [currentUserPermission, setCurrentUserPermission] = useState<
+    string | null
+  >(null);
+  const isOwner =
+    currentUsername === owner || currentUserPermission === "owner";
+
+  useEffect(() => {
+    setLoading(true);
+    setLoadError(null);
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    void (async () => {
+      try {
+        const data = await getDocumentPermissions(owner, repo);
+        applyPayload(data);
+      } catch (err) {
+        setLoadError(
+          err instanceof Error ? err.message : "Unable to load permissions.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [owner, repo]);
+
+  function applyPayload(data: DocumentPermissionsPayload): void {
+    const bp = data.branchProtection;
+    setRequiredApprovals(bp?.requiredApprovals ?? 1);
+    setEnableApprovalsWhitelist(bp?.enableApprovalsWhitelist ?? false);
+    setApprovalsWhitelistInput(
+      (bp?.approvalsWhitelistUsernames ?? []).join(", "),
+    );
+    setEnableMergeWhitelist(bp?.enableMergeWhitelist ?? false);
+    setMergeWhitelistInput((bp?.mergeWhitelistUsernames ?? []).join(", "));
+    setIsPrivate(data.isPrivate);
+    setCurrentUserPermission(data.currentUserPermission?.access ?? null);
+  }
+
+  async function handleSave(): Promise<void> {
+    setSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    try {
+      const data = await updateDocumentPermissions(owner, repo, {
+        requiredApprovals,
+        enableApprovalsWhitelist,
+        approvalsWhitelistUsernames: enableApprovalsWhitelist
+          ? parseUsernameList(approvalsWhitelistInput)
+          : [],
+        enableMergeWhitelist,
+        mergeWhitelistUsernames: enableMergeWhitelist
+          ? parseUsernameList(mergeWhitelistInput)
+          : [],
+        isPrivate,
+      });
+      applyPayload(data);
+      setSaveSuccess(true);
+    } catch (err) {
+      setSaveError(
+        err instanceof Error ? err.message : "Unable to save permissions.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="vault-detail permissions-page">
+      <section className="vault-section permissions-hero">
+        <div className="bs-eyebrow">Permissions</div>
+        <h1>Document permissions</h1>
+        <p>
+          Control approval requirements, restrict who can approve or publish,
+          and manage public read access for{" "}
+          <code>
+            {owner}/{repo}
+          </code>
+          .
+        </p>
+      </section>
+
+      {loading ? (
+        <section className="bs-card permissions-panel" role="status">
+          Loading permissions...
+        </section>
+      ) : loadError ? (
+        <section className="bs-card permissions-panel permissions-error">
+          <div className="bs-eyebrow">Error</div>
+          <h2>Unable to load permissions</h2>
+          <p>{loadError}</p>
+        </section>
+      ) : !isOwner ? (
+        <section className="bs-card permissions-panel permissions-readonly">
+          <div className="bs-eyebrow">Read-Only</div>
+          <h2>Only the document owner can change permissions</h2>
+          <p>You can view these settings but cannot modify them.</p>
+        </section>
+      ) : null}
+
+      {!loading && !loadError ? (
+        <>
+          <section className="bs-card permissions-panel">
+            <div className="permissions-panel-header">
+              <div className="bs-eyebrow">Review Rules</div>
+              <h2>Approval requirements</h2>
+            </div>
+            <p className="permissions-description">
+              Set the minimum number of approvals required before a document can
+              be published.
+            </p>
+            <div className="permissions-field">
+              <label className="permissions-label" htmlFor="required-approvals">
+                Required approvals
+              </label>
+              <input
+                id="required-approvals"
+                className="bs-input permissions-number-input"
+                type="number"
+                min={0}
+                max={20}
+                value={requiredApprovals}
+                disabled={!isOwner || saving}
+                onChange={(e) =>
+                  setRequiredApprovals(Math.max(0, Number(e.target.value)))
+                }
+              />
+              <p className="permissions-hint">
+                Set to 0 to allow publishing without any approvals.
+              </p>
+            </div>
+
+            <div className="permissions-field">
+              <label className="permissions-toggle-label">
+                <input
+                  type="checkbox"
+                  className="permissions-toggle"
+                  checked={enableApprovalsWhitelist}
+                  disabled={!isOwner || saving}
+                  onChange={(e) =>
+                    setEnableApprovalsWhitelist(e.target.checked)
+                  }
+                />
+                <span>Restrict approvals to specific users</span>
+              </label>
+            </div>
+
+            {enableApprovalsWhitelist ? (
+              <div className="permissions-field">
+                <label
+                  className="permissions-label"
+                  htmlFor="approvals-whitelist"
+                >
+                  Allowed approvers (comma or space separated usernames)
+                </label>
+                <input
+                  id="approvals-whitelist"
+                  className="bs-input"
+                  type="text"
+                  placeholder="alice, bob, carol"
+                  value={approvalsWhitelistInput}
+                  disabled={!isOwner || saving}
+                  onChange={(e) => setApprovalsWhitelistInput(e.target.value)}
+                />
+              </div>
+            ) : null}
+          </section>
+
+          <section className="bs-card permissions-panel">
+            <div className="permissions-panel-header">
+              <div className="bs-eyebrow">Publish Rules</div>
+              <h2>Publish restrictions</h2>
+            </div>
+            <p className="permissions-description">
+              Control who is allowed to publish (merge) approved documents.
+            </p>
+            <div className="permissions-field">
+              <label className="permissions-toggle-label">
+                <input
+                  type="checkbox"
+                  className="permissions-toggle"
+                  checked={enableMergeWhitelist}
+                  disabled={!isOwner || saving}
+                  onChange={(e) => setEnableMergeWhitelist(e.target.checked)}
+                />
+                <span>Restrict publishing to specific users</span>
+              </label>
+            </div>
+
+            {enableMergeWhitelist ? (
+              <div className="permissions-field">
+                <label className="permissions-label" htmlFor="merge-whitelist">
+                  Allowed publishers (comma or space separated usernames)
+                </label>
+                <input
+                  id="merge-whitelist"
+                  className="bs-input"
+                  type="text"
+                  placeholder="alice, bob"
+                  value={mergeWhitelistInput}
+                  disabled={!isOwner || saving}
+                  onChange={(e) => setMergeWhitelistInput(e.target.value)}
+                />
+              </div>
+            ) : null}
+          </section>
+
+          <section className="bs-card permissions-panel">
+            <div className="permissions-panel-header">
+              <div className="bs-eyebrow">Public Access</div>
+              <h2>Visibility</h2>
+            </div>
+            <p className="permissions-description">
+              Public documents can be read by anyone — including anonymous
+              visitors. Reviews and version history are visible too. Private
+              documents are only accessible to collaborators.
+            </p>
+            <div className="permissions-field">
+              <label className="permissions-toggle-label">
+                <input
+                  type="checkbox"
+                  className="permissions-toggle"
+                  checked={isPrivate}
+                  disabled={!isOwner || saving}
+                  onChange={(e) => setIsPrivate(e.target.checked)}
+                />
+                <span>Keep this document private</span>
+              </label>
+              <p className="permissions-hint">
+                {isPrivate
+                  ? "Only collaborators can access this document."
+                  : "Anyone can read this document and its review history."}
+              </p>
+            </div>
+          </section>
+
+          {isOwner ? (
+            <div className="permissions-actions">
+              {saveError ? (
+                <p className="permissions-save-error" role="alert">
+                  {saveError}
+                </p>
+              ) : saveSuccess ? (
+                <p className="permissions-save-success" role="status">
+                  Permissions saved.
+                </p>
+              ) : null}
+              <button
+                className="bs-btn bs-btn-primary"
+                type="button"
+                disabled={saving}
+                onClick={() => void handleSave()}
+              >
+                {saving ? "Saving..." : "Save permissions"}
+              </button>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/app/components/DocumentPermissions.tsx
+++ b/apps/app/components/DocumentPermissions.tsx
@@ -188,6 +188,7 @@ export function DocumentPermissions({
   const [enableMergeWhitelist, setEnableMergeWhitelist] = useState(false);
   const [mergeWhitelistUsers, setMergeWhitelistUsers] = useState<string[]>([]);
   const [isPrivate, setIsPrivate] = useState(true);
+  const [isInternal, setIsInternal] = useState(false);
 
   const [currentUserPermission, setCurrentUserPermission] = useState<
     string | null
@@ -223,6 +224,7 @@ export function DocumentPermissions({
     setEnableMergeWhitelist(bp?.enableMergeWhitelist ?? false);
     setMergeWhitelistUsers(bp?.mergeWhitelistUsernames ?? []);
     setIsPrivate(data.isPrivate);
+    setIsInternal(data.isInternal);
     setCurrentUserPermission(data.currentUserPermission?.access ?? null);
   }
 
@@ -390,44 +392,69 @@ export function DocumentPermissions({
         <div className="perms-group">
           <p className="perms-group-heading">Visibility</p>
 
-          <div className="perms-radio-group">
-            <label
-              className={`perms-radio-option${isPrivate ? " perms-radio-option--selected" : ""}`}
-            >
-              <input
-                type="radio"
-                name="doc-visibility"
-                value="private"
-                checked={isPrivate}
-                disabled={disabled}
-                onChange={() => setIsPrivate(true)}
-              />
-              <div>
-                <div className="perms-radio-title">Private</div>
-                <div className="perms-radio-desc">
-                  Only collaborators can access this document.
-                </div>
+          {isInternal ? (
+            <div className="perms-notice">
+              <div className="bs-eyebrow">Internal (Gitea)</div>
+              <p>
+                This document uses <strong>Internal</strong> visibility —
+                accessible to all logged-in Gitea users but not listed on your
+                profile or in search results. To change it, update the
+                repository visibility in Gitea settings.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="perms-radio-group">
+                <label
+                  className={`perms-radio-option${isPrivate ? " perms-radio-option--selected" : ""}`}
+                >
+                  <input
+                    type="radio"
+                    name="doc-visibility"
+                    value="private"
+                    checked={isPrivate}
+                    disabled={disabled}
+                    onChange={() => setIsPrivate(true)}
+                  />
+                  <div>
+                    <div className="perms-radio-title">Private</div>
+                    <div className="perms-radio-desc">
+                      Only collaborators you've added can access this document.
+                      It won't appear in search results or on your profile.
+                    </div>
+                  </div>
+                </label>
+                <label
+                  className={`perms-radio-option${!isPrivate ? " perms-radio-option--selected" : ""}`}
+                >
+                  <input
+                    type="radio"
+                    name="doc-visibility"
+                    value="public"
+                    checked={!isPrivate}
+                    disabled={disabled}
+                    onChange={() => setIsPrivate(false)}
+                  />
+                  <div>
+                    <div className="perms-radio-title">Public</div>
+                    <div className="perms-radio-desc">
+                      Anyone on the internet can view this document and its full
+                      revision history, even without an account.
+                    </div>
+                  </div>
+                </label>
               </div>
-            </label>
-            <label
-              className={`perms-radio-option${!isPrivate ? " perms-radio-option--selected" : ""}`}
-            >
-              <input
-                type="radio"
-                name="doc-visibility"
-                value="public"
-                checked={!isPrivate}
-                disabled={disabled}
-                onChange={() => setIsPrivate(false)}
-              />
-              <div>
-                <div className="perms-radio-title">Public</div>
-                <div className="perms-radio-desc">
-                  Anyone can read this document and its review history.
-                </div>
-              </div>
-            </label>
-          </div>
+              {isPrivate && (
+                <p className="perms-public-access-hint">
+                  To allow anonymous users to view specific parts of this
+                  private document (such as code or issues), configure{" "}
+                  <strong>Public Access settings</strong> in your Gitea
+                  repository settings. These are separate from the
+                  public/private toggle above.
+                </p>
+              )}
+            </>
+          )}
         </div>
 
         {/* Footer */}

--- a/apps/app/components/DocumentPermissions.tsx
+++ b/apps/app/components/DocumentPermissions.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useState } from "react";
-import { getDocumentPermissions, updateDocumentPermissions } from "../api";
+import { useEffect, useRef, useState } from "react";
+import {
+  getDocumentPermissions,
+  searchWorkspaceUsers,
+  updateDocumentPermissions,
+} from "../api";
 import type { DocumentPermissionsPayload } from "../api";
+import type { RepoUserSummary } from "../../../packages/gitea-client/repos";
 
 interface DocumentPermissionsProps {
   owner: string;
@@ -8,12 +13,160 @@ interface DocumentPermissionsProps {
   currentUsername: string;
 }
 
-function parseUsernameList(raw: string): string[] {
-  return raw
-    .split(/[\s,]+/)
-    .map((u) => u.trim())
-    .filter(Boolean);
+interface UserResult {
+  login: string;
+  fullName: string;
 }
+
+function toUserResult(u: RepoUserSummary): UserResult {
+  return {
+    login: u.login,
+    fullName: u.full_name || u.login,
+  };
+}
+
+// ── User picker sub-component ─────────────────────────────────
+
+interface UserPickerFieldProps {
+  id: string;
+  selected: string[];
+  onChange: (users: string[]) => void;
+  disabled: boolean;
+}
+
+function UserPickerField({
+  id,
+  selected,
+  onChange,
+  disabled,
+}: UserPickerFieldProps) {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [results, setResults] = useState<UserResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const searchId = useRef(0);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setDebouncedQuery(query.trim()), 250);
+    return () => window.clearTimeout(t);
+  }, [query]);
+
+  useEffect(() => {
+    const q = debouncedQuery;
+    const reqId = ++searchId.current;
+
+    if (q.length < 2) {
+      setResults([]);
+      setIsSearching(false);
+      setIsOpen(false);
+      return;
+    }
+
+    setIsSearching(true);
+
+    void (async () => {
+      try {
+        const data = await searchWorkspaceUsers(q, 1, 8);
+        if (reqId !== searchId.current) return;
+        setResults(data.users.map(toUserResult));
+      } catch {
+        if (reqId !== searchId.current) return;
+        setResults([]);
+      } finally {
+        if (reqId === searchId.current) setIsSearching(false);
+      }
+    })();
+  }, [debouncedQuery]);
+
+  const visible = results.filter((u) => !selected.includes(u.login));
+
+  function add(login: string) {
+    onChange([...selected, login]);
+    setQuery("");
+    setDebouncedQuery("");
+    setResults([]);
+    setIsOpen(false);
+  }
+
+  function remove(login: string) {
+    onChange(selected.filter((u) => u !== login));
+  }
+
+  return (
+    <div className="perms-picker">
+      {selected.length > 0 && (
+        <div className="perms-picker-chips">
+          {selected.map((login) => (
+            <span className="perms-picker-chip" key={login}>
+              @{login}
+              {!disabled && (
+                <button
+                  type="button"
+                  className="perms-picker-chip-remove"
+                  aria-label={`Remove ${login}`}
+                  onClick={() => remove(login)}
+                >
+                  ×
+                </button>
+              )}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {!disabled && (
+        <div className="perms-picker-shell">
+          <input
+            id={id}
+            type="search"
+            className="bs-input perms-picker-input"
+            placeholder="Search by name or username…"
+            value={query}
+            autoComplete="off"
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setIsOpen(e.target.value.trim().length >= 2);
+            }}
+          />
+          {isOpen && query.trim().length >= 2 && (
+            <div className="perms-picker-dropdown" role="listbox">
+              {isSearching ? (
+                <p className="perms-picker-state">Searching…</p>
+              ) : visible.length === 0 ? (
+                <p className="perms-picker-state">
+                  {results.length > 0
+                    ? "All matching users are already added."
+                    : "No users found."}
+                </p>
+              ) : (
+                visible.map((user) => (
+                  <button
+                    key={user.login}
+                    type="button"
+                    role="option"
+                    aria-selected={false}
+                    className="perms-picker-result"
+                    onClick={() => add(user.login)}
+                  >
+                    <span className="perms-picker-result-name">
+                      {user.fullName !== user.login ? user.fullName : ""}
+                    </span>
+                    <span className="perms-picker-result-login">
+                      @{user.login}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────
 
 export function DocumentPermissions({
   owner,
@@ -29,9 +182,11 @@ export function DocumentPermissions({
   const [requiredApprovals, setRequiredApprovals] = useState(1);
   const [enableApprovalsWhitelist, setEnableApprovalsWhitelist] =
     useState(false);
-  const [approvalsWhitelistInput, setApprovalsWhitelistInput] = useState("");
+  const [approvalsWhitelistUsers, setApprovalsWhitelistUsers] = useState<
+    string[]
+  >([]);
   const [enableMergeWhitelist, setEnableMergeWhitelist] = useState(false);
-  const [mergeWhitelistInput, setMergeWhitelistInput] = useState("");
+  const [mergeWhitelistUsers, setMergeWhitelistUsers] = useState<string[]>([]);
   const [isPrivate, setIsPrivate] = useState(true);
 
   const [currentUserPermission, setCurrentUserPermission] = useState<
@@ -64,11 +219,9 @@ export function DocumentPermissions({
     const bp = data.branchProtection;
     setRequiredApprovals(bp?.requiredApprovals ?? 1);
     setEnableApprovalsWhitelist(bp?.enableApprovalsWhitelist ?? false);
-    setApprovalsWhitelistInput(
-      (bp?.approvalsWhitelistUsernames ?? []).join(", "),
-    );
+    setApprovalsWhitelistUsers(bp?.approvalsWhitelistUsernames ?? []);
     setEnableMergeWhitelist(bp?.enableMergeWhitelist ?? false);
-    setMergeWhitelistInput((bp?.mergeWhitelistUsernames ?? []).join(", "));
+    setMergeWhitelistUsers(bp?.mergeWhitelistUsernames ?? []);
     setIsPrivate(data.isPrivate);
     setCurrentUserPermission(data.currentUserPermission?.access ?? null);
   }
@@ -83,11 +236,11 @@ export function DocumentPermissions({
         requiredApprovals,
         enableApprovalsWhitelist,
         approvalsWhitelistUsernames: enableApprovalsWhitelist
-          ? parseUsernameList(approvalsWhitelistInput)
+          ? approvalsWhitelistUsers
           : [],
         enableMergeWhitelist,
         mergeWhitelistUsernames: enableMergeWhitelist
-          ? parseUsernameList(mergeWhitelistInput)
+          ? mergeWhitelistUsers
           : [],
         isPrivate,
       });
@@ -102,198 +255,207 @@ export function DocumentPermissions({
     }
   }
 
-  return (
-    <div className="vault-detail permissions-page">
-      <section className="vault-section permissions-hero">
-        <div className="bs-eyebrow">Permissions</div>
-        <h1>Document permissions</h1>
-        <p>
-          Control approval requirements, restrict who can approve or publish,
-          and manage public read access for{" "}
-          <code>
-            {owner}/{repo}
-          </code>
-          .
-        </p>
-      </section>
+  const disabled = !isOwner || saving;
 
-      {loading ? (
-        <section className="bs-card permissions-panel" role="status">
-          Loading permissions...
-        </section>
-      ) : loadError ? (
-        <section className="bs-card permissions-panel permissions-error">
+  if (loading) {
+    return (
+      <div className="perms-page">
+        <p className="perms-state-text">Loading permissions…</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="perms-page">
+        <div className="perms-notice perms-notice--error">
           <div className="bs-eyebrow">Error</div>
-          <h2>Unable to load permissions</h2>
           <p>{loadError}</p>
-        </section>
-      ) : !isOwner ? (
-        <section className="bs-card permissions-panel permissions-readonly">
-          <div className="bs-eyebrow">Read-Only</div>
-          <h2>Only the document owner can change permissions</h2>
-          <p>You can view these settings but cannot modify them.</p>
-        </section>
-      ) : null}
+        </div>
+      </div>
+    );
+  }
 
-      {!loading && !loadError ? (
-        <>
-          <section className="bs-card permissions-panel">
-            <div className="permissions-panel-header">
-              <div className="bs-eyebrow">Review Rules</div>
-              <h2>Approval requirements</h2>
-            </div>
-            <p className="permissions-description">
-              Set the minimum number of approvals required before a document can
-              be published.
-            </p>
-            <div className="permissions-field">
-              <label className="permissions-label" htmlFor="required-approvals">
+  return (
+    <div className="perms-page">
+      {!isOwner && (
+        <div className="perms-notice">
+          Only the document owner can change permissions. You can view these
+          settings but cannot modify them.
+        </div>
+      )}
+
+      <div className="perms-card">
+        {/* Review Rules */}
+        <div className="perms-group">
+          <p className="perms-group-heading">Review Rules</p>
+
+          <div className="perms-row perms-row--split">
+            <div className="perms-row-main">
+              <label className="perms-row-label" htmlFor="required-approvals">
                 Required approvals
               </label>
-              <input
-                id="required-approvals"
-                className="bs-input permissions-number-input"
-                type="number"
-                min={0}
-                max={20}
-                value={requiredApprovals}
-                disabled={!isOwner || saving}
-                onChange={(e) =>
-                  setRequiredApprovals(Math.max(0, Number(e.target.value)))
-                }
+              <p className="perms-row-hint">
+                Minimum approvals needed before a change can be published.
+              </p>
+            </div>
+            <input
+              id="required-approvals"
+              className="perms-number-input"
+              type="number"
+              min={0}
+              max={20}
+              value={requiredApprovals}
+              disabled={disabled}
+              onChange={(e) =>
+                setRequiredApprovals(Math.max(0, Number(e.target.value)))
+              }
+            />
+          </div>
+
+          <div className="perms-row perms-row--split">
+            <div className="perms-row-main">
+              <label className="perms-row-label" htmlFor="restrict-approvers">
+                Restrict who can approve
+              </label>
+              <p className="perms-row-hint">
+                When enabled, only the users listed can submit approvals.
+              </p>
+            </div>
+            <input
+              id="restrict-approvers"
+              type="checkbox"
+              className="perms-checkbox"
+              checked={enableApprovalsWhitelist}
+              disabled={disabled}
+              onChange={(e) => setEnableApprovalsWhitelist(e.target.checked)}
+            />
+          </div>
+
+          {enableApprovalsWhitelist && (
+            <div className="perms-row perms-row--sub">
+              <label className="perms-sub-label" htmlFor="approvals-picker">
+                Allowed approvers
+              </label>
+              <UserPickerField
+                id="approvals-picker"
+                selected={approvalsWhitelistUsers}
+                onChange={setApprovalsWhitelistUsers}
+                disabled={disabled}
               />
-              <p className="permissions-hint">
-                Set to 0 to allow publishing without any approvals.
+            </div>
+          )}
+        </div>
+
+        {/* Publish Rules */}
+        <div className="perms-group">
+          <p className="perms-group-heading">Publish Rules</p>
+
+          <div className="perms-row perms-row--split">
+            <div className="perms-row-main">
+              <label className="perms-row-label" htmlFor="restrict-publishers">
+                Restrict who can publish
+              </label>
+              <p className="perms-row-hint">
+                When enabled, only the users listed can publish approved
+                changes.
               </p>
             </div>
+            <input
+              id="restrict-publishers"
+              type="checkbox"
+              className="perms-checkbox"
+              checked={enableMergeWhitelist}
+              disabled={disabled}
+              onChange={(e) => setEnableMergeWhitelist(e.target.checked)}
+            />
+          </div>
 
-            <div className="permissions-field">
-              <label className="permissions-toggle-label">
-                <input
-                  type="checkbox"
-                  className="permissions-toggle"
-                  checked={enableApprovalsWhitelist}
-                  disabled={!isOwner || saving}
-                  onChange={(e) =>
-                    setEnableApprovalsWhitelist(e.target.checked)
-                  }
-                />
-                <span>Restrict approvals to specific users</span>
+          {enableMergeWhitelist && (
+            <div className="perms-row perms-row--sub">
+              <label className="perms-sub-label" htmlFor="publishers-picker">
+                Allowed publishers
               </label>
+              <UserPickerField
+                id="publishers-picker"
+                selected={mergeWhitelistUsers}
+                onChange={setMergeWhitelistUsers}
+                disabled={disabled}
+              />
             </div>
+          )}
+        </div>
 
-            {enableApprovalsWhitelist ? (
-              <div className="permissions-field">
-                <label
-                  className="permissions-label"
-                  htmlFor="approvals-whitelist"
-                >
-                  Allowed approvers (comma or space separated usernames)
-                </label>
-                <input
-                  id="approvals-whitelist"
-                  className="bs-input"
-                  type="text"
-                  placeholder="alice, bob, carol"
-                  value={approvalsWhitelistInput}
-                  disabled={!isOwner || saving}
-                  onChange={(e) => setApprovalsWhitelistInput(e.target.value)}
-                />
+        {/* Visibility */}
+        <div className="perms-group">
+          <p className="perms-group-heading">Visibility</p>
+
+          <div className="perms-radio-group">
+            <label
+              className={`perms-radio-option${isPrivate ? " perms-radio-option--selected" : ""}`}
+            >
+              <input
+                type="radio"
+                name="doc-visibility"
+                value="private"
+                checked={isPrivate}
+                disabled={disabled}
+                onChange={() => setIsPrivate(true)}
+              />
+              <div>
+                <div className="perms-radio-title">Private</div>
+                <div className="perms-radio-desc">
+                  Only collaborators can access this document.
+                </div>
               </div>
-            ) : null}
-          </section>
-
-          <section className="bs-card permissions-panel">
-            <div className="permissions-panel-header">
-              <div className="bs-eyebrow">Publish Rules</div>
-              <h2>Publish restrictions</h2>
-            </div>
-            <p className="permissions-description">
-              Control who is allowed to publish (merge) approved documents.
-            </p>
-            <div className="permissions-field">
-              <label className="permissions-toggle-label">
-                <input
-                  type="checkbox"
-                  className="permissions-toggle"
-                  checked={enableMergeWhitelist}
-                  disabled={!isOwner || saving}
-                  onChange={(e) => setEnableMergeWhitelist(e.target.checked)}
-                />
-                <span>Restrict publishing to specific users</span>
-              </label>
-            </div>
-
-            {enableMergeWhitelist ? (
-              <div className="permissions-field">
-                <label className="permissions-label" htmlFor="merge-whitelist">
-                  Allowed publishers (comma or space separated usernames)
-                </label>
-                <input
-                  id="merge-whitelist"
-                  className="bs-input"
-                  type="text"
-                  placeholder="alice, bob"
-                  value={mergeWhitelistInput}
-                  disabled={!isOwner || saving}
-                  onChange={(e) => setMergeWhitelistInput(e.target.value)}
-                />
+            </label>
+            <label
+              className={`perms-radio-option${!isPrivate ? " perms-radio-option--selected" : ""}`}
+            >
+              <input
+                type="radio"
+                name="doc-visibility"
+                value="public"
+                checked={!isPrivate}
+                disabled={disabled}
+                onChange={() => setIsPrivate(false)}
+              />
+              <div>
+                <div className="perms-radio-title">Public</div>
+                <div className="perms-radio-desc">
+                  Anyone can read this document and its review history.
+                </div>
               </div>
-            ) : null}
-          </section>
+            </label>
+          </div>
+        </div>
 
-          <section className="bs-card permissions-panel">
-            <div className="permissions-panel-header">
-              <div className="bs-eyebrow">Public Access</div>
-              <h2>Visibility</h2>
-            </div>
-            <p className="permissions-description">
-              Public documents can be read by anyone — including anonymous
-              visitors. Reviews and version history are visible too. Private
-              documents are only accessible to collaborators.
-            </p>
-            <div className="permissions-field">
-              <label className="permissions-toggle-label">
-                <input
-                  type="checkbox"
-                  className="permissions-toggle"
-                  checked={isPrivate}
-                  disabled={!isOwner || saving}
-                  onChange={(e) => setIsPrivate(e.target.checked)}
-                />
-                <span>Keep this document private</span>
-              </label>
-              <p className="permissions-hint">
-                {isPrivate
-                  ? "Only collaborators can access this document."
-                  : "Anyone can read this document and its review history."}
-              </p>
-            </div>
-          </section>
-
-          {isOwner ? (
-            <div className="permissions-actions">
-              {saveError ? (
-                <p className="permissions-save-error" role="alert">
+        {/* Footer */}
+        {isOwner && (
+          <div className="perms-footer">
+            <div className="perms-footer-messages">
+              {saveError && (
+                <p className="perms-save-error" role="alert">
                   {saveError}
                 </p>
-              ) : saveSuccess ? (
-                <p className="permissions-save-success" role="status">
+              )}
+              {saveSuccess && (
+                <p className="perms-save-success" role="status">
                   Permissions saved.
                 </p>
-              ) : null}
-              <button
-                className="bs-btn bs-btn-primary"
-                type="button"
-                disabled={saving}
-                onClick={() => void handleSave()}
-              >
-                {saving ? "Saving..." : "Save permissions"}
-              </button>
+              )}
             </div>
-          ) : null}
-        </>
-      ) : null}
+            <button
+              className="bs-btn bs-btn-primary"
+              type="button"
+              disabled={saving}
+              onClick={() => void handleSave()}
+            >
+              {saving ? "Saving…" : "Save permissions"}
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/app/routes.test.ts
+++ b/apps/app/routes.test.ts
@@ -29,6 +29,22 @@ test("getRoute preserves document detail routes", () => {
     repo: "quarterly-report",
     tab: "collaborators",
   });
+
+  expect(getRoute("/docs/alice/quarterly-report/permissions")).toEqual({
+    kind: "document",
+    owner: "alice",
+    repo: "quarterly-report",
+    tab: "permissions",
+  });
+});
+
+test("getRoute maps permissions path with URL-encoded owner/repo", () => {
+  expect(getRoute("/docs/alice-org/my%20doc/permissions")).toEqual({
+    kind: "document",
+    owner: "alice-org",
+    repo: "my%20doc",
+    tab: "permissions",
+  });
 });
 
 test("routeToPath keeps home and workspace on the root URL", () => {

--- a/apps/app/routes.ts
+++ b/apps/app/routes.ts
@@ -13,7 +13,7 @@ export type AppRoute =
       kind: "document";
       owner: string;
       repo: string;
-      tab: "overview" | "collaborators";
+      tab: "overview" | "collaborators" | "permissions";
     };
 
 function normalizePathname(pathname: string): string {
@@ -66,6 +66,18 @@ export function getRoute(pathname: string): AppRoute {
     return { kind: "billing" };
   }
 
+  const permissionsMatch = normalizedPath.match(
+    /^\/docs\/([^/]+)\/([^/]+)\/permissions$/,
+  );
+  if (permissionsMatch) {
+    return {
+      kind: "document",
+      owner: permissionsMatch[1]!,
+      repo: permissionsMatch[2]!,
+      tab: "permissions",
+    };
+  }
+
   const collaboratorsMatch = normalizedPath.match(
     /^\/docs\/([^/]+)\/([^/]+)\/collaborators$/,
   );
@@ -100,9 +112,11 @@ export function routeToPath(route: AppRoute): string {
     case "callback":
       return "/auth/callback";
     case "document":
-      return route.tab === "collaborators"
-        ? `/docs/${route.owner}/${route.repo}/collaborators`
-        : `/docs/${route.owner}/${route.repo}`;
+      if (route.tab === "collaborators")
+        return `/docs/${route.owner}/${route.repo}/collaborators`;
+      if (route.tab === "permissions")
+        return `/docs/${route.owner}/${route.repo}/permissions`;
+      return `/docs/${route.owner}/${route.repo}`;
     case "documents":
       return "/documents";
     case "inbox":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./data/gitea:/data
 
   gitea:
-    image: gitea/gitea:1.25
+    image: gitea/gitea:1.26
     container_name: bindersnap-gitea
     restart: unless-stopped
     depends_on:

--- a/packages/gitea-client/repos.ts
+++ b/packages/gitea-client/repos.ts
@@ -680,12 +680,15 @@ export interface GetRepoInfoParams {
 
 export async function getRepoInfo(
   params: GetRepoInfoParams,
-): Promise<{ isPrivate: boolean }> {
+): Promise<{ isPrivate: boolean; isInternal: boolean }> {
   const { client, owner, repo } = params;
   const repo_data = await unwrap(
     client.GET("/repos/{owner}/{repo}", {
       params: { path: { owner, repo } },
     }),
   );
-  return { isPrivate: repo_data.private ?? true };
+  return {
+    isPrivate: repo_data.private ?? true,
+    isInternal: repo_data.internal ?? false,
+  };
 }

--- a/packages/gitea-client/repos.ts
+++ b/packages/gitea-client/repos.ts
@@ -429,8 +429,10 @@ function normalizeBranchProtection(
     requiredApprovals: raw.required_approvals ?? 0,
     enableApprovalsWhitelist: raw.enable_approvals_whitelist ?? false,
     approvalsWhitelistUsernames: raw.approvals_whitelist_username ?? [],
+    approvalsWhitelistTeams: raw.approvals_whitelist_teams ?? [],
     enableMergeWhitelist: raw.enable_merge_whitelist ?? false,
     mergeWhitelistUsernames: raw.merge_whitelist_usernames ?? [],
+    mergeWhitelistTeams: raw.merge_whitelist_teams ?? [],
     blockOnRejectedReviews: raw.block_on_rejected_reviews ?? false,
   };
 }
@@ -553,8 +555,10 @@ export interface RepoBranchProtection {
   requiredApprovals: number;
   enableApprovalsWhitelist: boolean;
   approvalsWhitelistUsernames: string[];
+  approvalsWhitelistTeams: string[];
   enableMergeWhitelist: boolean;
   mergeWhitelistUsernames: string[];
+  mergeWhitelistTeams: string[];
   blockOnRejectedReviews: boolean;
 }
 
@@ -607,4 +611,81 @@ export async function createDocTag(
     throw new GiteaApiError(0, `Failed to parse created tag: ${tagName}`);
   }
   return docTag;
+}
+
+export interface UpdateRepoBranchProtectionParams {
+  client: GiteaClient;
+  owner: string;
+  repo: string;
+  ruleName: string;
+  requiredApprovals?: number;
+  enableApprovalsWhitelist?: boolean;
+  approvalsWhitelistUsernames?: string[];
+  enableMergeWhitelist?: boolean;
+  mergeWhitelistUsernames?: string[];
+}
+
+export async function updateRepoBranchProtection(
+  params: UpdateRepoBranchProtectionParams,
+): Promise<RepoBranchProtection> {
+  const { client, owner, repo, ruleName, ...rest } = params;
+  const body: Record<string, unknown> = {};
+  if (rest.requiredApprovals !== undefined)
+    body.required_approvals = rest.requiredApprovals;
+  if (rest.enableApprovalsWhitelist !== undefined)
+    body.enable_approvals_whitelist = rest.enableApprovalsWhitelist;
+  if (rest.approvalsWhitelistUsernames !== undefined)
+    body.approvals_whitelist_username = rest.approvalsWhitelistUsernames;
+  if (rest.enableMergeWhitelist !== undefined)
+    body.enable_merge_whitelist = rest.enableMergeWhitelist;
+  if (rest.mergeWhitelistUsernames !== undefined)
+    body.merge_whitelist_usernames = rest.mergeWhitelistUsernames;
+
+  const protection = await unwrap(
+    client.PATCH("/repos/{owner}/{repo}/branch_protections/{name}", {
+      params: { path: { owner, repo, name: ruleName } },
+      body: body as import("./spec/gitea").components["schemas"]["EditBranchProtectionOption"],
+    }),
+  );
+  return normalizeBranchProtection(protection);
+}
+
+export interface UpdateRepoVisibilityParams {
+  client: GiteaClient;
+  owner: string;
+  repo: string;
+  isPrivate: boolean;
+}
+
+export async function updateRepoVisibility(
+  params: UpdateRepoVisibilityParams,
+): Promise<void> {
+  const { client, owner, repo, isPrivate } = params;
+  const { error, response } = await client.PATCH("/repos/{owner}/{repo}", {
+    params: { path: { owner, repo } },
+    body: {
+      private: isPrivate,
+    } as import("./spec/gitea").components["schemas"]["EditRepoOption"],
+  });
+  if (error !== undefined || !response.ok) {
+    throw toGiteaApiError(response.status, error);
+  }
+}
+
+export interface GetRepoInfoParams {
+  client: GiteaClient;
+  owner: string;
+  repo: string;
+}
+
+export async function getRepoInfo(
+  params: GetRepoInfoParams,
+): Promise<{ isPrivate: boolean }> {
+  const { client, owner, repo } = params;
+  const repo_data = await unwrap(
+    client.GET("/repos/{owner}/{repo}", {
+      params: { path: { owner, repo } },
+    }),
+  );
+  return { isPrivate: repo_data.private ?? true };
 }

--- a/packages/gitea-client/spec/gitea.d.ts
+++ b/packages/gitea-client/spec/gitea.d.ts
@@ -1,4 +1,4 @@
-// Generated from Gitea 1.25.5 at 2026-04-04T15:10:18Z
+// Generated from Gitea 1.26.1 at 2026-05-02T01:12:03Z
 // Source: http://localhost:3000/swagger.v1.json
 // Note: Types have been extended via extensions.json
 // Do not edit manually — re-run: bun run generate:api
@@ -9,40 +9,6 @@
  */
 
 export interface paths {
-    "/activitypub/user-id/{user-id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Returns the Person actor for a user */
-        get: operations["activitypubPerson"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/activitypub/user-id/{user-id}/inbox": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Send to the inbox */
-        post: operations["activitypubPersonInbox"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/admin/actions/jobs": {
         parameters: {
             query?: never;
@@ -86,7 +52,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Get an global actions runner registration token */
+        /** Get a global actions runner registration token */
         post: operations["adminCreateRunnerRegistrationToken"];
         delete?: never;
         options?: never;
@@ -101,15 +67,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get an global runner */
+        /** Get a global runner */
         get: operations["getAdminRunner"];
         put?: never;
         post?: never;
-        /** Delete an global runner */
+        /** Delete a global runner */
         delete: operations["deleteAdminRunner"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update a global runner */
+        patch: operations["updateAdminRunner"];
         trace?: never;
     };
     "/admin/actions/runs": {
@@ -243,23 +210,6 @@ export interface paths {
         };
         /** List all organizations */
         get: operations["adminGetAllOrgs"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/runners/registration-token": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get an global actions runner registration token */
-        get: operations["adminGetRunnerRegistrationToken"];
         put?: never;
         post?: never;
         delete?: never;
@@ -596,23 +546,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/nodeinfo": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Returns the nodeinfo of the Gitea application */
-        get: operations["getNodeInfo"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/notifications": {
         parameters: {
             query?: never;
@@ -764,8 +697,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get an organization's actions runner registration token */
-        get: operations["orgGetRunnerRegistrationToken"];
+        get?: never;
         put?: never;
         /** Get an organization's actions runner registration token */
         post: operations["orgCreateRunnerRegistrationToken"];
@@ -790,7 +722,8 @@ export interface paths {
         delete: operations["deleteOrgRunner"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update an org-level runner */
+        patch: operations["updateOrgRunner"];
         trace?: never;
     };
     "/orgs/{org}/actions/runs": {
@@ -1196,7 +1129,8 @@ export interface paths {
         get: operations["listPackageVersions"];
         put?: never;
         post?: never;
-        delete?: never;
+        /** Delete a package */
+        delete: operations["deletePackage"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1264,8 +1198,8 @@ export interface paths {
         get: operations["getPackage"];
         put?: never;
         post?: never;
-        /** Delete a package */
-        delete: operations["deletePackage"];
+        /** Delete a package version */
+        delete: operations["deletePackageVersion"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1485,8 +1419,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get a repository's actions runner registration token */
-        get: operations["repoGetRunnerRegistrationToken"];
+        get?: never;
         put?: never;
         /** Get a repository's actions runner registration token */
         post: operations["repoCreateRunnerRegistrationToken"];
@@ -1503,15 +1436,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get an repo-level runner */
+        /** Get a repo-level runner */
         get: operations["getRepoRunner"];
         put?: never;
         post?: never;
-        /** Delete an repo-level runner */
+        /** Delete a repo-level runner */
         delete: operations["deleteRepoRunner"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update a repo-level runner */
+        patch: operations["updateRepoRunner"];
         trace?: never;
     };
     "/repos/{owner}/{repo}/actions/runs": {
@@ -1577,6 +1511,57 @@ export interface paths {
         get: operations["listWorkflowRunJobs"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repos/{owner}/{repo}/actions/runs/{run}/jobs/{job_id}/rerun": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reruns a specific workflow job in a run */
+        post: operations["rerunWorkflowJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repos/{owner}/{repo}/actions/runs/{run}/rerun": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reruns an entire workflow run */
+        post: operations["rerunWorkflowRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repos/{owner}/{repo}/actions/runs/{run}/rerun-failed-jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reruns all failed jobs in a workflow run */
+        post: operations["rerunFailedWorkflowRun"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1907,7 +1892,8 @@ export interface paths {
         };
         /** Retrieve a specific branch from a repository, including its effective branch protection */
         get: operations["repoGetBranch"];
-        put?: never;
+        /** Update a branch reference to a new commit */
+        put: operations["repoUpdateBranch"];
         post?: never;
         /** Delete a specific branch from a repository */
         delete: operations["repoDeleteBranch"];
@@ -2108,7 +2094,7 @@ export interface paths {
          * @description This API follows GitHub's design, and it is not easy to use. Recommend users to use the "contents-ext" API instead.
          */
         get: operations["repoGetContents"];
-        /** Update a file in a repository */
+        /** Update a file in a repository if SHA is set, or create the file if SHA is not set */
         put: operations["repoUpdateFile"];
         /** Create a file in a repository */
         post: operations["repoCreateFile"];
@@ -2614,7 +2600,11 @@ export interface paths {
         delete: operations["issueDelete"];
         options?: never;
         head?: never;
-        /** Edit an issue. If using deadline only the date will be taken into account, and time of day ignored. */
+        /**
+         * Edit an issue. If using deadline only the date will be taken into account, and time of day ignored.
+         * @description Pass `content_version` to enable optimistic locking on body edits.
+         *     If the version doesn't match the current value, the request fails with 409 Conflict.
+         */
         patch: operations["issueEditIssue"];
         trace?: never;
     };
@@ -3259,6 +3249,40 @@ export interface paths {
         put?: never;
         /** Create a pull request */
         post: operations["repoCreatePullRequest"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repos/{owner}/{repo}/pulls/comments/{id}/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resolve a pull request review comment */
+        post: operations["repoResolvePullReviewComment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repos/{owner}/{repo}/pulls/comments/{id}/unresolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Unresolve a pull request review comment */
+        post: operations["repoUnresolvePullReviewComment"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4436,8 +4460,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get an user's actions runner registration token */
-        get: operations["userGetRunnerRegistrationToken"];
+        get?: never;
         put?: never;
         /** Get an user's actions runner registration token */
         post: operations["userCreateRunnerRegistrationToken"];
@@ -4454,15 +4477,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get an user-level runner */
+        /** Get a user-level runner */
         get: operations["getUserRunner"];
         put?: never;
         post?: never;
-        /** Delete an user-level runner */
+        /** Delete a user-level runner */
         delete: operations["deleteUserRunner"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update a user-level runner */
+        patch: operations["updateUserRunner"];
         trace?: never;
     };
     "/user/actions/runs": {
@@ -5354,6 +5378,7 @@ export interface components {
         /** @description ActionRunner represents a Runner */
         ActionRunner: {
             busy?: boolean;
+            disabled?: boolean;
             ephemeral?: boolean;
             /** Format: int64 */
             id?: number;
@@ -5593,11 +5618,6 @@ export interface components {
              */
             user_id?: number;
         };
-        /** @description ActivityPub type */
-        ActivityPub: {
-            /** @description Context defines the JSON-LD context for ActivityPub */
-            "@context"?: string;
-        };
         /** @description AddCollaboratorOption options when adding a user as a collaborator of a repository */
         AddCollaboratorOption: {
             /** @enum {string} */
@@ -5644,14 +5664,16 @@ export interface components {
          */
         ApplyDiffPatchFileOptions: {
             author?: components["schemas"]["Identity"];
-            /** @description branch (optional) to base this file from. if not given, the default branch is used */
+            /** @description branch (optional) is the base branch for the changes. If not supplied, the default branch is used */
             branch?: string;
             committer?: components["schemas"]["Identity"];
             content: string;
             dates?: components["schemas"]["CommitDateOptions"];
-            /** @description message (optional) for the commit of this file. if not supplied, a default message will be used */
+            /** @description force_push (optional) will do a force-push if the new branch already exists */
+            force_push?: boolean;
+            /** @description message (optional) is the commit message of the changes. If not supplied, a default message will be used */
             message?: string;
-            /** @description new_branch (optional) will make a new branch from `branch` before creating the file */
+            /** @description new_branch (optional) will make a new branch from base branch for the changes. If not supplied, the changes will be committed to the base branch */
             new_branch?: string;
             /** @description Add a Signed-off-by trailer by the committer at the end of the commit log message. */
             signoff?: boolean;
@@ -5781,15 +5803,17 @@ export interface components {
          */
         ChangeFilesOptions: {
             author?: components["schemas"]["Identity"];
-            /** @description branch (optional) to base this file from. if not given, the default branch is used */
+            /** @description branch (optional) is the base branch for the changes. If not supplied, the default branch is used */
             branch?: string;
             committer?: components["schemas"]["Identity"];
             dates?: components["schemas"]["CommitDateOptions"];
             /** @description list of file operations */
             files: components["schemas"]["ChangeFileOperation"][];
-            /** @description message (optional) for the commit of this file. if not supplied, a default message will be used */
+            /** @description force_push (optional) will do a force-push if the new branch already exists */
+            force_push?: boolean;
+            /** @description message (optional) is the commit message of the changes. If not supplied, a default message will be used */
             message?: string;
-            /** @description new_branch (optional) will make a new branch from `branch` before creating the file */
+            /** @description new_branch (optional) will make a new branch from base branch for the changes. If not supplied, the changes will be committed to the base branch */
             new_branch?: string;
             /** @description Add a Signed-off-by trailer by the committer at the end of the commit log message. */
             signoff?: boolean;
@@ -6123,20 +6147,22 @@ export interface components {
             emails?: string[];
         };
         /**
-         * @description CreateFileOptions options for creating files
+         * @description CreateFileOptions options for creating a file
          *     Note: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)
          */
         CreateFileOptions: {
             author?: components["schemas"]["Identity"];
-            /** @description branch (optional) to base this file from. if not given, the default branch is used */
+            /** @description branch (optional) is the base branch for the changes. If not supplied, the default branch is used */
             branch?: string;
             committer?: components["schemas"]["Identity"];
             /** @description content must be base64 encoded */
             content: string;
             dates?: components["schemas"]["CommitDateOptions"];
-            /** @description message (optional) for the commit of this file. if not supplied, a default message will be used */
+            /** @description force_push (optional) will do a force-push if the new branch already exists */
+            force_push?: boolean;
+            /** @description message (optional) is the commit message of the changes. If not supplied, a default message will be used */
             message?: string;
-            /** @description new_branch (optional) will make a new branch from `branch` before creating the file */
+            /** @description new_branch (optional) will make a new branch from base branch for the changes. If not supplied, the changes will be committed to the base branch */
             new_branch?: string;
             /** @description Add a Signed-off-by trailer by the committer at the end of the commit log message. */
             signoff?: boolean;
@@ -6166,6 +6192,8 @@ export interface components {
             config: components["schemas"]["CreateHookOptionConfig"];
             /** @description List of events that will trigger this webhook */
             events?: string[];
+            /** @description Optional human-readable name for the webhook */
+            name?: string;
             /** @enum {string} */
             type: "dingtalk" | "discord" | "gitea" | "gogs" | "msteams" | "slack" | "telegram" | "feishu" | "wechatwork" | "packagist";
         };
@@ -6273,6 +6301,8 @@ export interface components {
         };
         /** @description CreatePullRequestOption options when creating a pull request */
         CreatePullRequestOption: {
+            /** @description Whether maintainers can edit the pull request */
+            allow_maintainer_edit?: boolean;
             /** @description The primary assignee username */
             assignee?: string;
             /** @description The list of assignee usernames */
@@ -6318,12 +6348,13 @@ export interface components {
             /** @description the tree path */
             path?: string;
         };
-        /** @description CreatePullReviewOptions are options to create a pull review */
+        /** @description CreatePullReviewOptions are options to create a pull request review */
         CreatePullReviewOptions: {
             body?: string;
             comments?: components["schemas"]["CreatePullReviewComment"][];
             commit_id?: string;
-            event?: components["schemas"]["ReviewStateType"];
+            /** @enum {string} */
+            event?: "APPROVED" | "PENDING" | "COMMENT" | "REQUEST_CHANGES" | "REQUEST_REVIEW";
         };
         /** CreatePushMirrorOption represents need information to create a push mirror of a repository. */
         CreatePushMirrorOption: {
@@ -6535,20 +6566,22 @@ export interface components {
             emails?: string[];
         };
         /**
-         * @description DeleteFileOptions options for deleting files (used for other File structs below)
+         * @description DeleteFileOptions options for deleting a file
          *     Note: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)
          */
         DeleteFileOptions: {
             author?: components["schemas"]["Identity"];
-            /** @description branch (optional) to base this file from. if not given, the default branch is used */
+            /** @description branch (optional) is the base branch for the changes. If not supplied, the default branch is used */
             branch?: string;
             committer?: components["schemas"]["Identity"];
             dates?: components["schemas"]["CommitDateOptions"];
-            /** @description message (optional) for the commit of this file. if not supplied, a default message will be used */
+            /** @description force_push (optional) will do a force-push if the new branch already exists */
+            force_push?: boolean;
+            /** @description message (optional) is the commit message of the changes. If not supplied, a default message will be used */
             message?: string;
-            /** @description new_branch (optional) will make a new branch from `branch` before creating the file */
+            /** @description new_branch (optional) will make a new branch from base branch for the changes. If not supplied, the changes will be committed to the base branch */
             new_branch?: string;
-            /** @description the blob ID (SHA) for the file that already exists, it is required for changing existing files */
+            /** @description the blob ID (SHA) for the file to delete */
             sha: string;
             /** @description Add a Signed-off-by trailer by the committer at the end of the commit log message. */
             signoff?: boolean;
@@ -6579,10 +6612,14 @@ export interface components {
             /** @description URL is the API URL for this deploy key */
             url?: string;
         };
-        /** @description DismissPullReviewOptions are options to dismiss a pull review */
+        /** @description DismissPullReviewOptions are options to dismiss a pull request review */
         DismissPullReviewOptions: {
             message?: string;
             priors?: boolean;
+        };
+        /** EditActionRunnerOption represents the editable fields for a runner. */
+        EditActionRunnerOption: {
+            disabled: boolean;
         };
         /** @description EditAttachmentOptions options for editing attachments */
         EditAttachmentOptions: {
@@ -6647,6 +6684,8 @@ export interface components {
             };
             /** @description List of events that trigger this webhook */
             events?: string[];
+            /** @description Optional human-readable name */
+            name?: string;
         };
         /** @description EditIssueCommentOption options for editing a comment */
         EditIssueCommentOption: {
@@ -6658,6 +6697,11 @@ export interface components {
             assignee?: string;
             assignees?: string[];
             body?: string;
+            /**
+             * Format: int64
+             * @description The current version of the issue content to detect conflicts during editing
+             */
+            content_version?: number;
             /** Format: date-time */
             due_date?: string;
             /** Format: int64 */
@@ -6689,8 +6733,11 @@ export interface components {
              * @description Deadline is the updated due date for the milestone
              */
             due_on?: string;
-            /** @description State indicates the updated state of the milestone */
-            state?: string;
+            /**
+             * @description State indicates the updated state of the milestone
+             * @enum {string}
+             */
+            state?: "open" | "closed";
             /** @description Title is the updated title of the milestone */
             title?: string;
         };
@@ -6698,7 +6745,7 @@ export interface components {
         EditOrgOption: {
             /** @description The description of the organization */
             description?: string;
-            /** @description The email address of the organization */
+            /** @description The email address of the organization; use empty string to clear */
             email?: string;
             /** @description The full display name of the organization */
             full_name?: string;
@@ -6726,6 +6773,11 @@ export interface components {
             base?: string;
             /** @description The new description body for the pull request */
             body?: string;
+            /**
+             * Format: int64
+             * @description The current version of the pull request content to detect conflicts during editing
+             */
+            content_version?: number;
             /** Format: date-time */
             due_date?: string;
             /** @description The new list of label IDs for the pull request */
@@ -7252,6 +7304,8 @@ export interface components {
              * @description The unique identifier of the webhook
              */
             id?: number;
+            /** @description Optional human-readable name for the webhook */
+            name?: string;
             /** @description The type of the webhook (e.g., gitea, slack, discord) */
             type?: string;
             /** Format: date-time */
@@ -7283,6 +7337,11 @@ export interface components {
             closed_at?: string;
             /** Format: int64 */
             comments?: number;
+            /**
+             * Format: int64
+             * @description The version of the issue content for optimistic locking
+             */
+            content_version?: number;
             /** Format: date-time */
             created_at?: string;
             /** Format: date-time */
@@ -7303,7 +7362,8 @@ export interface components {
             pull_request?: components["schemas"]["PullRequestMeta"];
             ref?: string;
             repository?: components["schemas"]["RepositoryMeta"];
-            state?: components["schemas"]["StateType"];
+            /** @enum {string} */
+            state?: "open" | "closed";
             /** Format: int64 */
             time_estimate?: number;
             title?: string;
@@ -7336,16 +7396,13 @@ export interface components {
                 [key: string]: unknown;
             };
             id?: string;
-            type?: components["schemas"]["IssueFormFieldType"];
+            /** @enum {string} */
+            type?: "markdown" | "textarea" | "input" | "dropdown" | "checkboxes";
             validations?: {
                 [key: string]: unknown;
             };
-            visible?: components["schemas"]["IssueFormFieldVisible"][];
+            visible?: ("form" | "content")[];
         };
-        /** IssueFormFieldType defines issue form field type, can be "markdown", "textarea", "input", "dropdown" or "checkboxes" */
-        IssueFormFieldType: string;
-        /** @description IssueFormFieldVisible defines issue form field visible */
-        IssueFormFieldVisible: string;
         /** @description IssueLabelsOption a collection of labels */
         IssueLabelsOption: {
             /**
@@ -7498,14 +7555,14 @@ export interface components {
         };
         /** @description MergePullRequestForm form for merging Pull Request */
         MergePullRequestOption: {
-            /** @enum {string} */
-            Do: "merge" | "rebase" | "rebase-merge" | "squash" | "fast-forward-only" | "manually-merged";
-            MergeCommitID?: string;
-            MergeMessageField?: string;
-            MergeTitleField?: string;
             delete_branch_after_merge?: boolean;
+            /** @enum {string} */
+            do: "merge" | "rebase" | "rebase-merge" | "squash" | "fast-forward-only" | "manually-merged";
             force_merge?: boolean;
             head_commit_id?: string;
+            merge_commit_id?: string;
+            merge_message_field?: string;
+            merge_title_field?: string;
             merge_when_checks_succeed?: boolean;
         };
         MergeUpstreamRequest: {
@@ -7574,7 +7631,13 @@ export interface components {
              * @description OpenIssues is the number of open issues in this milestone
              */
             open_issues?: number;
-            state?: components["schemas"]["StateType"];
+            /**
+             * @description State indicates if the milestone is open or closed
+             *     open StateOpen  StateOpen pr is opened
+             *     closed StateClosed  StateClosed pr is closed
+             * @enum {string}
+             */
+            state?: "open" | "closed";
             /** @description Title is the title of the milestone */
             title?: string;
             /** Format: date-time */
@@ -7671,10 +7734,25 @@ export interface components {
             latest_comment_html_url?: string;
             /** @description LatestCommentURL is the API URL for the latest comment */
             latest_comment_url?: string;
-            state?: components["schemas"]["StateType"];
+            /**
+             * @description State indicates the current state of the notification subject
+             *     open NotifySubjectStateOpen  NotifySubjectStateOpen is an open subject
+             *     closed NotifySubjectStateClosed  NotifySubjectStateClosed is a closed subject
+             *     merged NotifySubjectStateMerged  NotifySubjectStateMerged is a merged pull request
+             * @enum {string}
+             */
+            state?: "open" | "closed" | "merged";
             /** @description Title is the title of the notification subject */
             title?: string;
-            type?: components["schemas"]["NotifySubjectType"];
+            /**
+             * @description Type indicates the type of the notification subject
+             *     Issue NotifySubjectIssue  NotifySubjectIssue an issue is subject of an notification
+             *     Pull NotifySubjectPull  NotifySubjectPull an pull is subject of an notification
+             *     Commit NotifySubjectCommit  NotifySubjectCommit an commit is subject of an notification
+             *     Repository NotifySubjectRepository  NotifySubjectRepository an repository is subject of an notification
+             * @enum {string}
+             */
+            type?: "Issue" | "Pull" | "Commit" | "Repository";
             /** @description URL is the API URL for the notification subject */
             url?: string;
         };
@@ -7699,8 +7777,6 @@ export interface components {
             /** @description URL is the API URL for this notification thread */
             url?: string;
         };
-        /** @description NotifySubjectType represent type of notification subject */
-        NotifySubjectType: string;
         /** OAuth2Application represents an OAuth2 application. */
         OAuth2Application: {
             /** @description The client ID of the OAuth2 application */
@@ -7931,6 +8007,11 @@ export interface components {
              * @description The number of comments on the pull request
              */
             comments?: number;
+            /**
+             * Format: int64
+             * @description The version of the pull request content for optimistic locking
+             */
+            content_version?: number;
             /** Format: date-time */
             created_at?: string;
             /**
@@ -7989,7 +8070,13 @@ export interface components {
              * @description number of review comments made on the diff of a PR review (not including comments on commits or issues in a PR)
              */
             review_comments?: number;
-            state?: components["schemas"]["StateType"];
+            /**
+             * @description The current state of the pull request
+             *     open StateOpen  StateOpen pr is opened
+             *     closed StateClosed  StateClosed pr is closed
+             * @enum {string}
+             */
+            state?: "open" | "closed";
             /** @description The title of the pull request */
             title?: string;
             /** Format: date-time */
@@ -8021,7 +8108,8 @@ export interface components {
             /** @description HTMLPullURL is the web URL for the pull request */
             pull_request_url?: string;
             stale?: boolean;
-            state?: components["schemas"]["ReviewStateType"];
+            /** @enum {string} */
+            state?: "APPROVED" | "PENDING" | "COMMENT" | "REQUEST_CHANGES" | "REQUEST_REVIEW";
             /** Format: date-time */
             submitted_at?: string;
             team?: components["schemas"]["Team"];
@@ -8053,7 +8141,7 @@ export interface components {
             updated_at?: string;
             user?: components["schemas"]["User"];
         };
-        /** @description PullReviewRequestOptions are options to add or remove pull review requests */
+        /** @description PullReviewRequestOptions are options to add or remove pull request review requests */
         PullReviewRequestOptions: {
             reviewers?: string[];
             team_reviewers?: string[];
@@ -8189,6 +8277,8 @@ export interface components {
             archived_at?: string;
             autodetect_manual_merge?: boolean;
             avatar_url?: string;
+            /** Format: int64 */
+            branch_count?: number;
             clone_url?: string;
             /** Format: date-time */
             created_at?: string;
@@ -8196,6 +8286,7 @@ export interface components {
             default_branch?: string;
             default_delete_branch_after_merge?: boolean;
             default_merge_style?: string;
+            default_target_branch?: string;
             description?: string;
             empty?: boolean;
             external_tracker?: components["schemas"]["ExternalTracker"];
@@ -8267,11 +8358,13 @@ export interface components {
             name?: string;
             owner?: string;
         };
-        /**
-         * @description ReviewStateType review state type
-         * @enum {string}
-         */
-        ReviewStateType: "APPROVE" | "APPROVED" | "REQUEST_CHANGES" | "CHANGES_REQUESTED" | "COMMENT" | "PENDING";
+        /** @description RunDetails returns workflow_dispatch runid and url */
+        RunDetails: {
+            html_url?: string;
+            run_url?: string;
+            /** Format: int64 */
+            workflow_run_id?: number;
+        };
         /** @description SearchResults results of a successful search */
         SearchResults: {
             /** @description Data contains the repository search results */
@@ -8293,8 +8386,6 @@ export interface components {
             /** @description Version is the server version string */
             version?: string;
         };
-        /** @description StateType issue state type */
-        StateType: string;
         /** @description StopWatch represent a running stopwatch */
         StopWatch: {
             /** Format: date-time */
@@ -8318,10 +8409,11 @@ export interface components {
              */
             seconds?: number;
         };
-        /** @description SubmitPullReviewOptions are options to submit a pending pull review */
+        /** @description SubmitPullReviewOptions are options to submit a pending pull request review */
         SubmitPullReviewOptions: {
             body?: string;
-            event?: components["schemas"]["ReviewStateType"];
+            /** @enum {string} */
+            event?: "APPROVED" | "PENDING" | "COMMENT" | "REQUEST_CHANGES" | "REQUEST_REVIEW";
         };
         /** @description Tag represents a repository tag */
         Tag: {
@@ -8523,26 +8615,37 @@ export interface components {
         UpdateBranchProtectionPriories: {
             ids?: number[];
         };
+        /** @description UpdateBranchRepoOption options when updating a branch reference in a repository */
+        UpdateBranchRepoOption: {
+            /** @description Force update even if the change is not a fast-forward */
+            force?: boolean;
+            /** @description New commit SHA (or any ref) the branch should point to */
+            new_commit_id: string;
+            /** @description Expected old commit SHA of the branch; if provided it must match the current tip */
+            old_commit_id?: string;
+        };
         /**
-         * @description UpdateFileOptions options for updating files
+         * @description UpdateFileOptions options for updating or creating a file
          *     Note: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)
          */
         UpdateFileOptions: {
             author?: components["schemas"]["Identity"];
-            /** @description branch (optional) to base this file from. if not given, the default branch is used */
+            /** @description branch (optional) is the base branch for the changes. If not supplied, the default branch is used */
             branch?: string;
             committer?: components["schemas"]["Identity"];
             /** @description content must be base64 encoded */
             content: string;
             dates?: components["schemas"]["CommitDateOptions"];
+            /** @description force_push (optional) will do a force-push if the new branch already exists */
+            force_push?: boolean;
             /** @description from_path (optional) is the path of the original file which will be moved/renamed to the path in the URL */
             from_path?: string;
-            /** @description message (optional) for the commit of this file. if not supplied, a default message will be used */
+            /** @description message (optional) is the commit message of the changes. If not supplied, a default message will be used */
             message?: string;
-            /** @description new_branch (optional) will make a new branch from `branch` before creating the file */
+            /** @description new_branch (optional) will make a new branch from base branch for the changes. If not supplied, the changes will be committed to the base branch */
             new_branch?: string;
-            /** @description the blob ID (SHA) for the file that already exists, it is required for changing existing files */
-            sha: string;
+            /** @description the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file */
+            sha?: string;
             /** @description Add a Signed-off-by trailer by the committer at the end of the commit log message. */
             signoff?: boolean;
         };
@@ -8734,6 +8837,8 @@ export interface components {
             /** @description The title of the wiki page */
             title?: string;
         };
+        /** @enum {unknown} */
+        ReviewStateType: "APPROVE" | "APPROVED" | "REQUEST_CHANGES" | "CHANGES_REQUESTED" | "COMMENT" | "PENDING";
     };
     responses: {
         /** @description AccessToken represents an API access token. */
@@ -8743,7 +8848,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["AccessToken"];
-                "text/html": components["schemas"]["AccessToken"];
             };
         };
         /** @description AccessTokenList represents a list of API access token. */
@@ -8753,7 +8857,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["AccessToken"][];
-                "text/html": components["schemas"]["AccessToken"][];
             };
         };
         /** @description ActionVariable */
@@ -8763,7 +8866,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionVariable"];
-                "text/html": components["schemas"]["ActionVariable"];
             };
         };
         /** @description ActionWorkflow */
@@ -8773,7 +8875,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionWorkflow"];
-                "text/html": components["schemas"]["ActionWorkflow"];
             };
         };
         /** @description ActionWorkflowList */
@@ -8783,7 +8884,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionWorkflowResponse"];
-                "text/html": components["schemas"]["ActionWorkflowResponse"];
             };
         };
         /** @description ActivityFeedsList */
@@ -8793,17 +8893,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Activity"][];
-                "text/html": components["schemas"]["Activity"][];
-            };
-        };
-        /** @description ActivityPub */
-        ActivityPub: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["ActivityPub"];
-                "text/html": components["schemas"]["ActivityPub"];
             };
         };
         /** @description AnnotatedTag */
@@ -8813,7 +8902,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["AnnotatedTag"];
-                "text/html": components["schemas"]["AnnotatedTag"];
             };
         };
         /** @description Artifact */
@@ -8823,7 +8911,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionArtifact"];
-                "text/html": components["schemas"]["ActionArtifact"];
             };
         };
         /** @description ArtifactsList */
@@ -8833,7 +8920,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionArtifactsResponse"];
-                "text/html": components["schemas"]["ActionArtifactsResponse"];
             };
         };
         /** @description Attachment */
@@ -8843,7 +8929,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Attachment"];
-                "text/html": components["schemas"]["Attachment"];
             };
         };
         /** @description AttachmentList */
@@ -8853,7 +8938,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Attachment"][];
-                "text/html": components["schemas"]["Attachment"][];
             };
         };
         /** @description BadgeList */
@@ -8863,7 +8947,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Badge"][];
-                "text/html": components["schemas"]["Badge"][];
             };
         };
         /** @description Branch */
@@ -8873,7 +8956,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Branch"];
-                "text/html": components["schemas"]["Branch"];
             };
         };
         /** @description BranchList */
@@ -8883,7 +8965,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Branch"][];
-                "text/html": components["schemas"]["Branch"][];
             };
         };
         /** @description BranchProtection */
@@ -8893,7 +8974,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["BranchProtection"];
-                "text/html": components["schemas"]["BranchProtection"];
             };
         };
         /** @description BranchProtectionList */
@@ -8903,7 +8983,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["BranchProtection"][];
-                "text/html": components["schemas"]["BranchProtection"][];
             };
         };
         /** @description ChangedFileList */
@@ -8923,7 +9002,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ChangedFile"][];
-                "text/html": components["schemas"]["ChangedFile"][];
             };
         };
         /** @description CombinedStatus */
@@ -8933,7 +9011,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["CombinedStatus"];
-                "text/html": components["schemas"]["CombinedStatus"];
             };
         };
         /** @description Comment */
@@ -8943,7 +9020,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Comment"];
-                "text/html": components["schemas"]["Comment"];
             };
         };
         /** @description CommentList */
@@ -8953,7 +9029,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Comment"][];
-                "text/html": components["schemas"]["Comment"][];
             };
         };
         /** @description Commit */
@@ -8963,7 +9038,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Commit"];
-                "text/html": components["schemas"]["Commit"];
             };
         };
         /** @description CommitList */
@@ -8983,7 +9057,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Commit"][];
-                "text/html": components["schemas"]["Commit"][];
             };
         };
         /** @description CommitStatus */
@@ -8993,7 +9066,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["CommitStatus"];
-                "text/html": components["schemas"]["CommitStatus"];
             };
         };
         /** @description CommitStatusList */
@@ -9003,7 +9075,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["CommitStatus"][];
-                "text/html": components["schemas"]["CommitStatus"][];
             };
         };
         Compare: {
@@ -9012,7 +9083,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Compare"];
-                "text/html": components["schemas"]["Compare"];
             };
         };
         ContentsExtResponse: {
@@ -9021,7 +9091,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ContentsExtResponse"];
-                "text/html": components["schemas"]["ContentsExtResponse"];
             };
         };
         /** @description ContentsListResponse */
@@ -9031,7 +9100,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ContentsResponse"][];
-                "text/html": components["schemas"]["ContentsResponse"][];
             };
         };
         /** @description ContentsResponse */
@@ -9041,7 +9109,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ContentsResponse"];
-                "text/html": components["schemas"]["ContentsResponse"];
             };
         };
         /** @description CronList */
@@ -9051,7 +9118,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Cron"][];
-                "text/html": components["schemas"]["Cron"][];
             };
         };
         /** @description DeployKey */
@@ -9061,7 +9127,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["DeployKey"];
-                "text/html": components["schemas"]["DeployKey"];
             };
         };
         /** @description DeployKeyList */
@@ -9071,7 +9136,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["DeployKey"][];
-                "text/html": components["schemas"]["DeployKey"][];
             };
         };
         /** @description EmailList */
@@ -9081,7 +9145,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Email"][];
-                "text/html": components["schemas"]["Email"][];
             };
         };
         /** @description EmptyRepository */
@@ -9091,7 +9154,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["APIError"];
-                "text/html": components["schemas"]["APIError"];
             };
         };
         /** @description FileDeleteResponse */
@@ -9101,7 +9163,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["FileDeleteResponse"];
-                "text/html": components["schemas"]["FileDeleteResponse"];
             };
         };
         /** @description FileResponse */
@@ -9111,7 +9172,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["FileResponse"];
-                "text/html": components["schemas"]["FileResponse"];
             };
         };
         /** @description FilesResponse */
@@ -9121,7 +9181,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["FilesResponse"];
-                "text/html": components["schemas"]["FilesResponse"];
             };
         };
         /** @description GPGKey */
@@ -9131,7 +9190,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GPGKey"];
-                "text/html": components["schemas"]["GPGKey"];
             };
         };
         /** @description GPGKeyList */
@@ -9141,7 +9199,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GPGKey"][];
-                "text/html": components["schemas"]["GPGKey"][];
             };
         };
         /** @description GeneralAPISettings */
@@ -9151,7 +9208,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GeneralAPISettings"];
-                "text/html": components["schemas"]["GeneralAPISettings"];
             };
         };
         /** @description GeneralAttachmentSettings */
@@ -9161,7 +9217,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GeneralAttachmentSettings"];
-                "text/html": components["schemas"]["GeneralAttachmentSettings"];
             };
         };
         /** @description GeneralRepoSettings */
@@ -9171,7 +9226,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GeneralRepoSettings"];
-                "text/html": components["schemas"]["GeneralRepoSettings"];
             };
         };
         /** @description GeneralUISettings */
@@ -9181,7 +9235,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GeneralUISettings"];
-                "text/html": components["schemas"]["GeneralUISettings"];
             };
         };
         /** @description GitBlobResponse */
@@ -9191,7 +9244,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GitBlobResponse"];
-                "text/html": components["schemas"]["GitBlobResponse"];
             };
         };
         /** @description GitHook */
@@ -9201,7 +9253,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GitHook"];
-                "text/html": components["schemas"]["GitHook"];
             };
         };
         /** @description GitHookList */
@@ -9211,7 +9262,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GitHook"][];
-                "text/html": components["schemas"]["GitHook"][];
             };
         };
         /** @description GitTreeResponse */
@@ -9221,7 +9271,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GitTreeResponse"];
-                "text/html": components["schemas"]["GitTreeResponse"];
             };
         };
         /** @description GitignoreTemplateInfo */
@@ -9231,7 +9280,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["GitignoreTemplateInfo"];
-                "text/html": components["schemas"]["GitignoreTemplateInfo"];
             };
         };
         /** @description GitignoreTemplateList */
@@ -9241,7 +9289,6 @@ export interface components {
             };
             content: {
                 "application/json": string[];
-                "text/html": string[];
             };
         };
         /** @description Hook */
@@ -9251,7 +9298,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Hook"];
-                "text/html": components["schemas"]["Hook"];
             };
         };
         /** @description HookList */
@@ -9261,7 +9307,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Hook"][];
-                "text/html": components["schemas"]["Hook"][];
             };
         };
         /** @description Issue */
@@ -9271,7 +9316,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Issue"];
-                "text/html": components["schemas"]["Issue"];
             };
         };
         /** @description IssueDeadline */
@@ -9281,7 +9325,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["IssueDeadline"];
-                "text/html": components["schemas"]["IssueDeadline"];
             };
         };
         /** @description IssueList */
@@ -9291,7 +9334,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Issue"][];
-                "text/html": components["schemas"]["Issue"][];
             };
         };
         /** @description IssueTemplates */
@@ -9301,7 +9343,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["IssueTemplate"][];
-                "text/html": components["schemas"]["IssueTemplate"][];
             };
         };
         /** @description Label */
@@ -9311,7 +9352,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Label"];
-                "text/html": components["schemas"]["Label"];
             };
         };
         /** @description LabelList */
@@ -9321,7 +9361,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Label"][];
-                "text/html": components["schemas"]["Label"][];
             };
         };
         /** @description LabelTemplateInfo */
@@ -9331,7 +9370,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["LabelTemplate"][];
-                "text/html": components["schemas"]["LabelTemplate"][];
             };
         };
         /** @description LabelTemplateList */
@@ -9341,7 +9379,6 @@ export interface components {
             };
             content: {
                 "application/json": string[];
-                "text/html": string[];
             };
         };
         /** @description LanguageStatistics */
@@ -9353,9 +9390,6 @@ export interface components {
                 "application/json": {
                     [key: string]: number;
                 };
-                "text/html": {
-                    [key: string]: number;
-                };
             };
         };
         /** @description LicenseTemplateInfo */
@@ -9365,7 +9399,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["LicenseTemplateInfo"];
-                "text/html": components["schemas"]["LicenseTemplateInfo"];
             };
         };
         /** @description LicenseTemplateList */
@@ -9375,7 +9408,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["LicensesTemplateListEntry"][];
-                "text/html": components["schemas"]["LicensesTemplateListEntry"][];
             };
         };
         /** @description LicensesList */
@@ -9385,7 +9417,6 @@ export interface components {
             };
             content: {
                 "application/json": string[];
-                "text/html": string[];
             };
         };
         /** @description MarkdownRender is a rendered markdown document */
@@ -9395,7 +9426,6 @@ export interface components {
             };
             content: {
                 "application/json": string;
-                "text/html": string;
             };
         };
         /** @description MarkupRender is a rendered markup document */
@@ -9405,7 +9435,6 @@ export interface components {
             };
             content: {
                 "application/json": string;
-                "text/html": string;
             };
         };
         MergeUpstreamRequest: {
@@ -9414,7 +9443,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["MergeUpstreamRequest"];
-                "text/html": components["schemas"]["MergeUpstreamRequest"];
             };
         };
         MergeUpstreamResponse: {
@@ -9423,7 +9451,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["MergeUpstreamResponse"];
-                "text/html": components["schemas"]["MergeUpstreamResponse"];
             };
         };
         /** @description Milestone */
@@ -9433,7 +9460,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Milestone"];
-                "text/html": components["schemas"]["Milestone"];
             };
         };
         /** @description MilestoneList */
@@ -9443,7 +9469,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Milestone"][];
-                "text/html": components["schemas"]["Milestone"][];
             };
         };
         /** @description NodeInfo */
@@ -9453,7 +9478,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["NodeInfo"];
-                "text/html": components["schemas"]["NodeInfo"];
             };
         };
         /** @description Note */
@@ -9463,7 +9487,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Note"];
-                "text/html": components["schemas"]["Note"];
             };
         };
         /** @description Number of unread notifications */
@@ -9473,7 +9496,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["NotificationCount"];
-                "text/html": components["schemas"]["NotificationCount"];
             };
         };
         /** @description NotificationThread */
@@ -9483,7 +9505,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["NotificationThread"];
-                "text/html": components["schemas"]["NotificationThread"];
             };
         };
         /** @description NotificationThreadList */
@@ -9493,7 +9514,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["NotificationThread"][];
-                "text/html": components["schemas"]["NotificationThread"][];
             };
         };
         /** @description OAuth2Application */
@@ -9503,7 +9523,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["OAuth2Application"];
-                "text/html": components["schemas"]["OAuth2Application"];
             };
         };
         /** @description OAuth2ApplicationList represents a list of OAuth2 applications. */
@@ -9513,7 +9532,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["OAuth2Application"][];
-                "text/html": components["schemas"]["OAuth2Application"][];
             };
         };
         /** @description Organization */
@@ -9523,7 +9541,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Organization"];
-                "text/html": components["schemas"]["Organization"];
             };
         };
         /** @description OrganizationList */
@@ -9533,7 +9550,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Organization"][];
-                "text/html": components["schemas"]["Organization"][];
             };
         };
         /** @description OrganizationPermissions */
@@ -9543,7 +9559,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["OrganizationPermissions"];
-                "text/html": components["schemas"]["OrganizationPermissions"];
             };
         };
         /** @description Package */
@@ -9553,7 +9568,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Package"];
-                "text/html": components["schemas"]["Package"];
             };
         };
         /** @description PackageFileList */
@@ -9563,7 +9577,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PackageFile"][];
-                "text/html": components["schemas"]["PackageFile"][];
             };
         };
         /** @description PackageList */
@@ -9573,7 +9586,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Package"][];
-                "text/html": components["schemas"]["Package"][];
             };
         };
         /** @description PublicKey */
@@ -9583,7 +9595,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PublicKey"];
-                "text/html": components["schemas"]["PublicKey"];
             };
         };
         /** @description PublicKeyList */
@@ -9593,7 +9604,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PublicKey"][];
-                "text/html": components["schemas"]["PublicKey"][];
             };
         };
         /** @description PullRequest */
@@ -9603,7 +9613,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PullRequest"];
-                "text/html": components["schemas"]["PullRequest"];
             };
         };
         /** @description PullRequestList */
@@ -9613,7 +9622,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PullRequest"][];
-                "text/html": components["schemas"]["PullRequest"][];
             };
         };
         /** @description PullReview */
@@ -9623,7 +9631,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PullReview"];
-                "text/html": components["schemas"]["PullReview"];
             };
         };
         /** @description PullComment */
@@ -9633,7 +9640,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PullReviewComment"];
-                "text/html": components["schemas"]["PullReviewComment"];
             };
         };
         /** @description PullCommentList */
@@ -9643,7 +9649,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PullReviewComment"][];
-                "text/html": components["schemas"]["PullReviewComment"][];
             };
         };
         /** @description PullReviewList */
@@ -9653,7 +9658,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PullReview"][];
-                "text/html": components["schemas"]["PullReview"][];
             };
         };
         /** @description PushMirror */
@@ -9663,7 +9667,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PushMirror"];
-                "text/html": components["schemas"]["PushMirror"];
             };
         };
         /** @description PushMirrorList */
@@ -9673,7 +9676,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["PushMirror"][];
-                "text/html": components["schemas"]["PushMirror"][];
             };
         };
         /** @description Reaction */
@@ -9683,7 +9685,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Reaction"];
-                "text/html": components["schemas"]["Reaction"];
             };
         };
         /** @description ReactionList */
@@ -9693,7 +9694,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Reaction"][];
-                "text/html": components["schemas"]["Reaction"][];
             };
         };
         /** @description Reference */
@@ -9703,7 +9703,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Reference"];
-                "text/html": components["schemas"]["Reference"];
             };
         };
         /** @description ReferenceList */
@@ -9713,7 +9712,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Reference"][];
-                "text/html": components["schemas"]["Reference"][];
             };
         };
         /** @description RegistrationToken is response related to registration token */
@@ -9731,7 +9729,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Release"];
-                "text/html": components["schemas"]["Release"];
             };
         };
         /** @description ReleaseList */
@@ -9741,7 +9738,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Release"][];
-                "text/html": components["schemas"]["Release"][];
             };
         };
         /** @description RepoCollaboratorPermission */
@@ -9751,7 +9747,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["RepoCollaboratorPermission"];
-                "text/html": components["schemas"]["RepoCollaboratorPermission"];
             };
         };
         /** @description RepoIssueConfig */
@@ -9761,7 +9756,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["IssueConfig"];
-                "text/html": components["schemas"]["IssueConfig"];
             };
         };
         /** @description RepoIssueConfigValidation */
@@ -9771,7 +9765,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["IssueConfigValidation"];
-                "text/html": components["schemas"]["IssueConfigValidation"];
             };
         };
         /** @description RepoNewIssuePinsAllowed */
@@ -9781,7 +9774,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["NewIssuePinsAllowed"];
-                "text/html": components["schemas"]["NewIssuePinsAllowed"];
             };
         };
         /** @description Repository */
@@ -9791,7 +9783,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Repository"];
-                "text/html": components["schemas"]["Repository"];
             };
         };
         /** @description RepositoryList */
@@ -9801,7 +9792,15 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Repository"][];
-                "text/html": components["schemas"]["Repository"][];
+            };
+        };
+        /** @description RunDetails */
+        RunDetails: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["RunDetails"];
             };
         };
         /** @description Runner */
@@ -9811,7 +9810,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionRunner"];
-                "text/html": components["schemas"]["ActionRunner"];
             };
         };
         /** @description RunnerList */
@@ -9821,7 +9819,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionRunnersResponse"];
-                "text/html": components["schemas"]["ActionRunnersResponse"];
             };
         };
         /** @description SearchResults */
@@ -9831,7 +9828,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["SearchResults"];
-                "text/html": components["schemas"]["SearchResults"];
             };
         };
         /** @description Secret */
@@ -9841,7 +9837,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Secret"];
-                "text/html": components["schemas"]["Secret"];
             };
         };
         /** @description SecretList */
@@ -9851,7 +9846,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Secret"][];
-                "text/html": components["schemas"]["Secret"][];
             };
         };
         /** @description ServerVersion */
@@ -9861,7 +9855,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ServerVersion"];
-                "text/html": components["schemas"]["ServerVersion"];
             };
         };
         /** @description StopWatch */
@@ -9871,7 +9864,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["StopWatch"];
-                "text/html": components["schemas"]["StopWatch"];
             };
         };
         /** @description StopWatchList */
@@ -9881,7 +9873,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["StopWatch"][];
-                "text/html": components["schemas"]["StopWatch"][];
             };
         };
         /** @description StringSlice */
@@ -9891,7 +9882,6 @@ export interface components {
             };
             content: {
                 "application/json": string[];
-                "text/html": string[];
             };
         };
         /** @description Tag */
@@ -9901,7 +9891,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Tag"];
-                "text/html": components["schemas"]["Tag"];
             };
         };
         /** @description TagList */
@@ -9911,7 +9900,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Tag"][];
-                "text/html": components["schemas"]["Tag"][];
             };
         };
         /** @description TagProtection */
@@ -9921,7 +9909,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["TagProtection"];
-                "text/html": components["schemas"]["TagProtection"];
             };
         };
         /** @description TagProtectionList */
@@ -9931,7 +9918,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["TagProtection"][];
-                "text/html": components["schemas"]["TagProtection"][];
             };
         };
         /** @description TasksList */
@@ -9941,7 +9927,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionTaskResponse"];
-                "text/html": components["schemas"]["ActionTaskResponse"];
             };
         };
         /** @description Team */
@@ -9951,7 +9936,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Team"];
-                "text/html": components["schemas"]["Team"];
             };
         };
         /** @description TeamList */
@@ -9961,7 +9945,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Team"][];
-                "text/html": components["schemas"]["Team"][];
             };
         };
         /** @description TimelineList */
@@ -9971,7 +9954,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["TimelineComment"][];
-                "text/html": components["schemas"]["TimelineComment"][];
             };
         };
         /** @description TopicListResponse */
@@ -9981,7 +9963,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["TopicResponse"][];
-                "text/html": components["schemas"]["TopicResponse"][];
             };
         };
         /** @description TopicNames */
@@ -9991,7 +9972,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["TopicName"];
-                "text/html": components["schemas"]["TopicName"];
             };
         };
         /** @description TrackedTime */
@@ -10001,7 +9981,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["TrackedTime"];
-                "text/html": components["schemas"]["TrackedTime"];
             };
         };
         /** @description TrackedTimeList */
@@ -10011,7 +9990,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["TrackedTime"][];
-                "text/html": components["schemas"]["TrackedTime"][];
             };
         };
         /** @description User */
@@ -10021,7 +9999,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["User"];
-                "text/html": components["schemas"]["User"];
             };
         };
         /** @description UserHeatmapData */
@@ -10031,7 +10008,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["UserHeatmapData"][];
-                "text/html": components["schemas"]["UserHeatmapData"][];
             };
         };
         /** @description UserList */
@@ -10041,7 +10017,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["User"][];
-                "text/html": components["schemas"]["User"][];
             };
         };
         /** @description UserSettings */
@@ -10051,7 +10026,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["UserSettings"][];
-                "text/html": components["schemas"]["UserSettings"][];
             };
         };
         /** @description VariableList */
@@ -10061,7 +10035,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionVariable"][];
-                "text/html": components["schemas"]["ActionVariable"][];
             };
         };
         /** @description WatchInfo */
@@ -10071,7 +10044,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["WatchInfo"];
-                "text/html": components["schemas"]["WatchInfo"];
             };
         };
         /** @description WikiCommitList */
@@ -10081,7 +10053,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["WikiCommitList"];
-                "text/html": components["schemas"]["WikiCommitList"];
             };
         };
         /** @description WikiPage */
@@ -10091,7 +10062,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["WikiPage"];
-                "text/html": components["schemas"]["WikiPage"];
             };
         };
         /** @description WikiPageList */
@@ -10101,7 +10071,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["WikiPageMetaData"][];
-                "text/html": components["schemas"]["WikiPageMetaData"][];
             };
         };
         /** @description WorkflowJob */
@@ -10111,7 +10080,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionWorkflowJob"];
-                "text/html": components["schemas"]["ActionWorkflowJob"];
             };
         };
         /** @description WorkflowJobsList */
@@ -10121,7 +10089,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionWorkflowJobsResponse"];
-                "text/html": components["schemas"]["ActionWorkflowJobsResponse"];
             };
         };
         /** @description WorkflowRun */
@@ -10131,7 +10098,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionWorkflowRun"];
-                "text/html": components["schemas"]["ActionWorkflowRun"];
             };
         };
         /** @description WorkflowRunsList */
@@ -10141,7 +10107,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["ActionWorkflowRunsResponse"];
-                "text/html": components["schemas"]["ActionWorkflowRunsResponse"];
             };
         };
         /** @description APIConflict is a conflict empty response */
@@ -10199,7 +10164,6 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["LockIssueOption"];
-                "text/html": components["schemas"]["LockIssueOption"];
             };
         };
         /** @description APIRedirect is a redirect response */
@@ -10225,7 +10189,6 @@ export interface components {
             };
             content: {
                 "application/json": string;
-                "text/html": string;
             };
         };
         /** @description APIValidationError is error format response related to input validation */
@@ -10240,12 +10203,6 @@ export interface components {
     };
     parameters: never;
     requestBodies: {
-        CreateOAuth2ApplicationOptions: {
-            content: {
-                "application/json": components["schemas"]["CreateOAuth2ApplicationOptions"];
-                "text/plain": components["schemas"]["CreateOAuth2ApplicationOptions"];
-            };
-        };
         CreateWikiPageOptions: {
             content: {
                 "application/json": components["schemas"]["CreateWikiPageOptions"];
@@ -10261,6 +10218,21 @@ export interface components {
                 "application/json": components["schemas"]["CreateKeyOption"];
             };
         };
+        CreateOAuth2ApplicationOptions: {
+            content: {
+                "application/json": components["schemas"]["CreateOAuth2ApplicationOptions"];
+            };
+        };
+        UpdateUserAvatarOption: {
+            content: {
+                "application/json": components["schemas"]["UpdateUserAvatarOption"];
+            };
+        };
+        PullReviewRequestOptions: {
+            content: {
+                "application/json": components["schemas"]["PullReviewRequestOptions"];
+            };
+        };
         CreateOrgOption: {
             content: {
                 "application/json": components["schemas"]["CreateOrgOption"];
@@ -10271,12 +10243,6 @@ export interface components {
                 "application/json": components["schemas"]["IssueLabelsOption"];
             };
         };
-        UpdateUserAvatarOption: {
-            content: {
-                "application/json": components["schemas"]["UpdateUserAvatarOption"];
-                "text/plain": components["schemas"]["UpdateUserAvatarOption"];
-            };
-        };
         CreateHookOption: {
             content: {
                 "application/json": components["schemas"]["CreateHookOption"];
@@ -10285,6 +10251,16 @@ export interface components {
         EditReactionOption: {
             content: {
                 "application/json": components["schemas"]["EditReactionOption"];
+            };
+        };
+        UserBadgeOption: {
+            content: {
+                "application/json": components["schemas"]["UserBadgeOption"];
+            };
+        };
+        EditActionRunnerOption: {
+            content: {
+                "application/json": components["schemas"]["EditActionRunnerOption"];
             };
         };
         EditHookOption: {
@@ -10341,13 +10317,6 @@ export interface components {
         IssueMeta: {
             content: {
                 "application/json": components["schemas"]["IssueMeta"];
-                "text/plain": components["schemas"]["IssueMeta"];
-            };
-        };
-        PullReviewRequestOptions: {
-            content: {
-                "application/json": components["schemas"]["PullReviewRequestOptions"];
-                "text/plain": components["schemas"]["PullReviewRequestOptions"];
             };
         };
     };
@@ -10356,36 +10325,6 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    activitypubPerson: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description user ID of the user */
-                "user-id": number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: components["responses"]["ActivityPub"];
-        };
-    };
-    activitypubPersonInbox: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description user ID of the user */
-                "user-id": number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            204: components["responses"]["empty"];
-        };
-    };
     listAdminWorkflowJobs: {
         parameters: {
             query?: {
@@ -10409,14 +10348,17 @@ export interface operations {
     };
     getAdminRunners: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description filter by disabled status (true or false) */
+                disabled?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            200: components["schemas"]["ActionRunnersResponse"];
+            200: components["responses"]["RunnerList"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
         };
@@ -10445,7 +10387,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            200: components["schemas"]["ActionRunner"];
+            200: components["responses"]["Runner"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
         };
@@ -10471,6 +10413,24 @@ export interface operations {
             };
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
+        };
+    };
+    updateAdminRunner: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description id of the runner */
+                runner_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["EditActionRunnerOption"];
+        responses: {
+            200: components["responses"]["Runner"];
+            400: components["responses"]["error"];
+            404: components["responses"]["notFound"];
+            422: components["responses"]["validationError"];
         };
     };
     listAdminWorkflowRuns: {
@@ -10668,18 +10628,6 @@ export interface operations {
             403: components["responses"]["forbidden"];
         };
     };
-    adminGetRunnerRegistrationToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: components["responses"]["RegistrationToken"];
-        };
-    };
     adminUnadoptedList: {
         parameters: {
             query?: {
@@ -10748,6 +10696,24 @@ export interface operations {
                 page?: number;
                 /** @description page size of results */
                 limit?: number;
+                /** @description sort users by attribute. Supported values are "name", "created", "updated" and "id". Default is "name" */
+                sort?: string;
+                /** @description sort order, either "asc" (ascending) or "desc" (descending). Default is "asc", ignored if "sort" is not specified. */
+                order?: string;
+                /** @description search term (username, full name, email) */
+                q?: string;
+                /** @description visibility filter. Supported values are "public", "limited" and "private". */
+                visibility?: string;
+                /** @description filter active users */
+                is_active?: boolean;
+                /** @description filter admin users */
+                is_admin?: boolean;
+                /** @description filter restricted users */
+                is_restricted?: boolean;
+                /** @description filter 2FA enabled users */
+                is_2fa_enabled?: boolean;
+                /** @description filter login prohibited users */
+                is_prohibit_login?: boolean;
             };
             header?: never;
             path?: never;
@@ -10757,6 +10723,7 @@ export interface operations {
         responses: {
             200: components["responses"]["UserList"];
             403: components["responses"]["forbidden"];
+            422: components["responses"]["validationError"];
         };
     };
     adminCreateUser: {
@@ -10847,11 +10814,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["UserBadgeOption"];
-            };
-        };
+        requestBody?: components["requestBodies"]["UserBadgeOption"];
         responses: {
             204: components["responses"]["empty"];
             403: components["responses"]["forbidden"];
@@ -10867,12 +10830,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["UserBadgeOption"];
-                "text/plain": components["schemas"]["UserBadgeOption"];
-            };
-        };
+        requestBody?: components["requestBodies"]["UserBadgeOption"];
         responses: {
             204: components["responses"]["empty"];
             403: components["responses"]["forbidden"];
@@ -10945,7 +10903,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["RenameUserOption"];
-                "text/plain": components["schemas"]["RenameUserOption"];
             };
         };
         responses: {
@@ -11112,18 +11069,6 @@ export interface operations {
         responses: {
             200: components["responses"]["MarkupRender"];
             422: components["responses"]["validationError"];
-        };
-    };
-    getNodeInfo: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: components["responses"]["NodeInfo"];
         };
     };
     notifyGetList: {
@@ -11350,7 +11295,10 @@ export interface operations {
     };
     getOrgRunners: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description filter by disabled status (true or false) */
+                disabled?: boolean;
+            };
             header?: never;
             path: {
                 /** @description name of the organization */
@@ -11360,24 +11308,9 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            200: components["schemas"]["ActionRunnersResponse"];
+            200: components["responses"]["RunnerList"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
-        };
-    };
-    orgGetRunnerRegistrationToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description name of the organization */
-                org: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: components["responses"]["RegistrationToken"];
         };
     };
     orgCreateRunnerRegistrationToken: {
@@ -11409,7 +11342,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            200: components["schemas"]["ActionRunner"];
+            200: components["responses"]["Runner"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
         };
@@ -11437,6 +11370,26 @@ export interface operations {
             };
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
+        };
+    };
+    updateOrgRunner: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description name of the organization */
+                org: string;
+                /** @description id of the runner */
+                runner_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["EditActionRunnerOption"];
+        responses: {
+            200: components["responses"]["Runner"];
+            400: components["responses"]["error"];
+            404: components["responses"]["notFound"];
+            422: components["responses"]["validationError"];
         };
     };
     getOrgWorkflowRuns: {
@@ -12195,7 +12148,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["RenameOrgOption"];
-                "text/plain": components["schemas"]["RenameOrgOption"];
             };
         };
         responses: {
@@ -12329,7 +12281,7 @@ export interface operations {
                 /** @description page size of results */
                 limit?: number;
                 /** @description package type filter */
-                type?: "alpine" | "cargo" | "chef" | "composer" | "conan" | "conda" | "container" | "cran" | "debian" | "generic" | "go" | "helm" | "maven" | "npm" | "nuget" | "pub" | "pypi" | "rpm" | "rubygems" | "swift" | "vagrant";
+                type?: "alpine" | "cargo" | "chef" | "composer" | "conan" | "conda" | "container" | "cran" | "debian" | "generic" | "go" | "helm" | "maven" | "npm" | "nuget" | "pub" | "pypi" | "rpm" | "rubygems" | "swift" | "terraform" | "vagrant";
                 /** @description name filter */
                 q?: string;
             };
@@ -12368,6 +12320,26 @@ export interface operations {
         requestBody?: never;
         responses: {
             200: components["responses"]["PackageList"];
+            404: components["responses"]["notFound"];
+        };
+    };
+    deletePackage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description owner of the package */
+                owner: string;
+                /** @description type of the package */
+                type: string;
+                /** @description name of the package */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: components["responses"]["empty"];
             404: components["responses"]["notFound"];
         };
     };
@@ -12455,7 +12427,7 @@ export interface operations {
             404: components["responses"]["notFound"];
         };
     };
-    deletePackage: {
+    deletePackageVersion: {
         parameters: {
             query?: never;
             header?: never;
@@ -12510,8 +12482,6 @@ export interface operations {
                 milestones?: string;
                 /** @description Search string */
                 q?: string;
-                /** @description Repository ID to prioritize in the results */
-                priority_repo_id?: number;
                 /** @description Filter by issue type */
                 type?: "issues" | "pulls";
                 /** @description Only show issues updated after the given time (RFC 3339 format) */
@@ -12530,6 +12500,8 @@ export interface operations {
                 reviewed?: boolean;
                 /** @description Filter by repository owner */
                 owner?: string;
+                /** @description Only show items which were created by the given user */
+                created_by?: string;
                 /** @description Filter by team (requires organization owner parameter) */
                 team?: string;
                 /** @description Page number of results to return (1-based) */
@@ -12674,7 +12646,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["EditRepoOption"];
-                "text/plain": components["schemas"]["EditRepoOption"];
             };
         };
         responses: {
@@ -12857,7 +12828,10 @@ export interface operations {
     };
     getRepoRunners: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description filter by disabled status (true or false) */
+                disabled?: boolean;
+            };
             header?: never;
             path: {
                 /** @description owner of the repo */
@@ -12869,26 +12843,9 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            200: components["schemas"]["ActionRunnersResponse"];
+            200: components["responses"]["RunnerList"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
-        };
-    };
-    repoGetRunnerRegistrationToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description owner of the repo */
-                owner: string;
-                /** @description name of the repo */
-                repo: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: components["responses"]["RegistrationToken"];
         };
     };
     repoCreateRunnerRegistrationToken: {
@@ -12924,7 +12881,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            200: components["schemas"]["ActionRunner"];
+            200: components["responses"]["Runner"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
         };
@@ -12954,6 +12911,28 @@ export interface operations {
             };
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
+        };
+    };
+    updateRepoRunner: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description owner of the repo */
+                owner: string;
+                /** @description name of the repo */
+                repo: string;
+                /** @description id of the runner */
+                runner_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["EditActionRunnerOption"];
+        responses: {
+            200: components["responses"]["Runner"];
+            400: components["responses"]["error"];
+            404: components["responses"]["notFound"];
+            422: components["responses"]["validationError"];
         };
     };
     getWorkflowRuns: {
@@ -13000,7 +12979,7 @@ export interface operations {
                 /** @description name of the repository */
                 repo: string;
                 /** @description id of the run */
-                run: string;
+                run: number;
             };
             cookie?: never;
         };
@@ -13088,6 +13067,77 @@ export interface operations {
             200: components["responses"]["WorkflowJobsList"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
+        };
+    };
+    rerunWorkflowJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description owner of the repo */
+                owner: string;
+                /** @description name of the repository */
+                repo: string;
+                /** @description id of the run */
+                run: number;
+                /** @description id of the job */
+                job_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            201: components["responses"]["WorkflowJob"];
+            400: components["responses"]["error"];
+            403: components["responses"]["forbidden"];
+            404: components["responses"]["notFound"];
+            422: components["responses"]["validationError"];
+        };
+    };
+    rerunWorkflowRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description owner of the repo */
+                owner: string;
+                /** @description name of the repository */
+                repo: string;
+                /** @description id of the run */
+                run: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            201: components["responses"]["WorkflowRun"];
+            400: components["responses"]["error"];
+            403: components["responses"]["forbidden"];
+            404: components["responses"]["notFound"];
+            422: components["responses"]["validationError"];
+        };
+    };
+    rerunFailedWorkflowRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description owner of the repo */
+                owner: string;
+                /** @description name of the repository */
+                repo: string;
+                /** @description id of the run */
+                run: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            201: components["responses"]["empty"];
+            400: components["responses"]["error"];
+            403: components["responses"]["forbidden"];
+            404: components["responses"]["notFound"];
+            422: components["responses"]["validationError"];
         };
     };
     repoListActionsSecrets: {
@@ -13260,12 +13310,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["UpdateVariableOption"];
-                "text/plain": components["schemas"]["UpdateVariableOption"];
-            };
-        };
+        requestBody?: components["requestBodies"]["UpdateVariableOption"];
         responses: {
             /** @description response when updating a repo-level variable */
             201: {
@@ -13299,12 +13344,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["CreateVariableOption"];
-                "text/plain": components["schemas"]["CreateVariableOption"];
-            };
-        };
+        requestBody?: components["requestBodies"]["CreateVariableOption"];
         responses: {
             /** @description response when creating a repo-level variable */
             201: {
@@ -13436,7 +13476,10 @@ export interface operations {
     };
     ActionsDispatchWorkflow: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Whether the response should include the workflow run ID and URLs. */
+                return_run_details?: boolean;
+            };
             header?: never;
             path: {
                 /** @description owner of the repo */
@@ -13451,11 +13494,11 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["CreateActionWorkflowDispatch"];
-                "text/plain": components["schemas"]["CreateActionWorkflowDispatch"];
             };
         };
         responses: {
-            /** @description No Content */
+            200: components["responses"]["RunDetails"];
+            /** @description No Content, if return_run_details is missing or false */
             204: {
                 headers: {
                     [name: string]: unknown;
@@ -13525,7 +13568,10 @@ export interface operations {
     };
     repoGetArchive: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description subpath of the repository to download */
+                path?: string[];
+            };
             header?: never;
             path: {
                 /** @description owner of the repo */
@@ -13582,7 +13628,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["UpdateRepoAvatarOption"];
-                "text/plain": components["schemas"]["UpdateRepoAvatarOption"];
             };
         };
         responses: {
@@ -13825,6 +13870,33 @@ export interface operations {
             404: components["responses"]["notFound"];
         };
     };
+    repoUpdateBranch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description owner of the repo */
+                owner: string;
+                /** @description name of the repo */
+                repo: string;
+                /** @description name of the branch */
+                branch: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UpdateBranchRepoOption"];
+            };
+        };
+        responses: {
+            204: components["responses"]["empty"];
+            403: components["responses"]["forbidden"];
+            404: components["responses"]["notFound"];
+            409: components["responses"]["conflict"];
+            422: components["responses"]["validationError"];
+        };
+    };
     repoDeleteBranch: {
         parameters: {
             query?: never;
@@ -13934,7 +14006,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["AddCollaboratorOption"];
-                "text/plain": components["schemas"]["AddCollaboratorOption"];
             };
         };
         responses: {
@@ -14237,6 +14308,7 @@ export interface operations {
         };
         responses: {
             200: components["responses"]["FileResponse"];
+            201: components["responses"]["FileResponse"];
             403: components["responses"]["error"];
             404: components["responses"]["notFound"];
             422: components["responses"]["error"];
@@ -14391,7 +14463,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["GetFilesOptions"];
-                "text/plain": components["schemas"]["GetFilesOptions"];
             };
         };
         responses: {
@@ -14437,7 +14508,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["CreateForkOption"];
-                "text/plain": components["schemas"]["CreateForkOption"];
             };
         };
         responses: {
@@ -14758,7 +14828,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["EditGitHookOption"];
-                "text/plain": components["schemas"]["EditGitHookOption"];
             };
         };
         responses: {
@@ -14820,12 +14889,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["EditHookOption"];
-                "text/plain": components["schemas"]["EditHookOption"];
-            };
-        };
+        requestBody?: components["requestBodies"]["EditHookOption"];
         responses: {
             200: components["responses"]["Hook"];
             404: components["responses"]["notFound"];
@@ -14913,7 +14977,7 @@ export interface operations {
             query?: {
                 /** @description whether issue is open or closed */
                 state?: "closed" | "open" | "all";
-                /** @description comma separated list of labels. Fetch only issues that have any of this labels. Non existent labels are discarded */
+                /** @description comma separated list of label names. Fetch only issues that have any of this label names. Non existent labels are discarded. */
                 labels?: string;
                 /** @description search string */
                 q?: string;
@@ -15246,7 +15310,7 @@ export interface operations {
         };
         requestBody?: components["requestBodies"]["EditReactionOption"];
         responses: {
-            200: components["responses"]["empty"];
+            204: components["responses"]["empty"];
             403: components["responses"]["forbidden"];
             404: components["responses"]["notFound"];
         };
@@ -16001,7 +16065,7 @@ export interface operations {
         };
         requestBody?: components["requestBodies"]["EditReactionOption"];
         responses: {
-            200: components["responses"]["empty"];
+            204: components["responses"]["empty"];
             403: components["responses"]["forbidden"];
             404: components["responses"]["notFound"];
         };
@@ -16641,7 +16705,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["MergeUpstreamRequest"];
-                "text/plain": components["schemas"]["MergeUpstreamRequest"];
             };
         };
         responses: {
@@ -16920,6 +16983,50 @@ export interface operations {
             423: components["responses"]["repoArchivedError"];
         };
     };
+    repoResolvePullReviewComment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description owner of the repo */
+                owner: string;
+                /** @description name of the repo */
+                repo: string;
+                /** @description id of the review comment */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: components["responses"]["empty"];
+            400: components["responses"]["validationError"];
+            403: components["responses"]["forbidden"];
+            404: components["responses"]["notFound"];
+        };
+    };
+    repoUnresolvePullReviewComment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description owner of the repo */
+                owner: string;
+                /** @description name of the repo */
+                repo: string;
+                /** @description id of the review comment */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: components["responses"]["empty"];
+            400: components["responses"]["validationError"];
+            403: components["responses"]["forbidden"];
+            404: components["responses"]["notFound"];
+        };
+    };
     repoListPinnedPullRequests: {
         parameters: {
             query?: never;
@@ -17140,11 +17247,11 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["MergePullRequestOption"];
-                "text/plain": components["schemas"]["MergePullRequestOption"];
             };
         };
         responses: {
             200: components["responses"]["empty"];
+            403: components["responses"]["forbidden"];
             404: components["responses"]["notFound"];
             405: components["responses"]["empty"];
             409: components["responses"]["error"];
@@ -17258,7 +17365,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["CreatePullReviewOptions"];
-                "text/plain": components["schemas"]["CreatePullReviewOptions"];
             };
         };
         responses: {
@@ -17308,7 +17414,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["SubmitPullReviewOptions"];
-                "text/plain": components["schemas"]["SubmitPullReviewOptions"];
             };
         };
         responses: {
@@ -17381,7 +17486,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["DismissPullReviewOptions"];
-                "text/plain": components["schemas"]["DismissPullReviewOptions"];
             };
         };
         responses: {
@@ -17587,7 +17691,7 @@ export interface operations {
     repoListReleases: {
         parameters: {
             query?: {
-                /** @description filter (exclude / include) drafts, if you dont have repo write access none will show */
+                /** @description filter (exclude / include) drafts, if you don't have repo write access none will show */
                 draft?: boolean;
                 /** @description filter (exclude / include) pre-releases */
                 "pre-release"?: boolean;
@@ -18020,7 +18124,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["CreateStatusOption"];
-                "text/plain": components["schemas"]["CreateStatusOption"];
             };
         };
         responses: {
@@ -18259,7 +18362,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["CreateTagOption"];
-                "text/plain": components["schemas"]["CreateTagOption"];
             };
         };
         responses: {
@@ -18489,7 +18591,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["RepoTopicOptions"];
-                "text/plain": components["schemas"]["RepoTopicOptions"];
             };
         };
         responses: {
@@ -18556,7 +18657,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["TransferRepoOption"];
-                "text/plain": components["schemas"]["TransferRepoOption"];
             };
         };
         responses: {
@@ -19167,28 +19267,19 @@ export interface operations {
     };
     getUserRunners: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description filter by disabled status (true or false) */
+                disabled?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            200: components["schemas"]["ActionRunnersResponse"];
+            200: components["responses"]["RunnerList"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
-        };
-    };
-    userGetRunnerRegistrationToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: components["responses"]["RegistrationToken"];
         };
     };
     userCreateRunnerRegistrationToken: {
@@ -19215,7 +19306,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            200: components["schemas"]["ActionRunner"];
+            200: components["responses"]["Runner"];
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
         };
@@ -19241,6 +19332,24 @@ export interface operations {
             };
             400: components["responses"]["error"];
             404: components["responses"]["notFound"];
+        };
+    };
+    updateUserRunner: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description id of the runner */
+                runner_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["EditActionRunnerOption"];
+        responses: {
+            200: components["responses"]["Runner"];
+            400: components["responses"]["error"];
+            404: components["responses"]["notFound"];
+            422: components["responses"]["validationError"];
         };
     };
     getUserWorkflowRuns: {
@@ -19644,7 +19753,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["CreateEmailOption"];
-                "text/plain": components["schemas"]["CreateEmailOption"];
             };
         };
         responses: {
@@ -19662,7 +19770,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["DeleteEmailOption"];
-                "text/plain": components["schemas"]["DeleteEmailOption"];
             };
         };
         responses: {
@@ -20065,7 +20172,6 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": components["schemas"]["UserSettingsOptions"];
-                "text/plain": components["schemas"]["UserSettingsOptions"];
             };
         };
         responses: {

--- a/services/api/document-permissions.test.ts
+++ b/services/api/document-permissions.test.ts
@@ -15,7 +15,7 @@ import {
 // ── Mock Gitea state ─────────────────────────────────────────────────────────
 
 type MockedGiteaUser = { login: string; email: string };
-type MockedRepo = { private: boolean };
+type MockedRepo = { private: boolean; internal: boolean };
 type MockedBranchProtection = {
   rule_name: string;
   required_approvals: number;
@@ -190,6 +190,7 @@ beforeEach(() => {
           name: repoMatch[2],
           full_name: key,
           private: repo.private,
+          internal: repo.internal,
           permissions: { admin: true, push: true, pull: true },
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -324,9 +325,12 @@ function seedSession(username: string): string {
 function seedRepo(
   owner: string,
   repo: string,
-  options?: { isPrivate?: boolean },
+  options?: { isPrivate?: boolean; isInternal?: boolean },
 ): void {
-  reposByKey.set(repoKey(owner, repo), { private: options?.isPrivate ?? true });
+  reposByKey.set(repoKey(owner, repo), {
+    private: options?.isPrivate ?? true,
+    internal: options?.isInternal ?? false,
+  });
 }
 
 function seedBranchProtection(
@@ -514,6 +518,60 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as { isPrivate: boolean };
       expect(body.isPrivate).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns isInternal: false for a normal private repo", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "private-doc";
+    const sessionId = seedSession(owner);
+
+    seedRepo(owner, repo, { isPrivate: true, isInternal: false });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+        ),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        isPrivate: boolean;
+        isInternal: boolean;
+      };
+      expect(body.isPrivate).toBe(true);
+      expect(body.isInternal).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns isInternal: true for an internal repo", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "internal-doc";
+    const sessionId = seedSession(owner);
+
+    seedRepo(owner, repo, { isPrivate: false, isInternal: true });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+        ),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        isPrivate: boolean;
+        isInternal: boolean;
+      };
+      expect(body.isPrivate).toBe(false);
+      expect(body.isInternal).toBe(true);
     } finally {
       server.stop(true);
     }

--- a/services/api/document-permissions.test.ts
+++ b/services/api/document-permissions.test.ts
@@ -74,13 +74,9 @@ beforeEach(() => {
           : input.url;
     const url = new URL(requestUrl);
     const headers =
-      input instanceof Request
-        ? input.headers
-        : new Headers(init?.headers);
+      input instanceof Request ? input.headers : new Headers(init?.headers);
     const method =
-      input instanceof Request
-        ? input.method
-        : (init?.method ?? "GET");
+      input instanceof Request ? input.method : (init?.method ?? "GET");
     const rawBody =
       input instanceof Request
         ? await input.clone().text()
@@ -104,7 +100,12 @@ beforeEach(() => {
         });
       }
       return new Response(
-        JSON.stringify({ login: user.login, email: user.email, full_name: "", is_admin: false }),
+        JSON.stringify({
+          login: user.login,
+          email: user.email,
+          full_name: "",
+          is_admin: false,
+        }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     }
@@ -137,7 +138,9 @@ beforeEach(() => {
           headers: { "Content-Type": "application/json" },
         });
       }
-      const patch = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {};
+      const patch = bodyText
+        ? (JSON.parse(bodyText) as Record<string, unknown>)
+        : {};
       const updated: MockedBranchProtection = {
         ...existing,
         ...(typeof patch.required_approvals === "number" && {
@@ -147,16 +150,20 @@ beforeEach(() => {
           enable_approvals_whitelist: patch.enable_approvals_whitelist,
         }),
         ...(Array.isArray(patch.approvals_whitelist_username) && {
-          approvals_whitelist_username: patch.approvals_whitelist_username as string[],
+          approvals_whitelist_username:
+            patch.approvals_whitelist_username as string[],
         }),
         ...(typeof patch.enable_merge_whitelist === "boolean" && {
           enable_merge_whitelist: patch.enable_merge_whitelist,
         }),
         ...(Array.isArray(patch.merge_whitelist_usernames) && {
-          merge_whitelist_usernames: patch.merge_whitelist_usernames as string[],
+          merge_whitelist_usernames:
+            patch.merge_whitelist_usernames as string[],
         }),
       };
-      const newRules = rules.map((r) => (r.rule_name === ruleName ? updated : r));
+      const newRules = rules.map((r) =>
+        r.rule_name === ruleName ? updated : r,
+      );
       branchProtectionsByRepoKey.set(key, newRules);
       return new Response(JSON.stringify(updated), {
         status: 200,
@@ -165,7 +172,9 @@ beforeEach(() => {
     }
 
     // Gitea: GET /api/v1/repos/{owner}/{repo}
-    const repoMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)$/);
+    const repoMatch = url.pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)$/,
+    );
     if (repoMatch && method === "GET") {
       const key = repoKey(repoMatch[1]!, repoMatch[2]!);
       const repo = reposByKey.get(key);
@@ -197,16 +206,25 @@ beforeEach(() => {
           headers: { "Content-Type": "application/json" },
         });
       }
-      const patch = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {};
+      const patch = bodyText
+        ? (JSON.parse(bodyText) as Record<string, unknown>)
+        : {};
       if (typeof patch.private === "boolean") repo.private = patch.private;
       return new Response(
-        JSON.stringify({ id: 1, name: repoMatch[2], full_name: key, private: repo.private }),
+        JSON.stringify({
+          id: 1,
+          name: repoMatch[2],
+          full_name: key,
+          private: repo.private,
+        }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     }
 
     // Gitea: GET /api/v1/repos/{owner}/{repo}/tags — return empty tags
-    const tagsMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/tags$/);
+    const tagsMatch = url.pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/tags$/,
+    );
     if (tagsMatch && method === "GET") {
       return new Response(JSON.stringify([]), {
         status: 200,
@@ -215,7 +233,9 @@ beforeEach(() => {
     }
 
     // Gitea: GET /api/v1/repos/{owner}/{repo}/pulls — return empty pulls
-    const pullsMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/pulls$/);
+    const pullsMatch = url.pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/pulls$/,
+    );
     if (pullsMatch && method === "GET") {
       return new Response(JSON.stringify([]), {
         status: 200,
@@ -224,7 +244,9 @@ beforeEach(() => {
     }
 
     // Gitea: GET /api/v1/repos/{owner}/{repo}/contents/* — return empty
-    const contentsMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/contents\//);
+    const contentsMatch = url.pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/contents\//,
+    );
     if (contentsMatch && method === "GET") {
       return new Response(JSON.stringify({ message: "Not found" }), {
         status: 404,
@@ -233,7 +255,9 @@ beforeEach(() => {
     }
 
     // Gitea: GET /api/v1/repos/{owner}/{repo}/branches — return empty branches
-    const branchesMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/branches$/);
+    const branchesMatch = url.pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/branches$/,
+    );
     if (branchesMatch && method === "GET") {
       return new Response(JSON.stringify([]), {
         status: 200,
@@ -242,7 +266,9 @@ beforeEach(() => {
     }
 
     // Gitea: GET /api/v1/repos/{owner}/{repo}/collaborators/{user} — return 404 (no collaborators setup)
-    const collabMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/collaborators\/([^/]+)$/);
+    const collabMatch = url.pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/collaborators\/([^/]+)$/,
+    );
     if (collabMatch && method === "GET") {
       return new Response(JSON.stringify({ message: "Not found" }), {
         status: 404,
@@ -269,7 +295,10 @@ afterEach(() => {
 function seedSession(username: string): string {
   const sessionId = `sess_${randomUUID()}`;
   const giteaToken = `gitea_${randomUUID()}`;
-  giteaUsersByLogin.set(username, { login: username, email: `${username}@test.local` });
+  giteaUsersByLogin.set(username, {
+    login: username,
+    email: `${username}@test.local`,
+  });
   giteaLoginsByToken.set(giteaToken, username);
   sessionStore.put({
     id: sessionId,
@@ -347,9 +376,12 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     try {
       const response = await server.fetch(
-        new Request("http://localhost/api/app/documents/alice/my-doc/permissions", {
-          headers: { Origin: config.appOrigin },
-        }),
+        new Request(
+          "http://localhost/api/app/documents/alice/my-doc/permissions",
+          {
+            headers: { Origin: config.appOrigin },
+          },
+        ),
       );
       expect(response.status).toBe(401);
     } finally {
@@ -362,7 +394,10 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
     const sessionId = `sess_${randomUUID()}`;
     const giteaToken = `gitea_${randomUUID()}`;
     const username = `no-sub-${randomUUID()}`;
-    giteaUsersByLogin.set(username, { login: username, email: `${username}@test.local` });
+    giteaUsersByLogin.set(username, {
+      login: username,
+      email: `${username}@test.local`,
+    });
     giteaLoginsByToken.set(giteaToken, username);
     sessionStore.put({
       id: sessionId,
@@ -376,7 +411,10 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${username}/my-doc/permissions`, sessionId),
+        makeRequest(
+          `/api/app/documents/${username}/my-doc/permissions`,
+          sessionId,
+        ),
       );
       expect(response.status).toBe(402);
     } finally {
@@ -400,7 +438,10 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+        ),
       );
       expect(response.status).toBe(200);
 
@@ -417,7 +458,9 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
       expect(body.branchProtection).not.toBeNull();
       expect(body.branchProtection?.requiredApprovals).toBe(2);
       expect(body.branchProtection?.enableApprovalsWhitelist).toBe(true);
-      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual(["reviewer1"]);
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual([
+        "reviewer1",
+      ]);
       expect(body.isPrivate).toBe(true);
     } finally {
       server.stop(true);
@@ -435,11 +478,17 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+        ),
       );
       expect(response.status).toBe(200);
 
-      const body = (await response.json()) as { branchProtection: null; isPrivate: boolean };
+      const body = (await response.json()) as {
+        branchProtection: null;
+        isPrivate: boolean;
+      };
       expect(body.branchProtection).toBeNull();
       expect(body.isPrivate).toBe(false);
     } finally {
@@ -457,7 +506,10 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as { isPrivate: boolean };
@@ -482,10 +534,14 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, collabSessionId, {
-          method: "PUT",
-          body: { requiredApprovals: 3 },
-        }),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          collabSessionId,
+          {
+            method: "PUT",
+            body: { requiredApprovals: 3 },
+          },
+        ),
       );
       expect(response.status).toBe(403);
       const body = (await response.json()) as { error: string };
@@ -501,14 +557,21 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const repo = "my-doc";
     const sessionId = seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
-    seedBranchProtection(owner, repo, { rule_name: "main", required_approvals: 1 });
+    seedBranchProtection(owner, repo, {
+      rule_name: "main",
+      required_approvals: 1,
+    });
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: { requiredApprovals: 3 },
-        }),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: { requiredApprovals: 3 },
+          },
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -530,13 +593,17 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: {
-            enableApprovalsWhitelist: true,
-            approvalsWhitelistUsernames: ["alice", "bob"],
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: {
+              enableApprovalsWhitelist: true,
+              approvalsWhitelistUsernames: ["alice", "bob"],
+            },
           },
-        }),
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -546,7 +613,10 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
         } | null;
       };
       expect(body.branchProtection?.enableApprovalsWhitelist).toBe(true);
-      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual(["alice", "bob"]);
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual([
+        "alice",
+        "bob",
+      ]);
     } finally {
       server.stop(true);
     }
@@ -562,13 +632,17 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: {
-            enableMergeWhitelist: true,
-            mergeWhitelistUsernames: ["publisher1"],
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: {
+              enableMergeWhitelist: true,
+              mergeWhitelistUsernames: ["publisher1"],
+            },
           },
-        }),
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -578,7 +652,9 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
         } | null;
       };
       expect(body.branchProtection?.enableMergeWhitelist).toBe(true);
-      expect(body.branchProtection?.mergeWhitelistUsernames).toEqual(["publisher1"]);
+      expect(body.branchProtection?.mergeWhitelistUsernames).toEqual([
+        "publisher1",
+      ]);
     } finally {
       server.stop(true);
     }
@@ -594,10 +670,14 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: { isPrivate: false },
-        }),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: { isPrivate: false },
+          },
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as { isPrivate: boolean };
@@ -617,10 +697,14 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: { isPrivate: true },
-        }),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: { isPrivate: true },
+          },
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as { isPrivate: boolean };
@@ -636,14 +720,21 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const repo = "my-doc";
     const sessionId = seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
-    seedBranchProtection(owner, repo, { rule_name: "main", required_approvals: 1 });
+    seedBranchProtection(owner, repo, {
+      rule_name: "main",
+      required_approvals: 1,
+    });
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: { requiredApprovals: -5 },
-        }),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: { requiredApprovals: -5 },
+          },
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -665,19 +756,31 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: {
-            enableApprovalsWhitelist: true,
-            approvalsWhitelistUsernames: ["alice", 42, null, "bob"] as unknown as string[],
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: {
+              enableApprovalsWhitelist: true,
+              approvalsWhitelistUsernames: [
+                "alice",
+                42,
+                null,
+                "bob",
+              ] as unknown as string[],
+            },
           },
-        }),
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
         branchProtection: { approvalsWhitelistUsernames: string[] } | null;
       };
-      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual(["alice", "bob"]);
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual([
+        "alice",
+        "bob",
+      ]);
     } finally {
       server.stop(true);
     }
@@ -687,14 +790,17 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     try {
       const response = await server.fetch(
-        new Request("http://localhost/api/app/documents/alice/my-doc/permissions", {
-          method: "PUT",
-          headers: {
-            Origin: config.appOrigin,
-            "Content-Type": "application/json",
+        new Request(
+          "http://localhost/api/app/documents/alice/my-doc/permissions",
+          {
+            method: "PUT",
+            headers: {
+              Origin: config.appOrigin,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ isPrivate: false }),
           },
-          body: JSON.stringify({ isPrivate: false }),
-        }),
+        ),
       );
       expect(response.status).toBe(401);
     } finally {
@@ -708,14 +814,21 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const repo = "my-doc";
     const sessionId = seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
-    seedBranchProtection(owner, repo, { rule_name: "main", required_approvals: 2 });
+    seedBranchProtection(owner, repo, {
+      rule_name: "main",
+      required_approvals: 2,
+    });
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: { requiredApprovals: 0 },
-        }),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: { requiredApprovals: 0 },
+          },
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -733,14 +846,21 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const repo = "my-doc";
     const sessionId = seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
-    seedBranchProtection(owner, repo, { rule_name: "main", required_approvals: 1 });
+    seedBranchProtection(owner, repo, {
+      rule_name: "main",
+      required_approvals: 1,
+    });
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: { requiredApprovals: 5 },
-        }),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: { requiredApprovals: 5 },
+          },
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -766,13 +886,17 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: {
-            enableApprovalsWhitelist: false,
-            approvalsWhitelistUsernames: [],
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: {
+              enableApprovalsWhitelist: false,
+              approvalsWhitelistUsernames: [],
+            },
           },
-        }),
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -802,13 +926,17 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: {
-            enableMergeWhitelist: false,
-            mergeWhitelistUsernames: [],
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: {
+              enableMergeWhitelist: false,
+              mergeWhitelistUsernames: [],
+            },
           },
-        }),
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -834,19 +962,31 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: {
-            enableMergeWhitelist: true,
-            mergeWhitelistUsernames: ["publisher1", 123, null, "publisher2"] as unknown as string[],
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: {
+              enableMergeWhitelist: true,
+              mergeWhitelistUsernames: [
+                "publisher1",
+                123,
+                null,
+                "publisher2",
+              ] as unknown as string[],
+            },
           },
-        }),
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
         branchProtection: { mergeWhitelistUsernames: string[] } | null;
       };
-      expect(body.branchProtection?.mergeWhitelistUsernames).toEqual(["publisher1", "publisher2"]);
+      expect(body.branchProtection?.mergeWhitelistUsernames).toEqual([
+        "publisher1",
+        "publisher2",
+      ]);
     } finally {
       server.stop(true);
     }
@@ -862,16 +1002,20 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
-          method: "PUT",
-          body: {
-            requiredApprovals: 2,
-            enableApprovalsWhitelist: true,
-            approvalsWhitelistUsernames: ["alice"],
-            enableMergeWhitelist: true,
-            mergeWhitelistUsernames: ["bob"],
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+          {
+            method: "PUT",
+            body: {
+              requiredApprovals: 2,
+              enableApprovalsWhitelist: true,
+              approvalsWhitelistUsernames: ["alice"],
+              enableMergeWhitelist: true,
+              mergeWhitelistUsernames: ["bob"],
+            },
           },
-        }),
+        ),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
@@ -885,7 +1029,9 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
       };
       expect(body.branchProtection?.requiredApprovals).toBe(2);
       expect(body.branchProtection?.enableApprovalsWhitelist).toBe(true);
-      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual(["alice"]);
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual([
+        "alice",
+      ]);
       expect(body.branchProtection?.enableMergeWhitelist).toBe(true);
       expect(body.branchProtection?.mergeWhitelistUsernames).toEqual(["bob"]);
     } finally {
@@ -912,7 +1058,10 @@ describe("GET /api/app/documents/:owner/:repo/permissions - additional scenarios
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+        ),
       );
       expect(response.status).toBe(200);
 
@@ -925,7 +1074,9 @@ describe("GET /api/app/documents/:owner/:repo/permissions - additional scenarios
 
       expect(body.branchProtection).not.toBeNull();
       expect(body.branchProtection?.enableMergeWhitelist).toBe(true);
-      expect(body.branchProtection?.mergeWhitelistUsernames).toContain("publisher");
+      expect(body.branchProtection?.mergeWhitelistUsernames).toContain(
+        "publisher",
+      );
     } finally {
       server.stop(true);
     }
@@ -942,7 +1093,10 @@ describe("GET /api/app/documents/:owner/:repo/permissions - additional scenarios
 
     try {
       const response = await server.fetch(
-        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+        makeRequest(
+          `/api/app/documents/${owner}/${repo}/permissions`,
+          sessionId,
+        ),
       );
       expect(response.status).toBe(200);
 
@@ -985,7 +1139,9 @@ describe("GET /api/app/documents/:owner/:repo - public and private access", () =
         makeRequest(`/api/app/documents/${owner}/${repo}`, nonOwnerSessionId),
       );
       expect(response.status).toBe(200);
-      const body = (await response.json()) as { repository: { full_name: string } };
+      const body = (await response.json()) as {
+        repository: { full_name: string };
+      };
       expect(body.repository.full_name).toBe(`${owner}/${repo}`);
     } finally {
       server.stop(true);
@@ -1013,15 +1169,17 @@ describe("GET /api/app/documents/:owner/:repo - public and private access", () =
             : input.url;
       const url = new URL(requestUrl);
       const headers =
-        input instanceof Request
-          ? input.headers
-          : new Headers(init?.headers);
+        input instanceof Request ? input.headers : new Headers(init?.headers);
 
       // Check if this is a repo GET request for the private repo from the non-collaborator
-      const repoMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)$/);
+      const repoMatch = url.pathname.match(
+        /^\/api\/v1\/repos\/([^/]+)\/([^/]+)$/,
+      );
       if (repoMatch && repoMatch[1] === owner && repoMatch[2] === repo) {
         const authHeader = headers.get("Authorization") ?? "";
-        const token = authHeader.startsWith("token ") ? authHeader.slice(6) : "";
+        const token = authHeader.startsWith("token ")
+          ? authHeader.slice(6)
+          : "";
         const login = giteaLoginsByToken.get(token);
 
         // If the requesting user is NOT the owner, return 404

--- a/services/api/document-permissions.test.ts
+++ b/services/api/document-permissions.test.ts
@@ -1,0 +1,1052 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "crypto";
+
+import { config } from "./config";
+import { createApiServer } from "./server";
+import { SessionStore, sessionStore } from "./sessions";
+import { resetStripeClientForTests } from "./stripe/client";
+import {
+  SubscriptionStore,
+  subscriptionStore,
+  WebhookEventStore,
+  webhookEventStore,
+} from "./subscriptions";
+
+// ── Mock Gitea state ─────────────────────────────────────────────────────────
+
+type MockedGiteaUser = { login: string; email: string };
+type MockedRepo = { private: boolean };
+type MockedBranchProtection = {
+  rule_name: string;
+  required_approvals: number;
+  enable_approvals_whitelist: boolean;
+  approvals_whitelist_username: string[];
+  approvals_whitelist_teams: string[];
+  enable_merge_whitelist: boolean;
+  merge_whitelist_usernames: string[];
+  merge_whitelist_teams: string[];
+  block_on_rejected_reviews: boolean;
+};
+type MockedFetchCall = { path: string; method: string; body: string | null };
+
+const originalFetch = globalThis.fetch;
+const originalApiPort = config.apiPort;
+const originalSessionsDbPath = config.sessionsDbPath;
+
+let fetchCalls: MockedFetchCall[] = [];
+let giteaUsersByLogin = new Map<string, MockedGiteaUser>();
+let giteaLoginsByToken = new Map<string, string>();
+let reposByKey = new Map<string, MockedRepo>();
+let branchProtectionsByRepoKey = new Map<string, MockedBranchProtection[]>();
+
+function repoKey(owner: string, repo: string): string {
+  return `${owner}/${repo}`;
+}
+
+beforeEach(() => {
+  config.apiPort = 0;
+  config.stripeSecretKey = "sk_test_perms";
+  config.stripeWebhookSecret = "whsec_test_perms";
+  config.stripePriceId = "price_test_perms";
+  config.sessionsDbPath = `/tmp/bindersnap-perms-test-${randomUUID()}.sqlite`;
+  resetStripeClientForTests();
+
+  (sessionStore as { _store: SessionStore | null })._store = new SessionStore(
+    config.sessionsDbPath,
+  );
+  (subscriptionStore as { _store: SubscriptionStore | null })._store =
+    new SubscriptionStore(config.sessionsDbPath);
+  (webhookEventStore as { _store: WebhookEventStore | null })._store =
+    new WebhookEventStore(config.sessionsDbPath);
+
+  fetchCalls = [];
+  giteaUsersByLogin = new Map();
+  giteaLoginsByToken = new Map();
+  reposByKey = new Map();
+  branchProtectionsByRepoKey = new Map();
+
+  globalThis.fetch = (async (input, init) => {
+    const requestUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const url = new URL(requestUrl);
+    const headers =
+      input instanceof Request
+        ? input.headers
+        : new Headers(init?.headers);
+    const method =
+      input instanceof Request
+        ? input.method
+        : (init?.method ?? "GET");
+    const rawBody =
+      input instanceof Request
+        ? await input.clone().text()
+        : typeof init?.body === "string"
+          ? init.body
+          : null;
+    const bodyText = rawBody || null;
+
+    fetchCalls.push({ path: url.pathname, method, body: bodyText });
+
+    // Gitea: GET /api/v1/user — authenticate token
+    if (url.pathname === "/api/v1/user") {
+      const authHeader = headers.get("Authorization") ?? "";
+      const token = authHeader.startsWith("token ") ? authHeader.slice(6) : "";
+      const login = giteaLoginsByToken.get(token);
+      const user = login ? giteaUsersByLogin.get(login) : null;
+      if (!user) {
+        return new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ login: user.login, email: user.email, full_name: "", is_admin: false }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Gitea: GET /api/v1/repos/{owner}/{repo}/branch_protections
+    const bpListMatch = url.pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/branch_protections$/,
+    );
+    if (bpListMatch && method === "GET") {
+      const key = repoKey(bpListMatch[1]!, bpListMatch[2]!);
+      const rules = branchProtectionsByRepoKey.get(key) ?? [];
+      return new Response(JSON.stringify(rules), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Gitea: PATCH /api/v1/repos/{owner}/{repo}/branch_protections/{name}
+    const bpPatchMatch = url.pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/branch_protections\/([^/]+)$/,
+    );
+    if (bpPatchMatch && method === "PATCH") {
+      const key = repoKey(bpPatchMatch[1]!, bpPatchMatch[2]!);
+      const ruleName = bpPatchMatch[3]!;
+      const rules = branchProtectionsByRepoKey.get(key) ?? [];
+      const existing = rules.find((r) => r.rule_name === ruleName) ?? rules[0];
+      if (!existing) {
+        return new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const patch = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {};
+      const updated: MockedBranchProtection = {
+        ...existing,
+        ...(typeof patch.required_approvals === "number" && {
+          required_approvals: patch.required_approvals,
+        }),
+        ...(typeof patch.enable_approvals_whitelist === "boolean" && {
+          enable_approvals_whitelist: patch.enable_approvals_whitelist,
+        }),
+        ...(Array.isArray(patch.approvals_whitelist_username) && {
+          approvals_whitelist_username: patch.approvals_whitelist_username as string[],
+        }),
+        ...(typeof patch.enable_merge_whitelist === "boolean" && {
+          enable_merge_whitelist: patch.enable_merge_whitelist,
+        }),
+        ...(Array.isArray(patch.merge_whitelist_usernames) && {
+          merge_whitelist_usernames: patch.merge_whitelist_usernames as string[],
+        }),
+      };
+      const newRules = rules.map((r) => (r.rule_name === ruleName ? updated : r));
+      branchProtectionsByRepoKey.set(key, newRules);
+      return new Response(JSON.stringify(updated), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Gitea: GET /api/v1/repos/{owner}/{repo}
+    const repoMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)$/);
+    if (repoMatch && method === "GET") {
+      const key = repoKey(repoMatch[1]!, repoMatch[2]!);
+      const repo = reposByKey.get(key);
+      if (!repo) {
+        return new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          id: 1,
+          name: repoMatch[2],
+          full_name: key,
+          private: repo.private,
+          permissions: { admin: true, push: true, pull: true },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Gitea: PATCH /api/v1/repos/{owner}/{repo} — update visibility
+    if (repoMatch && method === "PATCH") {
+      const key = repoKey(repoMatch[1]!, repoMatch[2]!);
+      const repo = reposByKey.get(key);
+      if (!repo) {
+        return new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const patch = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {};
+      if (typeof patch.private === "boolean") repo.private = patch.private;
+      return new Response(
+        JSON.stringify({ id: 1, name: repoMatch[2], full_name: key, private: repo.private }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Gitea: GET /api/v1/repos/{owner}/{repo}/tags — return empty tags
+    const tagsMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/tags$/);
+    if (tagsMatch && method === "GET") {
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Gitea: GET /api/v1/repos/{owner}/{repo}/pulls — return empty pulls
+    const pullsMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/pulls$/);
+    if (pullsMatch && method === "GET") {
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Gitea: GET /api/v1/repos/{owner}/{repo}/contents/* — return empty
+    const contentsMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/contents\//);
+    if (contentsMatch && method === "GET") {
+      return new Response(JSON.stringify({ message: "Not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Gitea: GET /api/v1/repos/{owner}/{repo}/branches — return empty branches
+    const branchesMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/branches$/);
+    if (branchesMatch && method === "GET") {
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Gitea: GET /api/v1/repos/{owner}/{repo}/collaborators/{user} — return 404 (no collaborators setup)
+    const collabMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/collaborators\/([^/]+)$/);
+    if (collabMatch && method === "GET") {
+      return new Response(JSON.stringify({ message: "Not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Fallback — unexpected call
+    return new Response(JSON.stringify({ error: "unmocked fetch" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  config.apiPort = originalApiPort;
+  config.sessionsDbPath = originalSessionsDbPath;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function seedSession(username: string): string {
+  const sessionId = `sess_${randomUUID()}`;
+  const giteaToken = `gitea_${randomUUID()}`;
+  giteaUsersByLogin.set(username, { login: username, email: `${username}@test.local` });
+  giteaLoginsByToken.set(giteaToken, username);
+  sessionStore.put({
+    id: sessionId,
+    username,
+    giteaToken,
+    giteaTokenName: "perms-test-token",
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  });
+  subscriptionStore.upsert({
+    username,
+    stripeCustomerId: `cus_${randomUUID()}`,
+    stripeSubscriptionId: `sub_${randomUUID()}`,
+    status: "active",
+    currentPeriodEnd: Math.floor(Date.now() / 1000) + 86_400,
+    cancelAtPeriodEnd: false,
+    cancelAt: null,
+    updatedAt: Date.now(),
+  });
+  return sessionId;
+}
+
+function seedRepo(
+  owner: string,
+  repo: string,
+  options?: { isPrivate?: boolean },
+): void {
+  reposByKey.set(repoKey(owner, repo), { private: options?.isPrivate ?? true });
+}
+
+function seedBranchProtection(
+  owner: string,
+  repo: string,
+  rule: Partial<MockedBranchProtection> & { rule_name: string },
+): void {
+  const key = repoKey(owner, repo);
+  const existing = branchProtectionsByRepoKey.get(key) ?? [];
+  branchProtectionsByRepoKey.set(key, [
+    ...existing,
+    {
+      required_approvals: 1,
+      enable_approvals_whitelist: false,
+      approvals_whitelist_username: [],
+      approvals_whitelist_teams: [],
+      enable_merge_whitelist: false,
+      merge_whitelist_usernames: [],
+      merge_whitelist_teams: [],
+      block_on_rejected_reviews: false,
+      ...rule,
+    },
+  ]);
+}
+
+function makeRequest(
+  pathname: string,
+  sessionId: string,
+  options?: { method?: string; body?: Record<string, unknown> },
+): Request {
+  const method = options?.method ?? "GET";
+  return new Request(`http://localhost${pathname}`, {
+    method,
+    headers: {
+      Origin: config.appOrigin,
+      Cookie: `${config.sessionCookieName}=${sessionId}`,
+      ...(options?.body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: options?.body ? JSON.stringify(options.body) : undefined,
+  });
+}
+
+// ── Tests: GET /api/app/documents/:owner/:repo/permissions ───────────────────
+
+describe("GET /api/app/documents/:owner/:repo/permissions", () => {
+  test("returns 401 when no session cookie is present", async () => {
+    const server = createApiServer();
+    try {
+      const response = await server.fetch(
+        new Request("http://localhost/api/app/documents/alice/my-doc/permissions", {
+          headers: { Origin: config.appOrigin },
+        }),
+      );
+      expect(response.status).toBe(401);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns 402 when user has no active subscription", async () => {
+    const server = createApiServer();
+    const sessionId = `sess_${randomUUID()}`;
+    const giteaToken = `gitea_${randomUUID()}`;
+    const username = `no-sub-${randomUUID()}`;
+    giteaUsersByLogin.set(username, { login: username, email: `${username}@test.local` });
+    giteaLoginsByToken.set(giteaToken, username);
+    sessionStore.put({
+      id: sessionId,
+      username,
+      giteaToken,
+      giteaTokenName: "perms-test-token",
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    });
+    // no subscriptionStore.upsert — no active subscription
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${username}/my-doc/permissions`, sessionId),
+      );
+      expect(response.status).toBe(402);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns branch protection and visibility for a document with a branch protection rule", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, {
+      rule_name: "main",
+      required_approvals: 2,
+      enable_approvals_whitelist: true,
+      approvals_whitelist_username: ["reviewer1"],
+    });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+      );
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        branchProtection: {
+          requiredApprovals: number;
+          enableApprovalsWhitelist: boolean;
+          approvalsWhitelistUsernames: string[];
+        } | null;
+        isPrivate: boolean;
+        currentUserPermission: unknown;
+      };
+
+      expect(body.branchProtection).not.toBeNull();
+      expect(body.branchProtection?.requiredApprovals).toBe(2);
+      expect(body.branchProtection?.enableApprovalsWhitelist).toBe(true);
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual(["reviewer1"]);
+      expect(body.isPrivate).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns null branchProtection when repo has no branch protection rules", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "no-bp-doc";
+    const sessionId = seedSession(owner);
+
+    seedRepo(owner, repo, { isPrivate: false });
+    // no seedBranchProtection — empty list
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+      );
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as { branchProtection: null; isPrivate: boolean };
+      expect(body.branchProtection).toBeNull();
+      expect(body.isPrivate).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns isPrivate: false for a public repo", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "public-doc";
+    const sessionId = seedSession(owner);
+
+    seedRepo(owner, repo, { isPrivate: false });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { isPrivate: boolean };
+      expect(body.isPrivate).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+// ── Tests: PUT /api/app/documents/:owner/:repo/permissions ───────────────────
+
+describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
+  test("returns 403 when the requesting user is not the repo owner", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const collaborator = `collab-${randomUUID()}`;
+    const repo = "shared-doc";
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+    const collabSessionId = seedSession(collaborator);
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, collabSessionId, {
+          method: "PUT",
+          body: { requiredApprovals: 3 },
+        }),
+      );
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toMatch(/owner/i);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can update requiredApprovals", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main", required_approvals: 1 });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: { requiredApprovals: 3 },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: { requiredApprovals: number } | null;
+      };
+      expect(body.branchProtection?.requiredApprovals).toBe(3);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can enable approvals whitelist with specific users", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: {
+            enableApprovalsWhitelist: true,
+            approvalsWhitelistUsernames: ["alice", "bob"],
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: {
+          enableApprovalsWhitelist: boolean;
+          approvalsWhitelistUsernames: string[];
+        } | null;
+      };
+      expect(body.branchProtection?.enableApprovalsWhitelist).toBe(true);
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual(["alice", "bob"]);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can enable merge whitelist with specific users", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: {
+            enableMergeWhitelist: true,
+            mergeWhitelistUsernames: ["publisher1"],
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: {
+          enableMergeWhitelist: boolean;
+          mergeWhitelistUsernames: string[];
+        } | null;
+      };
+      expect(body.branchProtection?.enableMergeWhitelist).toBe(true);
+      expect(body.branchProtection?.mergeWhitelistUsernames).toEqual(["publisher1"]);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can flip repo from private to public", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: { isPrivate: false },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { isPrivate: boolean };
+      expect(body.isPrivate).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can flip repo from public to private", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: false });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: { isPrivate: true },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { isPrivate: boolean };
+      expect(body.isPrivate).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("floats requiredApprovals to 0 when a negative value is provided", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main", required_approvals: 1 });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: { requiredApprovals: -5 },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: { requiredApprovals: number } | null;
+      };
+      expect(body.branchProtection?.requiredApprovals).toBe(0);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("non-string entries in approvalsWhitelistUsernames are stripped", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: {
+            enableApprovalsWhitelist: true,
+            approvalsWhitelistUsernames: ["alice", 42, null, "bob"] as unknown as string[],
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: { approvalsWhitelistUsernames: string[] } | null;
+      };
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual(["alice", "bob"]);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns 401 when no session cookie is present", async () => {
+    const server = createApiServer();
+    try {
+      const response = await server.fetch(
+        new Request("http://localhost/api/app/documents/alice/my-doc/permissions", {
+          method: "PUT",
+          headers: {
+            Origin: config.appOrigin,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ isPrivate: false }),
+        }),
+      );
+      expect(response.status).toBe(401);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can set requiredApprovals to 0 (no approvals needed)", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main", required_approvals: 2 });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: { requiredApprovals: 0 },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: { requiredApprovals: number } | null;
+      };
+      expect(body.branchProtection?.requiredApprovals).toBe(0);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can set multiple requiredApprovals (e.g. 5)", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main", required_approvals: 1 });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: { requiredApprovals: 5 },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: { requiredApprovals: number } | null;
+      };
+      expect(body.branchProtection?.requiredApprovals).toBe(5);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can disable approvals whitelist", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, {
+      rule_name: "main",
+      enable_approvals_whitelist: true,
+      approvals_whitelist_username: ["alice", "bob"],
+    });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: {
+            enableApprovalsWhitelist: false,
+            approvalsWhitelistUsernames: [],
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: {
+          enableApprovalsWhitelist: boolean;
+          approvalsWhitelistUsernames: string[];
+        } | null;
+      };
+      expect(body.branchProtection?.enableApprovalsWhitelist).toBe(false);
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual([]);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can disable merge whitelist", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, {
+      rule_name: "main",
+      enable_merge_whitelist: true,
+      merge_whitelist_usernames: ["publisher1"],
+    });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: {
+            enableMergeWhitelist: false,
+            mergeWhitelistUsernames: [],
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: {
+          enableMergeWhitelist: boolean;
+          mergeWhitelistUsernames: string[];
+        } | null;
+      };
+      expect(body.branchProtection?.enableMergeWhitelist).toBe(false);
+      expect(body.branchProtection?.mergeWhitelistUsernames).toEqual([]);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("non-string entries in mergeWhitelistUsernames are stripped", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: {
+            enableMergeWhitelist: true,
+            mergeWhitelistUsernames: ["publisher1", 123, null, "publisher2"] as unknown as string[],
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: { mergeWhitelistUsernames: string[] } | null;
+      };
+      expect(body.branchProtection?.mergeWhitelistUsernames).toEqual(["publisher1", "publisher2"]);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("owner can update multiple permission fields simultaneously", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId, {
+          method: "PUT",
+          body: {
+            requiredApprovals: 2,
+            enableApprovalsWhitelist: true,
+            approvalsWhitelistUsernames: ["alice"],
+            enableMergeWhitelist: true,
+            mergeWhitelistUsernames: ["bob"],
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        branchProtection: {
+          requiredApprovals: number;
+          enableApprovalsWhitelist: boolean;
+          approvalsWhitelistUsernames: string[];
+          enableMergeWhitelist: boolean;
+          mergeWhitelistUsernames: string[];
+        } | null;
+      };
+      expect(body.branchProtection?.requiredApprovals).toBe(2);
+      expect(body.branchProtection?.enableApprovalsWhitelist).toBe(true);
+      expect(body.branchProtection?.approvalsWhitelistUsernames).toEqual(["alice"]);
+      expect(body.branchProtection?.enableMergeWhitelist).toBe(true);
+      expect(body.branchProtection?.mergeWhitelistUsernames).toEqual(["bob"]);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+// ── Tests: Additional GET /api/app/documents/:owner/:repo/permissions scenarios ──
+
+describe("GET /api/app/documents/:owner/:repo/permissions - additional scenarios", () => {
+  test("returns merge whitelist data when present", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, {
+      rule_name: "main",
+      enable_merge_whitelist: true,
+      merge_whitelist_usernames: ["publisher"],
+    });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+      );
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        branchProtection: {
+          enableMergeWhitelist: boolean;
+          mergeWhitelistUsernames: string[];
+        } | null;
+      };
+
+      expect(body.branchProtection).not.toBeNull();
+      expect(body.branchProtection?.enableMergeWhitelist).toBe(true);
+      expect(body.branchProtection?.mergeWhitelistUsernames).toContain("publisher");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns currentUserPermission for owner", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const repo = "my-doc";
+    const sessionId = seedSession(owner);
+
+    seedRepo(owner, repo, { isPrivate: true });
+    seedBranchProtection(owner, repo, { rule_name: "main" });
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}/permissions`, sessionId),
+      );
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        currentUserPermission: {
+          permission: string;
+          access: string;
+          permissionLabel: string;
+          roleName: string;
+          user: { login: string };
+        } | null;
+      };
+
+      expect(body.currentUserPermission).not.toBeNull();
+      expect(body.currentUserPermission?.permission).toBe("owner");
+      expect(body.currentUserPermission?.access).toBe("owner");
+      expect(body.currentUserPermission?.permissionLabel).toBe("Owner");
+      expect(body.currentUserPermission?.roleName).toBe("owner");
+      expect(body.currentUserPermission?.user.login).toBe(owner);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+// ── Tests: GET /api/app/documents/:owner/:repo (public/private access) ──
+
+describe("GET /api/app/documents/:owner/:repo - public and private access", () => {
+  test("public repo is viewable by non-owner with valid session", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const nonOwner = `viewer-${randomUUID()}`;
+    const repo = "public-doc";
+
+    seedRepo(owner, repo, { isPrivate: false });
+    const nonOwnerSessionId = seedSession(nonOwner);
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}`, nonOwnerSessionId),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { repository: { full_name: string } };
+      expect(body.repository.full_name).toBe(`${owner}/${repo}`);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("private repo is blocked for non-collaborator", async () => {
+    const server = createApiServer();
+    const owner = `owner-${randomUUID()}`;
+    const nonCollaborator = `outsider-${randomUUID()}`;
+    const repo = "private-doc";
+
+    seedRepo(owner, repo, { isPrivate: true });
+    const nonCollabSessionId = seedSession(nonCollaborator);
+
+    // Override the mock fetch for this test to simulate Gitea returning 404
+    // for a private repo when accessed by a non-collaborator
+    const originalMockFetch = globalThis.fetch;
+    globalThis.fetch = (async (input, init) => {
+      const requestUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const url = new URL(requestUrl);
+      const headers =
+        input instanceof Request
+          ? input.headers
+          : new Headers(init?.headers);
+
+      // Check if this is a repo GET request for the private repo from the non-collaborator
+      const repoMatch = url.pathname.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)$/);
+      if (repoMatch && repoMatch[1] === owner && repoMatch[2] === repo) {
+        const authHeader = headers.get("Authorization") ?? "";
+        const token = authHeader.startsWith("token ") ? authHeader.slice(6) : "";
+        const login = giteaLoginsByToken.get(token);
+
+        // If the requesting user is NOT the owner, return 404
+        if (login !== owner) {
+          return new Response(JSON.stringify({ message: "Not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      }
+
+      // Fall back to the original mock for all other calls
+      return originalMockFetch(input, init);
+    }) as typeof fetch;
+
+    try {
+      const response = await server.fetch(
+        makeRequest(`/api/app/documents/${owner}/${repo}`, nonCollabSessionId),
+      );
+      // Expect a 4xx error (likely 404 propagated from Gitea)
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
+    } finally {
+      globalThis.fetch = originalMockFetch;
+      server.stop(true);
+    }
+  });
+});

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -33,13 +33,17 @@ import {
   getLatestDocTag,
   getRepoBranchProtection,
   getRepoCollaboratorPermission,
+  getRepoInfo,
   listDocTags,
   listRepoCollaborators,
   listWorkspaceRepos,
   repoExists,
   searchUsers,
   removeRepoCollaborator,
+  updateRepoBranchProtection,
+  updateRepoVisibility,
   type RepoCollaboratorPermissionSummary,
+  type RepoBranchProtection,
   type RepoUserSummary,
   type WorkspaceRepo,
 } from "../../packages/gitea-client/repos";
@@ -2898,6 +2902,147 @@ async function handleDeleteCollaborator(
   }
 }
 
+async function handleGetDocumentPermissions(
+  req: Request,
+  baseHeaders: Headers,
+  owner: string,
+  repo: string,
+): Promise<Response> {
+  const auth = requireSubscription(req, baseHeaders);
+  if (auth instanceof Response) return auth;
+  const { client, session } = auth;
+
+  try {
+    const [branchProtection, repoInfo, currentUserPermission] =
+      await Promise.all([
+        getRepoBranchProtection(client, owner, repo, "main").catch(() => null),
+        getRepoInfo({ client, owner, repo }),
+        resolveCurrentUserPermission(
+          client,
+          owner,
+          repo,
+          session.username,
+        ).catch(() => null),
+      ]);
+
+    return json(
+      200,
+      {
+        branchProtection,
+        isPrivate: repoInfo.isPrivate,
+        currentUserPermission,
+      },
+      baseHeaders,
+    );
+  } catch (err) {
+    return responseFromError(
+      err,
+      baseHeaders,
+      "Unable to load document permissions.",
+    );
+  }
+}
+
+async function handleUpdateDocumentPermissions(
+  req: Request,
+  baseHeaders: Headers,
+  owner: string,
+  repo: string,
+): Promise<Response> {
+  const auth = requireSubscription(req, baseHeaders);
+  if (auth instanceof Response) return auth;
+  const { client, session } = auth;
+
+  if (session.username !== owner) {
+    return json(
+      403,
+      { error: "Only the document owner can change permissions." },
+      baseHeaders,
+    );
+  }
+
+  const payload = await readJsonBody(req);
+
+  const requiredApprovals =
+    typeof payload?.requiredApprovals === "number"
+      ? Math.max(0, Math.floor(payload.requiredApprovals))
+      : undefined;
+  const enableApprovalsWhitelist =
+    typeof payload?.enableApprovalsWhitelist === "boolean"
+      ? payload.enableApprovalsWhitelist
+      : undefined;
+  const approvalsWhitelistUsernames = Array.isArray(
+    payload?.approvalsWhitelistUsernames,
+  )
+    ? (payload.approvalsWhitelistUsernames as unknown[]).filter(
+        (u): u is string => typeof u === "string",
+      )
+    : undefined;
+  const enableMergeWhitelist =
+    typeof payload?.enableMergeWhitelist === "boolean"
+      ? payload.enableMergeWhitelist
+      : undefined;
+  const mergeWhitelistUsernames = Array.isArray(
+    payload?.mergeWhitelistUsernames,
+  )
+    ? (payload.mergeWhitelistUsernames as unknown[]).filter(
+        (u): u is string => typeof u === "string",
+      )
+    : undefined;
+  const isPrivate =
+    typeof payload?.isPrivate === "boolean" ? payload.isPrivate : undefined;
+
+  try {
+    const updates: Array<Promise<unknown>> = [];
+
+    const hasBranchUpdate =
+      requiredApprovals !== undefined ||
+      enableApprovalsWhitelist !== undefined ||
+      approvalsWhitelistUsernames !== undefined ||
+      enableMergeWhitelist !== undefined ||
+      mergeWhitelistUsernames !== undefined;
+
+    if (hasBranchUpdate) {
+      updates.push(
+        updateRepoBranchProtection({
+          client,
+          owner,
+          repo,
+          ruleName: "main",
+          requiredApprovals,
+          enableApprovalsWhitelist,
+          approvalsWhitelistUsernames,
+          enableMergeWhitelist,
+          mergeWhitelistUsernames,
+        }),
+      );
+    }
+
+    if (isPrivate !== undefined) {
+      updates.push(updateRepoVisibility({ client, owner, repo, isPrivate }));
+    }
+
+    await Promise.all(updates);
+
+    const [branchProtection, repoInfo] = await Promise.all([
+      getRepoBranchProtection(client, owner, repo, "main").catch(() => null),
+      getRepoInfo({ client, owner, repo }),
+    ]);
+
+    return json(
+      200,
+      { branchProtection, isPrivate: repoInfo.isPrivate },
+      baseHeaders,
+    );
+  } catch (err) {
+    return responseFromError(
+      err,
+      baseHeaders,
+      "Unable to update document permissions.",
+    );
+  }
+}
+
 async function handleStripeWebhook(
   req: Request,
   baseHeaders: Headers,
@@ -3575,6 +3720,9 @@ export function createApiServer() {
         const versionsMatch = pathname.match(
           /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/versions$/,
         );
+        const permissionsMatch = pathname.match(
+          /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/permissions$/,
+        );
         const collaboratorsActionMatch = pathname.match(
           /^\/api\/app\/documents\/([^/]+)\/([^/]+)\/collaborators\/([^/]+)$/,
         );
@@ -3626,6 +3774,20 @@ export function createApiServer() {
             baseHeaders,
             decodePathParam(versionsMatch[1] ?? ""),
             decodePathParam(versionsMatch[2] ?? ""),
+          );
+        } else if (permissionsMatch && method === "GET") {
+          response = await handleGetDocumentPermissions(
+            req,
+            baseHeaders,
+            decodePathParam(permissionsMatch[1] ?? ""),
+            decodePathParam(permissionsMatch[2] ?? ""),
+          );
+        } else if (permissionsMatch && method === "PUT") {
+          response = await handleUpdateDocumentPermissions(
+            req,
+            baseHeaders,
+            decodePathParam(permissionsMatch[1] ?? ""),
+            decodePathParam(permissionsMatch[2] ?? ""),
           );
         } else if (adminSubscriptionGrantMatch && method === "POST") {
           response = await upsertLegacyAdminSubscriptionOverride(

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -2930,6 +2930,7 @@ async function handleGetDocumentPermissions(
       {
         branchProtection,
         isPrivate: repoInfo.isPrivate,
+        isInternal: repoInfo.isInternal,
         currentUserPermission,
       },
       baseHeaders,
@@ -3031,7 +3032,11 @@ async function handleUpdateDocumentPermissions(
 
     return json(
       200,
-      { branchProtection, isPrivate: repoInfo.isPrivate },
+      {
+        branchProtection,
+        isPrivate: repoInfo.isPrivate,
+        isInternal: repoInfo.isInternal,
+      },
       baseHeaders,
     );
   } catch (err) {


### PR DESCRIPTION
## Summary

Closes #206.

Adds a new **Permissions** tab to every document, giving owners full control over approval and publish rules, and public read access.

- **Required approvals** — set the minimum approval count (0 = unrestricted)
- **Approval whitelist** — optionally restrict which users can approve a PR
- **Publish whitelist** — optionally restrict which users can merge/publish
- **Visibility toggle** — flip a document between private (collaborators only) and public (anyone can read)

## Changes

### `packages/gitea-client/repos.ts`
- Expanded `RepoBranchProtection` with `approvalsWhitelistTeams` and `mergeWhitelistTeams`
- Added `updateRepoBranchProtection()` — PATCH branch protection rule
- Added `updateRepoVisibility()` — PATCH repo private/public flag
- Added `getRepoInfo()` — fetch current repo visibility

### `services/api/server.ts`
- `GET /api/app/documents/:owner/:repo/permissions` — returns branch protection + visibility + current user permission
- `PUT /api/app/documents/:owner/:repo/permissions` — owner-only update; validates and applies changes

### `apps/app/api.ts`
- `DocumentPermissionsPayload` interface
- `getDocumentPermissions()` and `updateDocumentPermissions()` client functions

### `apps/app/routes.ts`
- Added `"permissions"` tab to document route
- Route `/docs/:owner/:repo/permissions` → `tab: "permissions"`

### `apps/app/components/DocumentPermissions.tsx` (new)
- Owner sees editable form; non-owners see read-only view
- Three sections: Review Rules, Publish Restrictions, Public Access
- Follows design system (CSS tokens, `bs-card`, `bs-eyebrow`, `bs-btn-primary`)

### `apps/app/components/DocumentDetail.tsx`
- Added Permissions tab button and panel

## Test plan

- [ ] As document owner, open Permissions tab — all three sections are visible and editable
- [ ] Change required approvals to 2, save — Gitea branch protection updated
- [ ] Enable approval whitelist, add a username, save — subsequent reviews only count from that user
- [ ] Enable publish whitelist, add a username, save — only that user can merge
- [ ] Toggle visibility to public, save — repo becomes public in Gitea
- [ ] As a collaborator (non-owner), open Permissions tab — read-only message is shown, inputs are disabled
- [ ] All 143 unit tests pass (`bun run test:app`)

## Workflow evidence

- Issue read: `mcp__github__issue_read` (#206)
- Branch created: local git, pushed via `git push -u origin feature/206-document-permissions`
- Commit SHA: `3d197b0`
- PR created: `mcp__github__create_pull_request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)