### PR TITLE
refactor(frontend): remove all gitea-client imports from frontend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,6 @@ bindersnap-editor-demo/
 ├── packages/                       ← Shared internal libraries
 │   ├── editor/                     ← Tiptap editor component (shared by landing + app)
 │   │   └── README.md               ← Read before editing
-│   ├── gitea-client/               ← All Gitea API interaction
-│   │   └── README.md               ← Read before editing
 │   ├── ui-tokens/                  ← CSS design tokens, fonts, icons
 │   └── utils/                      ← Shared utilities (sanitizer, etc.)
 │

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,6 @@ This is a **Bun monorepo** with one unified SPA, shared packages, and backend se
 
 ### Packages (shared)
 
-- `packages/editor/` — Tiptap 3 + ProseMirror editor. Backend-agnostic: receives a `giteaClient` prop for real use, runs demo mode without it. **Never import `gitea-client` inside `editor/`.**
 - `packages/ui-tokens/` — CSS design tokens (single source of truth for all visual values).
 - `packages/utils/` — Shared utilities (DOMPurify sanitizer, etc.).
 

--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -15,7 +15,6 @@ import { BindersnapLogoMark } from "./components/BindersnapLogoMark";
 import { LandingPage } from "./components/LandingPage";
 import {
   type SessionUser,
-  clearToken,
   createCheckoutSession,
   createPortalSession,
   fetchBillingStatus,
@@ -23,7 +22,6 @@ import {
   login,
   logoutSession,
   signup,
-  storeToken,
 } from "./api";
 import { usePaymentRequiredHandler } from "./paymentRequired";
 import {
@@ -307,11 +305,6 @@ export function App() {
 
     try {
       const nextSession = await fetchSessionUser();
-      if (nextSession?.token) {
-        storeToken(nextSession.token);
-      } else {
-        clearToken();
-      }
       const resolvedUser = nextSession?.user ?? null;
       setUser(resolvedUser);
       setCallbackError(null);
@@ -551,7 +544,6 @@ export function App() {
         }}
         onSignOut={async () => {
           await logoutSession();
-          clearToken();
           setUser(null);
           setCallbackError(null);
           navigateTo({ kind: "home" }, true);
@@ -574,15 +566,11 @@ export function App() {
         prefilledEmail={prefilledEmail}
         callbackError={callbackError}
         onLogin={async (identifier, password, rememberMe) => {
-          clearToken();
           const authenticatedSession = await login(
             identifier,
             password,
             rememberMe,
           );
-          if (authenticatedSession.token) {
-            storeToken(authenticatedSession.token);
-          }
           const loginUser =
             authenticatedSession.user ?? (await refreshSession());
           if (!loginUser) {
@@ -599,11 +587,7 @@ export function App() {
           navigateTo({ kind: "home" }, true);
         }}
         onSignup={async (username, email, password) => {
-          clearToken();
           const authenticatedSession = await signup(username, email, password);
-          if (authenticatedSession.token) {
-            storeToken(authenticatedSession.token);
-          }
           const signupUser =
             authenticatedSession.user ?? (await refreshSession());
           if (!signupUser) {
@@ -639,7 +623,6 @@ export function App() {
         onNavigate={navigateTo}
         onSignOut={async () => {
           await logoutSession();
-          clearToken();
           setUser(null);
           setCallbackError(null);
           navigateTo({ kind: "home" }, true);

--- a/apps/app/api.ts
+++ b/apps/app/api.ts
@@ -1,6 +1,3 @@
-// Re-export gitea-client auth (token ops, not API calls)
-export { clearToken, storeToken } from "../../services/api/gitea-client/auth";
-
 // Re-export document search utilities
 export type { DocumentSearchParams } from "./documentSearch";
 export { parseDocumentSearchQuery } from "./documentSearch";
@@ -56,13 +53,44 @@ export type {
   BillingStatusPayload,
 } from "../../packages/api-schema/schemas/billing";
 export type { SearchUsersPayload } from "../../packages/api-schema/schemas/users";
+export type {
+  DocTag,
+  RepoCollaboratorPermissionSummary,
+  RepoUserSummary,
+} from "../../packages/api-schema/schemas/common";
+export type {
+  ApprovalState,
+  RepoBranchProtection,
+} from "../../packages/api-schema/schemas/documents";
 
-// Re-export from gitea-client for validation
-export {
-  validateUploadFile,
-  validateUploadFile as validateUploadFileWithClient,
-} from "../../services/api/gitea-client/uploads";
-export type { UploadValidationResult } from "../../services/api/gitea-client/uploads";
+export interface UploadValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export type InitialDocumentUploadStep =
+  | "hashing"
+  | "creating-repo"
+  | "bootstrapping"
+  | "protecting"
+  | "creating-branch"
+  | "committing"
+  | "opening-pr";
+
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+
+export function validateUploadFile(file: File): UploadValidationResult {
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    const sizeMiB = (file.size / (1024 * 1024)).toFixed(1);
+    return {
+      valid: false,
+      reason: `File is too large (${sizeMiB} MiB). Maximum allowed size is 25 MiB.`,
+    };
+  }
+  return { valid: true };
+}
+
+export { validateUploadFile as validateUploadFileWithClient };
 
 import { ApiRequestError } from "../../packages/api-client/mutator";
 import {
@@ -282,10 +310,7 @@ export async function addDocumentCollaborator(
   repo: string,
   collaborator: string,
   permission: "read" | "write" | "admin",
-): Promise<
-  | import("../../services/api/gitea-client/repos").RepoCollaboratorPermissionSummary
-  | null
-> {
+): Promise<RepoCollaboratorPermissionSummary | null> {
   try {
     const response = await DocumentsClient.addDocumentCollaborator(
       owner,
@@ -388,7 +413,7 @@ export async function publishDocument(
   nextVersion: number,
 ): Promise<{
   ok: boolean;
-  tag: import("../../services/api/gitea-client/repos").DocTag;
+  tag: DocTag;
 }> {
   try {
     const response = await DocumentsClient.publishDocument(

--- a/apps/app/components/CreateDocumentModal.tsx
+++ b/apps/app/components/CreateDocumentModal.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { createInitialDocumentUpload } from "../api";
 import {
+  createInitialDocumentUpload,
   type InitialDocumentUploadStep,
   validateUploadFile,
-} from "../../../services/api/gitea-client/uploads";
+} from "../api";
 
 interface CreateDocumentModalProps {
   owner: string;

--- a/apps/app/components/DocumentCollaborators.tsx
+++ b/apps/app/components/DocumentCollaborators.tsx
@@ -9,7 +9,7 @@ import {
 import type {
   RepoCollaboratorPermissionSummary,
   RepoUserSummary,
-} from "../../../services/api/gitea-client/repos";
+} from "../api";
 
 type WritablePermission = "read" | "write" | "admin";
 type DisplayPermission = WritablePermission | "owner" | "unknown";

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 
-import type { PullRequestWithApprovalState } from "../api";
 import type {
+  PullRequestWithApprovalState,
   DocTag,
   RepoBranchProtection,
-} from "../../../services/api/gitea-client/repos";
-import type { UploadResult } from "../../../services/api/gitea-client/uploads";
+  UploadResult,
+} from "../api";
 import {
   downloadDocument,
   getDocumentDetail,

--- a/apps/app/components/DocumentPermissions.tsx
+++ b/apps/app/components/DocumentPermissions.tsx
@@ -5,7 +5,7 @@ import {
   updateDocumentPermissions,
 } from "../api";
 import type { DocumentPermissionsPayload } from "../api";
-import type { RepoUserSummary } from "../../../services/api/gitea-client/repos";
+import type { RepoUserSummary } from "../api";
 
 interface DocumentPermissionsProps {
   owner: string;

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -93,7 +93,7 @@ import { VersionHistory } from "./extensions/VersionHistory";
 import { Conflict } from "./extensions/conflict";
 import { gitService } from "./services/GitService";
 import { sanitizeHtml, sanitizeProseMirrorJson } from "../utils/sanitizer";
-import type { ApprovalState } from "../../services/api/gitea-client/pullRequests";
+import type { ApprovalState } from "@api-schema/schemas/documents";
 
 // --- Types ---
 interface ToolbarProps {

--- a/packages/editor/extensions/ApprovalStatus/ApprovalStatus.test.ts
+++ b/packages/editor/extensions/ApprovalStatus/ApprovalStatus.test.ts
@@ -6,7 +6,7 @@ import { JSDOM } from "jsdom";
 
 import { ApprovalStatusBanner } from "./ApprovalStatusBanner";
 import type { ApprovalStatusBannerProps } from "./ApprovalStatusBanner";
-import type { ApprovalState } from "../../../../services/api/gitea-client/pullRequests";
+import type { ApprovalState } from "@api-schema/schemas/documents";
 
 const { window } = new JSDOM("<!doctype html><html><body></body></html>");
 

--- a/packages/editor/extensions/ApprovalStatus/ApprovalStatusBanner.stories.tsx
+++ b/packages/editor/extensions/ApprovalStatus/ApprovalStatusBanner.stories.tsx
@@ -1,5 +1,5 @@
 import { ApprovalStatusBanner } from "./ApprovalStatusBanner";
-import type { ApprovalState } from "../../../../services/api/gitea-client/pullRequests";
+import type { ApprovalState } from "@api-schema/schemas/documents";
 import "../../assets/bindersnap-editor.css";
 
 export default {

--- a/packages/editor/extensions/ApprovalStatus/ApprovalStatusBanner.tsx
+++ b/packages/editor/extensions/ApprovalStatus/ApprovalStatusBanner.tsx
@@ -1,4 +1,4 @@
-import type { ApprovalState } from "../../../../services/api/gitea-client/pullRequests";
+import type { ApprovalState } from "@api-schema/schemas/documents";
 
 export interface ApprovalStatusBannerProps {
   approvalState: ApprovalState;


### PR DESCRIPTION
## Summary

- Replace all `gitea-client` type imports in `apps/app/` and `packages/editor/` with equivalents from `packages/api-schema` (`ApprovalState`, `DocTag`, `RepoBranchProtection`, `RepoCollaboratorPermissionSummary`, `RepoUserSummary`)
- Move `validateUploadFile` and `UploadValidationResult` / `InitialDocumentUploadStep` into `apps/app/api.ts` as local definitions — no longer imported from the backend service module
- Remove `storeToken` / `clearToken` calls from `App.tsx` — the BFF session cookie is the sole auth mechanism; the Gitea token stored in `sessionStorage` was never read by any frontend code

## Workflow evidence

- Issue read: `gh issue view 245`
- Branch created: `git checkout -b refactor/remove-gitea-client-frontend`
- Commit SHA: `5baefe7`
- Push: `git push -u origin refactor/remove-gitea-client-frontend`
- PR creation: `gh pr create` (MCP `issue_read` and `create_branch` returned 404 — wrong owner slug)

## Test plan

- [x] `bun run test:app` — 78 tests pass, 0 fail
- [x] No remaining `gitea-client` imports in `apps/app/` or `packages/editor/`

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)