### PR TITLE
refactor(#224): async SessionBackend/SubscriptionBackend/WebhookEventBackend

### DIFF
--- a/scripts/reconcile-stripe-customer.ts
+++ b/scripts/reconcile-stripe-customer.ts
@@ -78,7 +78,7 @@ export async function runReconcileStripeCustomerCli(
   }
 
   const store = options.store ?? subscriptionStore;
-  store.upsert(result.record);
+  await store.upsert(result.record);
 
   const writeStdout =
     options.writeStdout ?? ((output: string) => process.stdout.write(output));

--- a/services/api/document-permissions.test.ts
+++ b/services/api/document-permissions.test.ts
@@ -304,7 +304,7 @@ afterEach(() => {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function seedSession(username: string): string {
+async function seedSession(username: string): Promise<string> {
   const sessionId = `sess_${randomUUID()}`;
   const giteaToken = `gitea_${randomUUID()}`;
   giteaUsersByLogin.set(username, {
@@ -312,7 +312,7 @@ function seedSession(username: string): string {
     email: `${username}@test.local`,
   });
   giteaLoginsByToken.set(giteaToken, username);
-  sessionStore.put({
+  await sessionStore.put({
     id: sessionId,
     username,
     giteaToken,
@@ -320,7 +320,7 @@ function seedSession(username: string): string {
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
   });
-  subscriptionStore.upsert({
+  await subscriptionStore.upsert({
     username,
     stripeCustomerId: `cus_${randomUUID()}`,
     stripeSubscriptionId: `sub_${randomUUID()}`,
@@ -647,7 +647,7 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
       email: `${username}@test.local`,
     });
     giteaLoginsByToken.set(giteaToken, username);
-    sessionStore.put({
+    await sessionStore.put({
       id: sessionId,
       username,
       giteaToken,
@@ -674,7 +674,7 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
 
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, {
@@ -719,7 +719,7 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "no-bp-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
 
     seedRepo(owner, repo, { isPrivate: false });
     // no seedBranchProtection — empty list
@@ -748,7 +748,7 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "public-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
 
     seedRepo(owner, repo, { isPrivate: false });
 
@@ -771,7 +771,7 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "private-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
 
     seedRepo(owner, repo, { isPrivate: true, isInternal: false });
 
@@ -798,7 +798,7 @@ describe("GET /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "internal-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
 
     seedRepo(owner, repo, { isPrivate: false, isInternal: true });
 
@@ -832,7 +832,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const repo = "shared-doc";
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, { rule_name: "main" });
-    const collabSessionId = seedSession(collaborator);
+    const collabSessionId = await seedSession(collaborator);
 
     try {
       const response = await server.fetch(
@@ -857,7 +857,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, {
       rule_name: "main",
@@ -889,7 +889,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, { rule_name: "main" });
 
@@ -928,7 +928,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, { rule_name: "main" });
 
@@ -966,7 +966,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, { rule_name: "main" });
 
@@ -993,7 +993,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: false });
     seedBranchProtection(owner, repo, { rule_name: "main" });
 
@@ -1020,7 +1020,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, {
       rule_name: "main",
@@ -1052,7 +1052,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, { rule_name: "main" });
 
@@ -1114,7 +1114,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, {
       rule_name: "main",
@@ -1146,7 +1146,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, {
       rule_name: "main",
@@ -1178,7 +1178,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, {
       rule_name: "main",
@@ -1218,7 +1218,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, {
       rule_name: "main",
@@ -1258,7 +1258,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, { rule_name: "main" });
 
@@ -1298,7 +1298,7 @@ describe("PUT /api/app/documents/:owner/:repo/permissions", () => {
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, { rule_name: "main" });
 
@@ -1349,7 +1349,7 @@ describe("GET /api/app/documents/:owner/:repo/permissions - additional scenarios
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
 
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, {
@@ -1388,7 +1388,7 @@ describe("GET /api/app/documents/:owner/:repo/permissions - additional scenarios
     const server = createApiServer();
     const owner = `owner-${randomUUID()}`;
     const repo = "my-doc";
-    const sessionId = seedSession(owner);
+    const sessionId = await seedSession(owner);
 
     seedRepo(owner, repo, { isPrivate: true });
     seedBranchProtection(owner, repo, { rule_name: "main" });
@@ -1434,7 +1434,7 @@ describe("GET /api/app/documents/:owner/:repo - public and private access", () =
     const repo = "public-doc";
 
     seedRepo(owner, repo, { isPrivate: false });
-    const nonOwnerSessionId = seedSession(nonOwner);
+    const nonOwnerSessionId = await seedSession(nonOwner);
 
     try {
       const response = await server.fetch(
@@ -1457,7 +1457,7 @@ describe("GET /api/app/documents/:owner/:repo - public and private access", () =
     const repo = "private-doc";
 
     seedRepo(owner, repo, { isPrivate: true });
-    const nonCollabSessionId = seedSession(nonCollaborator);
+    const nonCollabSessionId = await seedSession(nonCollaborator);
 
     // Override the mock fetch for this test to simulate Gitea returning 404
     // for a private repo when accessed by a non-collaborator

--- a/services/api/reconcile-stripe-customer.test.ts
+++ b/services/api/reconcile-stripe-customer.test.ts
@@ -127,7 +127,7 @@ describe("runReconcileStripeCustomerCli", () => {
         ),
       ),
     ).toBe(true);
-    expect(testStore.getByUsername(username)).toEqual({
+    expect(await testStore.getByUsername(username)).toEqual({
       username,
       stripeCustomerId: customerId,
       stripeSubscriptionId: subscriptionId,
@@ -196,7 +196,7 @@ describe("runReconcileStripeCustomerCli", () => {
         ),
       ),
     ).toBe(true);
-    expect(testStore.getByUsername(username)).toEqual({
+    expect(await testStore.getByUsername(username)).toEqual({
       username,
       stripeCustomerId: customerId,
       stripeSubscriptionId: subscriptionId,

--- a/services/api/server-search.test.ts
+++ b/services/api/server-search.test.ts
@@ -311,14 +311,14 @@ afterEach(() => {
   config.bypassSubscriptionForUsers = originalBypassSubscriptionForUsers;
 });
 
-function seedSession(
+async function seedSession(
   username: string,
   options?: {
     email?: string;
     fullName?: string;
     isAdmin?: boolean;
   },
-): string {
+): Promise<string> {
   const sessionId = `sess_${randomUUID()}`;
   const giteaToken = `gitea_token_${randomUUID()}`;
   const email =
@@ -336,7 +336,7 @@ function seedSession(
   giteaUsersByLogin.set(username, user);
   giteaUsersById.set(userId, user);
   giteaLoginsByToken.set(giteaToken, username);
-  sessionStore.put({
+  await sessionStore.put({
     id: sessionId,
     username,
     giteaToken,
@@ -397,7 +397,7 @@ function makeSessionRequest(
 describe("GET /api/app/documents with search query", () => {
   test("no query param uses listWorkspaceRepos (no filters on search)", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
 
     seedGiteaRepo({
@@ -428,7 +428,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("no query params resolves to no filters", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
 
     seedGiteaRepo({
@@ -454,7 +454,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("owner:@me resolves to session username and exclusive=true", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
 
     seedGiteaRepo({
@@ -484,7 +484,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("owner:@username resolves to specified username and exclusive=true", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const bobUser = seedGiteaUser({ login: "bob", email: "bob@example.com" });
 
     seedGiteaRepo({
@@ -511,7 +511,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("contributed-by:@me resolves to session username without exclusive", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
 
     seedGiteaRepo({
@@ -540,7 +540,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("contributed-by:@username resolves to specified username without exclusive", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const bobUser = seedGiteaUser({ login: "bob", email: "bob@example.com" });
 
     seedGiteaRepo({
@@ -567,7 +567,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("owner:@me with free text passes freeText to q param", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
 
     seedGiteaRepo({
@@ -598,7 +598,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("contributed-by:@me with free text passes freeText to q param", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
 
     seedGiteaRepo({
@@ -629,7 +629,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("both owner and contributed-by: owner takes precedence (exclusive=true)", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
     const bobUser = seedGiteaUser({ login: "bob", email: "bob@example.com" });
 
@@ -660,7 +660,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("free text without owner or contributed-by searches all repos", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
 
     seedGiteaRepo({
@@ -688,7 +688,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("@me is resolved in owner query", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const aliceUser = giteaUsersByLogin.get("alice")!;
 
     seedGiteaRepo({
@@ -716,7 +716,7 @@ describe("GET /api/app/documents with search query", () => {
 
   test("@ prefix is stripped from usernames", async () => {
     const server = await createApiServer();
-    const sessionId = seedSession("alice");
+    const sessionId = await seedSession("alice");
     const bobUser = seedGiteaUser({ login: "bob", email: "bob@example.com" });
 
     seedGiteaRepo({

--- a/services/api/server.test.ts
+++ b/services/api/server.test.ts
@@ -238,14 +238,14 @@ afterEach(() => {
   config.sessionsDbPath = originalSessionsDbPath;
 });
 
-function seedSession(
+async function seedSession(
   username: string,
   options?: {
     email?: string;
     fullName?: string;
     isAdmin?: boolean;
   },
-): string {
+): Promise<string> {
   const sessionId = `sess_${randomUUID()}`;
   const giteaToken = `gitea_token_${randomUUID()}`;
   const email =
@@ -258,7 +258,7 @@ function seedSession(
     isAdmin: options?.isAdmin === true,
   });
   giteaLoginsByToken.set(giteaToken, username);
-  sessionStore.put({
+  await sessionStore.put({
     id: sessionId,
     username,
     giteaToken,
@@ -389,7 +389,7 @@ describe("billing Stripe idempotency", () => {
   test("checkout sends a unique Stripe Idempotency-Key per attempt when no client key provided", async () => {
     const server = createApiServer();
     const username = `checkout-${randomUUID()}`;
-    const sessionId = seedSession(username);
+    const sessionId = await seedSession(username);
 
     try {
       const first = await server.fetch(
@@ -420,7 +420,7 @@ describe("billing Stripe idempotency", () => {
   test("checkout uses client-supplied idempotency key when valid", async () => {
     const server = createApiServer();
     const username = `checkout-client-key-${randomUUID()}`;
-    const sessionId = seedSession(username);
+    const sessionId = await seedSession(username);
     const clientKey = randomUUID();
 
     try {
@@ -449,7 +449,7 @@ describe("billing Stripe idempotency", () => {
   test("checkout falls back to server-generated key when client key is invalid", async () => {
     const server = createApiServer();
     const username = `checkout-invalid-key-${randomUUID()}`;
-    const sessionId = seedSession(username);
+    const sessionId = await seedSession(username);
 
     try {
       const response = await server.fetch(
@@ -475,7 +475,7 @@ describe("billing Stripe idempotency", () => {
     const server = createApiServer();
     const username = `checkout-metadata-${randomUUID()}`;
     const email = `${username}@${config.emailDomain}`;
-    const sessionId = seedSession(username, { email });
+    const sessionId = await seedSession(username, { email });
 
     try {
       const response = await server.fetch(
@@ -500,9 +500,9 @@ describe("billing Stripe idempotency", () => {
     const username = `checkout-customer-${randomUUID()}`;
     const email = `${username}@${config.emailDomain}`;
     const existingCustomerId = "cus_existing_123";
-    const sessionId = seedSession(username, { email });
+    const sessionId = await seedSession(username, { email });
 
-    subscriptionStore.upsert({
+    await subscriptionStore.upsert({
       username,
       stripeCustomerId: existingCustomerId,
       stripeSubscriptionId: "sub_existing_123",
@@ -534,9 +534,9 @@ describe("billing Stripe idempotency", () => {
   test("portal sends a unique Stripe Idempotency-Key per attempt when no client key provided", async () => {
     const server = createApiServer();
     const username = `portal-${randomUUID()}`;
-    const sessionId = seedSession(username);
+    const sessionId = await seedSession(username);
 
-    subscriptionStore.upsert({
+    await subscriptionStore.upsert({
       username,
       stripeCustomerId: "cus_test_123",
       stripeSubscriptionId: "sub_test_123",
@@ -576,10 +576,10 @@ describe("billing Stripe idempotency", () => {
   test("portal uses client-supplied idempotency key when valid", async () => {
     const server = createApiServer();
     const username = `portal-client-key-${randomUUID()}`;
-    const sessionId = seedSession(username);
+    const sessionId = await seedSession(username);
     const clientKey = randomUUID();
 
-    subscriptionStore.upsert({
+    await subscriptionStore.upsert({
       username,
       stripeCustomerId: "cus_test_456",
       stripeSubscriptionId: "sub_test_456",
@@ -738,7 +738,7 @@ describe("billing Stripe webhook recovery", () => {
       expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(
         1,
       );
-      expect(subscriptionStore.getByUsername(username)).toEqual({
+      expect(await subscriptionStore.getByUsername(username)).toEqual({
         username,
         stripeCustomerId: customerId,
         stripeSubscriptionId: subscriptionId,
@@ -789,7 +789,7 @@ describe("billing Stripe webhook recovery", () => {
       expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(
         1,
       );
-      expect(subscriptionStore.getByUsername(username)).toEqual({
+      expect(await subscriptionStore.getByUsername(username)).toEqual({
         username,
         stripeCustomerId: customerId,
         stripeSubscriptionId: subscriptionId,
@@ -841,7 +841,7 @@ describe("billing Stripe webhook recovery", () => {
       expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(
         1,
       );
-      expect(subscriptionStore.getByUsername(username)).toEqual({
+      expect(await subscriptionStore.getByUsername(username)).toEqual({
         username,
         stripeCustomerId: customerId,
         stripeSubscriptionId: subscriptionId,
@@ -908,7 +908,7 @@ describe("billing Stripe webhook recovery", () => {
       );
       expect(updateBody.get("metadata[bindersnap_username]")).toBe(username);
 
-      expect(subscriptionStore.getByUsername(username)).toEqual({
+      expect(await subscriptionStore.getByUsername(username)).toEqual({
         username,
         stripeCustomerId: customerId,
         stripeSubscriptionId: subscriptionId,
@@ -955,7 +955,7 @@ describe("billing Stripe webhook recovery", () => {
       expect(getFetchCallsByPath(`/v1/customers/${customerId}`)).toHaveLength(
         1,
       );
-      expect(subscriptionStore.getByCustomerId(customerId)).toBeNull();
+      expect(await subscriptionStore.getByCustomerId(customerId)).toBeNull();
     } finally {
       server.stop(true);
     }
@@ -965,7 +965,7 @@ describe("billing Stripe webhook recovery", () => {
 describe("admin subscription access overrides", () => {
   test("auth/me exposes the current user's admin flag", async () => {
     const server = createApiServer();
-    const sessionId = seedSession(`admin-${randomUUID()}`, {
+    const sessionId = await seedSession(`admin-${randomUUID()}`, {
       isAdmin: true,
       fullName: "Admin User",
     });
@@ -992,9 +992,9 @@ describe("admin subscription access overrides", () => {
   test("billing status reflects an admin revoke override over an active Stripe subscription", async () => {
     const server = createApiServer();
     const username = `revoked-${randomUUID()}`;
-    const sessionId = seedSession(username);
+    const sessionId = await seedSession(username);
 
-    subscriptionStore.upsert({
+    await subscriptionStore.upsert({
       username,
       stripeCustomerId: `cus_${randomUUID()}`,
       stripeSubscriptionId: `sub_${randomUUID()}`,
@@ -1004,7 +1004,7 @@ describe("admin subscription access overrides", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    subscriptionStore.putAccessOverride({
+    await subscriptionStore.putAccessOverride({
       username,
       access: "revoke",
       reason: "manual review hold",
@@ -1037,7 +1037,7 @@ describe("admin subscription access overrides", () => {
 
   test("admin list without a query includes Stripe-backed and override-only users", async () => {
     const server = createApiServer();
-    const adminSessionId = seedSession(`admin-${randomUUID()}`, {
+    const adminSessionId = await seedSession(`admin-${randomUUID()}`, {
       isAdmin: true,
     });
     const stripeUser = `stripe-${randomUUID()}`;
@@ -1052,7 +1052,7 @@ describe("admin subscription access overrides", () => {
       email: `${overrideUser}@${config.emailDomain}`,
     });
 
-    subscriptionStore.upsert({
+    await subscriptionStore.upsert({
       username: stripeUser,
       stripeCustomerId: `cus_${randomUUID()}`,
       stripeSubscriptionId: `sub_${randomUUID()}`,
@@ -1062,7 +1062,7 @@ describe("admin subscription access overrides", () => {
       cancelAt: null,
       updatedAt: Date.now() - 1_000,
     });
-    subscriptionStore.putAccessOverride({
+    await subscriptionStore.putAccessOverride({
       username: overrideUser,
       access: "grant",
       reason: "manual comp",
@@ -1103,11 +1103,11 @@ describe("admin subscription access overrides", () => {
     const server = createApiServer();
     const adminUsername = `admin-${randomUUID()}`;
     const memberUsername = `member-${randomUUID()}`;
-    const outsiderSessionId = seedSession(`outsider-${randomUUID()}`);
-    const adminSessionId = seedSession(adminUsername, { isAdmin: true });
-    const memberSessionId = seedSession(memberUsername);
+    const outsiderSessionId = await seedSession(`outsider-${randomUUID()}`);
+    const adminSessionId = await seedSession(adminUsername, { isAdmin: true });
+    const memberSessionId = await seedSession(memberUsername);
 
-    subscriptionStore.upsert({
+    await subscriptionStore.upsert({
       username: memberUsername,
       stripeCustomerId: `cus_${randomUUID()}`,
       stripeSubscriptionId: `sub_${randomUUID()}`,

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -371,15 +371,17 @@ function parseCookies(req: Request): Map<string, string> {
   return parsed;
 }
 
-function getSessionFromRequest(req: Request): SessionRecord | null {
+async function getSessionFromRequest(
+  req: Request,
+): Promise<SessionRecord | null> {
   const sessionId = parseCookies(req).get(config.sessionCookieName);
   if (!sessionId) return null;
 
-  const session = sessionStore.get(sessionId);
+  const session = await sessionStore.get(sessionId);
   if (!session) return null;
 
   if (session.expiresAt <= Date.now()) {
-    sessionStore.delete(sessionId);
+    await sessionStore.delete(sessionId);
     void revokeUserToken(session);
     return null;
   }
@@ -552,7 +554,7 @@ async function resolveDocumentAccess(
   owner: string,
   repo: string,
 ): Promise<DocumentAccessContext | Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (!(auth instanceof Response)) {
     return {
       client: auth.client,
@@ -593,11 +595,11 @@ async function resolveDocumentAccess(
   }
 }
 
-function requireSession(
+async function requireSession(
   req: Request,
   baseHeaders: Headers,
-): { session: SessionRecord; client: GiteaClient } | Response {
-  const session = getSessionFromRequest(req);
+): Promise<{ session: SessionRecord; client: GiteaClient } | Response> {
+  const session = await getSessionFromRequest(req);
   if (!session) {
     return json(401, { error: "Unauthorized." }, baseHeaders);
   }
@@ -605,11 +607,11 @@ function requireSession(
   return { session, client: createSessionGiteaClient(session) };
 }
 
-function requireSubscription(
+async function requireSubscription(
   req: Request,
   baseHeaders: Headers,
-): { session: SessionRecord; client: GiteaClient } | Response {
-  const auth = requireSession(req, baseHeaders);
+): Promise<{ session: SessionRecord; client: GiteaClient } | Response> {
+  const auth = await requireSession(req, baseHeaders);
   if (auth instanceof Response) return auth;
   if (config.bypassSubscriptionForUsers.includes(auth.session.username)) {
     logger.info("Subscription requirement bypassed for user", {
@@ -618,7 +620,7 @@ function requireSubscription(
     });
     return auth;
   }
-  if (!hasActiveSubscription(auth.session.username)) {
+  if (!(await hasActiveSubscription(auth.session.username))) {
     return json(402, { error: "Subscription required." }, baseHeaders);
   }
   return auth;
@@ -635,7 +637,7 @@ async function requireAdminSession(
     }
   | Response
 > {
-  const auth = requireSession(req, baseHeaders);
+  const auth = await requireSession(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -663,7 +665,7 @@ async function requireSubscriptionOrAdmin(
   req: Request,
   baseHeaders: Headers,
 ): Promise<{ session: SessionRecord; client: GiteaClient } | Response> {
-  const auth = requireSession(req, baseHeaders);
+  const auth = await requireSession(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -672,7 +674,7 @@ async function requireSubscriptionOrAdmin(
     return auth;
   }
 
-  if (hasActiveSubscription(auth.session.username)) {
+  if (await hasActiveSubscription(auth.session.username)) {
     return auth;
   }
 
@@ -684,17 +686,19 @@ async function requireSubscriptionOrAdmin(
   return json(402, { error: "Subscription required." }, baseHeaders);
 }
 
-function resolveSubscriptionAccessSource(
+async function resolveSubscriptionAccessSource(
   username: string,
-): "config_bypass" | "stripe" | "admin_grant" | "admin_revoke" | "none" {
+): Promise<
+  "config_bypass" | "stripe" | "admin_grant" | "admin_revoke" | "none"
+> {
   if (config.bypassSubscriptionForUsers.includes(username)) {
     return "config_bypass";
   }
 
-  return subscriptionStore.resolveAccess(username).source;
+  return (await subscriptionStore.resolveAccess(username)).source;
 }
 
-function resolveSubscriptionAccessState(username: string): {
+async function resolveSubscriptionAccessState(username: string): Promise<{
   hasAccess: boolean;
   source: "config_bypass" | "stripe" | "admin_grant" | "admin_revoke" | "none";
   status: string | null;
@@ -703,21 +707,22 @@ function resolveSubscriptionAccessState(username: string): {
   cancelAtPeriodEnd: boolean;
   cancelAt: number | null;
   override: SubscriptionAccessOverrideRecord | null;
-} {
+}> {
   if (config.bypassSubscriptionForUsers.includes(username)) {
     return {
       hasAccess: true,
       source: "config_bypass",
       status: "active",
-      stripeStatus: subscriptionStore.getByUsername(username)?.status ?? null,
+      stripeStatus:
+        (await subscriptionStore.getByUsername(username))?.status ?? null,
       currentPeriodEnd: null,
       cancelAtPeriodEnd: false,
       cancelAt: null,
-      override: subscriptionStore.getAccessOverride(username),
+      override: await subscriptionStore.getAccessOverride(username),
     };
   }
 
-  const access = subscriptionStore.resolveAccess(username);
+  const access = await subscriptionStore.resolveAccess(username);
   return {
     hasAccess: access.hasAccess,
     source: access.source,
@@ -1463,7 +1468,7 @@ async function createAuthenticatedSession(
   }
 
   const lifetime = buildSessionLifetime(rememberMe);
-  const session = createSession(
+  const session = await createSession(
     username,
     token,
     tokenName,
@@ -1627,12 +1632,12 @@ async function createGiteaUser(
   };
 }
 
-function createSession(
+async function createSession(
   username: string,
   giteaToken: string,
   giteaTokenName: string,
   expiresAt: number,
-): SessionRecord {
+): Promise<SessionRecord> {
   const now = Date.now();
   const session: SessionRecord = {
     id: randomUUID(),
@@ -1643,12 +1648,12 @@ function createSession(
     expiresAt,
   };
 
-  sessionStore.put(session);
+  await sessionStore.put(session);
   return session;
 }
 
 async function revokeAndDeleteSession(session: SessionRecord): Promise<void> {
-  sessionStore.delete(session.id);
+  await sessionStore.delete(session.id);
   await revokeUserToken(session).catch(() => undefined);
 }
 
@@ -1841,13 +1846,13 @@ async function handleLogout(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
-  const session = getSessionFromRequest(req);
+  const session = await getSessionFromRequest(req);
   if (session) {
     logger.debug("Revoking session on logout", {
       username: session.username,
       clientIp: requestClientIp(req),
     });
-    sessionStore.delete(session.id);
+    await sessionStore.delete(session.id);
     await revokeUserToken(session);
   } else {
     logger.debug("Logout called with no active session", {
@@ -1866,7 +1871,7 @@ async function handleAuthMe(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
-  const session = getSessionFromRequest(req);
+  const session = await getSessionFromRequest(req);
   if (!session) {
     logger.debug("Auth/me: no valid session found", {
       clientIp: requestClientIp(req),
@@ -1899,7 +1904,7 @@ async function handleDocuments(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -1981,7 +1986,7 @@ async function handleCreateDocument(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -2239,7 +2244,7 @@ async function handleDocumentVersions(
   owner: string,
   repo: string,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -2381,7 +2386,7 @@ async function handleDocumentReview(
   repo: string,
   prNumber: number,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -2440,7 +2445,7 @@ async function handleDocumentPublish(
   repo: string,
   prNumber: number,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -2672,10 +2677,10 @@ function accessStateUpdatedAt(access: EffectiveSubscriptionAccess): number {
   );
 }
 
-function buildAdminSubscriptionAccessEntry(
+async function buildAdminSubscriptionAccessEntry(
   user: Pick<RepoUserSummary, "login" | "full_name" | "email">,
 ) {
-  const accessState = resolveSubscriptionAccessState(user.login);
+  const accessState = await resolveSubscriptionAccessState(user.login);
 
   return {
     username: user.login,
@@ -2728,9 +2733,8 @@ async function handleAdminSubscriptionAccessList(
 
   if (query === "") {
     const offset = (page - 1) * limit;
-    const accessRows = subscriptionStore
-      .listKnownAccessStates()
-      .sort((left, right) => {
+    const accessRows = (await subscriptionStore.listKnownAccessStates()).sort(
+      (left, right) => {
         const updatedAtDiff =
           accessStateUpdatedAt(right) - accessStateUpdatedAt(left);
         if (updatedAtDiff !== 0) {
@@ -2738,14 +2742,17 @@ async function handleAdminSubscriptionAccessList(
         }
 
         return left.username.localeCompare(right.username);
-      });
+      },
+    );
     const hasMore = accessRows.length > offset + limit;
-    const users = accessRows.slice(offset, offset + limit).map((access) =>
-      buildAdminSubscriptionAccessEntry({
-        login: access.username,
-        full_name: "",
-        email: "",
-      }),
+    const users = await Promise.all(
+      accessRows.slice(offset, offset + limit).map((access) =>
+        buildAdminSubscriptionAccessEntry({
+          login: access.username,
+          full_name: "",
+          email: "",
+        }),
+      ),
     );
 
     return json(
@@ -2772,7 +2779,9 @@ async function handleAdminSubscriptionAccessList(
     return json(
       200,
       {
-        users: result.users.map(buildAdminSubscriptionAccessEntry),
+        users: await Promise.all(
+          result.users.map(buildAdminSubscriptionAccessEntry),
+        ),
         page: result.page,
         limit: result.limit,
         hasMore: result.hasMore,
@@ -2824,7 +2833,7 @@ async function handleAdminSubscriptionAccessUpdate(
   const reasonInput = readInputString(payload, null, "reason");
   const reason = reasonInput === "" ? null : reasonInput;
 
-  subscriptionStore.putAccessOverride({
+  await subscriptionStore.putAccessOverride({
     username,
     access,
     reason,
@@ -2835,7 +2844,7 @@ async function handleAdminSubscriptionAccessUpdate(
   return json(
     200,
     {
-      user: buildAdminSubscriptionAccessEntry({
+      user: await buildAdminSubscriptionAccessEntry({
         login: username,
         full_name: "",
         email: "",
@@ -2868,14 +2877,14 @@ async function handleAdminSubscriptionAccessDelete(
     );
   }
 
-  subscriptionStore.deleteAccessOverride(username);
+  await subscriptionStore.deleteAccessOverride(username);
 
   return json(
     200,
     {
       ok: true,
       username,
-      user: buildAdminSubscriptionAccessEntry({
+      user: await buildAdminSubscriptionAccessEntry({
         login: username,
         full_name: "",
         email: "",
@@ -2892,7 +2901,7 @@ async function handleAddCollaborator(
   repo: string,
   login: string,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -2962,7 +2971,7 @@ async function handleDeleteCollaborator(
   repo: string,
   login: string,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) {
     return auth;
   }
@@ -2993,7 +3002,7 @@ async function handleGetDocumentPermissions(
   owner: string,
   repo: string,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) return auth;
   const { client, session } = auth;
 
@@ -3035,7 +3044,7 @@ async function handleUpdateDocumentPermissions(
   owner: string,
   repo: string,
 ): Promise<Response> {
-  const auth = requireSubscription(req, baseHeaders);
+  const auth = await requireSubscription(req, baseHeaders);
   if (auth instanceof Response) return auth;
   const { client, session } = auth;
 
@@ -3170,7 +3179,7 @@ async function handleStripeWebhook(
 
   logger.info("Stripe webhook received", { type, eventId });
 
-  if (eventId && webhookEventStore.isProcessed(eventId)) {
+  if (eventId && (await webhookEventStore.isProcessed(eventId))) {
     logger.info("Duplicate webhook event — skipping", { eventId, type });
     return json(200, { received: true }, baseHeaders);
   }
@@ -3178,7 +3187,7 @@ async function handleStripeWebhook(
   if (
     customerId &&
     eventCreated !== undefined &&
-    webhookEventStore.isOutOfOrder(customerId, eventCreated)
+    (await webhookEventStore.isOutOfOrder(customerId, eventCreated))
   ) {
     logger.info("Out-of-order webhook event — skipping", {
       eventId,
@@ -3187,7 +3196,7 @@ async function handleStripeWebhook(
       eventCreated,
     });
     if (eventId) {
-      webhookEventStore.markProcessed(
+      await webhookEventStore.markProcessed(
         eventId,
         type ?? "unknown",
         customerId,
@@ -3205,7 +3214,7 @@ async function handleStripeWebhook(
     if (username && customerId && subscriptionId) {
       try {
         const sub = await stripe.subscriptions.retrieve(subscriptionId);
-        subscriptionStore.upsert(
+        await subscriptionStore.upsert(
           buildStripeSubscriptionRecord(
             username,
             customerId,
@@ -3262,9 +3271,9 @@ async function handleStripeWebhook(
     const customerId = data.customer as string | undefined;
     const subscriptionId = data.id as string | undefined;
     if (customerId) {
-      const record = subscriptionStore.getByCustomerId(customerId);
+      const record = await subscriptionStore.getByCustomerId(customerId);
       if (record) {
-        subscriptionStore.upsert({
+        await subscriptionStore.upsert({
           ...record,
           stripeSubscriptionId: subscriptionId ?? record.stripeSubscriptionId,
           status:
@@ -3292,7 +3301,7 @@ async function handleStripeWebhook(
           },
         );
         if (reconciled) {
-          subscriptionStore.upsert(reconciled.record);
+          await subscriptionStore.upsert(reconciled.record);
           logger.info(
             "Reconciled missing subscription row from Stripe customer metadata",
             {
@@ -3317,9 +3326,9 @@ async function handleStripeWebhook(
   } else if (type === "invoice.payment_failed" && data) {
     const customerId = data.customer as string | undefined;
     if (customerId) {
-      const record = subscriptionStore.getByCustomerId(customerId);
+      const record = await subscriptionStore.getByCustomerId(customerId);
       if (record && record.status !== "canceled") {
-        subscriptionStore.upsert({
+        await subscriptionStore.upsert({
           ...record,
           status: "past_due",
           updatedAt: Date.now(),
@@ -3332,9 +3341,9 @@ async function handleStripeWebhook(
   } else if (type === "invoice.payment_succeeded" && data) {
     const customerId = data.customer as string | undefined;
     if (customerId) {
-      const record = subscriptionStore.getByCustomerId(customerId);
+      const record = await subscriptionStore.getByCustomerId(customerId);
       if (record && record.status === "past_due") {
-        subscriptionStore.upsert({
+        await subscriptionStore.upsert({
           ...record,
           status: "active",
           updatedAt: Date.now(),
@@ -3348,7 +3357,7 @@ async function handleStripeWebhook(
   }
 
   if (eventId) {
-    webhookEventStore.markProcessed(
+    await webhookEventStore.markProcessed(
       eventId,
       type ?? "unknown",
       customerId ?? null,
@@ -3363,13 +3372,13 @@ async function handleBillingStatus(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
-  const auth = requireSession(req, baseHeaders);
+  const auth = await requireSession(req, baseHeaders);
   if (auth instanceof Response) return auth;
 
   const { username } = auth.session;
 
   const priceInfo = await fetchStripePriceInfo();
-  const accessState = resolveSubscriptionAccessState(username);
+  const accessState = await resolveSubscriptionAccessState(username);
   return json(
     200,
     {
@@ -3391,7 +3400,7 @@ async function handleBillingCheckout(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
-  const auth = requireSession(req, baseHeaders);
+  const auth = await requireSession(req, baseHeaders);
   if (auth instanceof Response) return auth;
 
   const checkoutRateLimit = consumeCheckoutRateLimit(auth.session.username);
@@ -3409,7 +3418,7 @@ async function handleBillingCheckout(
     return json(503, { error: "Billing not configured." }, baseHeaders);
   }
 
-  const existingSubscription = subscriptionStore.getByUsername(
+  const existingSubscription = await subscriptionStore.getByUsername(
     auth.session.username,
   );
   const userEmail = await fetchSessionUserEmail(auth.session);
@@ -3469,11 +3478,11 @@ async function handleDevGrantSubscription(
     return json(404, { error: "Not found." }, baseHeaders);
   }
 
-  const auth = requireSession(req, baseHeaders);
+  const auth = await requireSession(req, baseHeaders);
   if (auth instanceof Response) return auth;
 
   const { username } = auth.session;
-  subscriptionStore.upsert({
+  await subscriptionStore.upsert({
     username,
     stripeCustomerId: `cus_dev_${username}`,
     stripeSubscriptionId: `sub_dev_${username}`,
@@ -3487,8 +3496,8 @@ async function handleDevGrantSubscription(
   return json(200, { ok: true, username }, baseHeaders);
 }
 
-function buildLegacyAdminSubscriptionAccessState(username: string) {
-  const accessState = resolveSubscriptionAccessState(username);
+async function buildLegacyAdminSubscriptionAccessState(username: string) {
+  const accessState = await resolveSubscriptionAccessState(username);
 
   return {
     username,
@@ -3527,7 +3536,7 @@ async function handleAdminSubscriptionStatus(
 
   return json(
     200,
-    buildLegacyAdminSubscriptionAccessState(matchedUser.login),
+    await buildLegacyAdminSubscriptionAccessState(matchedUser.login),
     baseHeaders,
   );
 }
@@ -3555,7 +3564,7 @@ async function upsertLegacyAdminSubscriptionOverride(
     return json(404, { error: "User not found." }, baseHeaders);
   }
 
-  subscriptionStore.putAccessOverride({
+  await subscriptionStore.putAccessOverride({
     username: matchedUser.login,
     access,
     updatedBy: auth.currentUser.username,
@@ -3564,7 +3573,7 @@ async function upsertLegacyAdminSubscriptionOverride(
 
   return json(
     200,
-    buildLegacyAdminSubscriptionAccessState(matchedUser.login),
+    await buildLegacyAdminSubscriptionAccessState(matchedUser.login),
     baseHeaders,
   );
 }
@@ -3616,10 +3625,10 @@ async function handleBillingPortal(
   req: Request,
   baseHeaders: Headers,
 ): Promise<Response> {
-  const auth = requireSession(req, baseHeaders);
+  const auth = await requireSession(req, baseHeaders);
   if (auth instanceof Response) return auth;
 
-  const record = subscriptionStore.getByUsername(auth.session.username);
+  const record = await subscriptionStore.getByUsername(auth.session.username);
   if (!record) {
     return json(404, { error: "No subscription found." }, baseHeaders);
   }
@@ -3657,7 +3666,7 @@ async function handleBillingPortal(
 
 async function cleanupExpiredSessions(): Promise<void> {
   const now = Date.now();
-  const expired = sessionStore.reap(now);
+  const expired = await sessionStore.reap(now);
 
   if (expired.length > 0) {
     await Promise.allSettled(

--- a/services/api/sessions.test.ts
+++ b/services/api/sessions.test.ts
@@ -25,27 +25,27 @@ describe("SessionStore", () => {
     store = makeStore();
   });
 
-  test("put then get returns the session", () => {
+  test("put then get returns the session", async () => {
     const session = makeSession();
-    store.put(session);
-    const result = store.get(session.id);
+    await store.put(session);
+    const result = await store.get(session.id);
     expect(result).toEqual(session);
   });
 
-  test("get on unknown id returns null", () => {
-    const result = store.get("nonexistent-id");
+  test("get on unknown id returns null", async () => {
+    const result = await store.get("nonexistent-id");
     expect(result).toBeNull();
   });
 
-  test("delete removes the session", () => {
+  test("delete removes the session", async () => {
     const session = makeSession();
-    store.put(session);
-    store.delete(session.id);
-    const result = store.get(session.id);
+    await store.put(session);
+    await store.delete(session.id);
+    const result = await store.get(session.id);
     expect(result).toBeNull();
   });
 
-  test("reap removes only expired sessions and returns them", () => {
+  test("reap removes only expired sessions and returns them", async () => {
     const now = Date.now();
     const expired = makeSession({
       id: "expired-session",
@@ -56,25 +56,25 @@ describe("SessionStore", () => {
       expiresAt: now + 60_000,
     });
 
-    store.put(expired);
-    store.put(future);
+    await store.put(expired);
+    await store.put(future);
 
-    const reaped = store.reap(now);
+    const reaped = await store.reap(now);
 
     expect(reaped).toHaveLength(1);
     expect(reaped[0].id).toBe("expired-session");
 
-    expect(store.get("expired-session")).toBeNull();
-    expect(store.get("future-session")).not.toBeNull();
+    expect(await store.get("expired-session")).toBeNull();
+    expect(await store.get("future-session")).not.toBeNull();
   });
 
-  test("reap returns empty array when nothing expired", () => {
+  test("reap returns empty array when nothing expired", async () => {
     const now = Date.now();
     const future = makeSession({ expiresAt: now + 60_000 });
-    store.put(future);
+    await store.put(future);
 
-    const reaped = store.reap(now);
+    const reaped = await store.reap(now);
     expect(reaped).toHaveLength(0);
-    expect(store.get(future.id)).not.toBeNull();
+    expect(await store.get(future.id)).not.toBeNull();
   });
 });

--- a/services/api/sessions.ts
+++ b/services/api/sessions.ts
@@ -11,12 +11,14 @@ export interface SessionRecord {
 }
 
 // Backend-agnostic interface for the session store. Implementations may be
-// SQLite (current), DynamoDB (planned, see #224), or in-memory (tests).
+// SQLite (current), Postgres (planned, see #224), or in-memory (tests).
+// Async because the Postgres backend is async; SQLite wraps sync calls in
+// Promise.resolve to satisfy the interface.
 export interface SessionBackend {
-  get(id: string): SessionRecord | null;
-  put(session: SessionRecord): void;
-  delete(id: string): void;
-  reap(now: number): SessionRecord[];
+  get(id: string): Promise<SessionRecord | null>;
+  put(session: SessionRecord): Promise<void>;
+  delete(id: string): Promise<void>;
+  reap(now: number): Promise<SessionRecord[]>;
 }
 
 interface SessionRow {
@@ -58,14 +60,14 @@ export class SessionStore implements SessionBackend {
     `);
   }
 
-  get(id: string): SessionRecord | null {
+  async get(id: string): Promise<SessionRecord | null> {
     const row = this.db
       .query<SessionRow, [string]>("SELECT * FROM sessions WHERE id = ?")
       .get(id);
     return row ? rowToRecord(row) : null;
   }
 
-  put(session: SessionRecord): void {
+  async put(session: SessionRecord): Promise<void> {
     this.db
       .query<void, [string, string, string, string, number, number]>(
         `INSERT INTO sessions (id, username, gitea_token, gitea_token_name, created_at, expires_at)
@@ -87,11 +89,11 @@ export class SessionStore implements SessionBackend {
       );
   }
 
-  delete(id: string): void {
+  async delete(id: string): Promise<void> {
     this.db.query<void, [string]>("DELETE FROM sessions WHERE id = ?").run(id);
   }
 
-  reap(now: number): SessionRecord[] {
+  async reap(now: number): Promise<SessionRecord[]> {
     const rows = this.db
       .query<
         SessionRow,
@@ -129,19 +131,19 @@ class LazySessionStore implements SessionBackend {
     return this._store;
   }
 
-  get(id: string): SessionRecord | null {
+  get(id: string): Promise<SessionRecord | null> {
     return this.store.get(id);
   }
 
-  put(session: SessionRecord): void {
-    this.store.put(session);
+  put(session: SessionRecord): Promise<void> {
+    return this.store.put(session);
   }
 
-  delete(id: string): void {
-    this.store.delete(id);
+  delete(id: string): Promise<void> {
+    return this.store.delete(id);
   }
 
-  reap(now: number): SessionRecord[] {
+  reap(now: number): Promise<SessionRecord[]> {
     return this.store.reap(now);
   }
 }

--- a/services/api/stripe/webhook-idempotency.test.ts
+++ b/services/api/stripe/webhook-idempotency.test.ts
@@ -15,136 +15,153 @@ const NOW = Math.floor(Date.now() / 1000);
 const CUSTOMER = "cus_test123";
 
 describe("WebhookEventStore — idempotency", () => {
-  it("isProcessed returns false for unknown event", () => {
+  it("isProcessed returns false for unknown event", async () => {
     const store = makeWebhookStore();
-    expect(store.isProcessed("evt_new")).toBe(false);
+    expect(await store.isProcessed("evt_new")).toBe(false);
   });
 
-  it("isProcessed returns true after markProcessed", () => {
+  it("isProcessed returns true after markProcessed", async () => {
     const store = makeWebhookStore();
-    store.markProcessed("evt_1", "checkout.session.completed", CUSTOMER, NOW);
-    expect(store.isProcessed("evt_1")).toBe(true);
+    await store.markProcessed(
+      "evt_1",
+      "checkout.session.completed",
+      CUSTOMER,
+      NOW,
+    );
+    expect(await store.isProcessed("evt_1")).toBe(true);
   });
 
-  it("markProcessed is idempotent — second call does not throw", () => {
+  it("markProcessed is idempotent — second call does not throw", async () => {
     const store = makeWebhookStore();
-    store.markProcessed(
+    await store.markProcessed(
       "evt_dup",
       "customer.subscription.updated",
       CUSTOMER,
       NOW,
     );
-    expect(() =>
+    await expect(
       store.markProcessed(
         "evt_dup",
         "customer.subscription.updated",
         CUSTOMER,
         NOW,
       ),
-    ).not.toThrow();
-    expect(store.isProcessed("evt_dup")).toBe(true);
+    ).resolves.toBeUndefined();
+    expect(await store.isProcessed("evt_dup")).toBe(true);
   });
 
-  it("different event IDs are independent", () => {
+  it("different event IDs are independent", async () => {
     const store = makeWebhookStore();
-    store.markProcessed("evt_a", "invoice.payment_failed", CUSTOMER, NOW);
-    expect(store.isProcessed("evt_a")).toBe(true);
-    expect(store.isProcessed("evt_b")).toBe(false);
+    await store.markProcessed("evt_a", "invoice.payment_failed", CUSTOMER, NOW);
+    expect(await store.isProcessed("evt_a")).toBe(true);
+    expect(await store.isProcessed("evt_b")).toBe(false);
   });
 
-  it("null customerId is accepted", () => {
+  it("null customerId is accepted", async () => {
     const store = makeWebhookStore();
-    store.markProcessed("evt_no_cust", "checkout.session.completed", null, NOW);
-    expect(store.isProcessed("evt_no_cust")).toBe(true);
+    await store.markProcessed(
+      "evt_no_cust",
+      "checkout.session.completed",
+      null,
+      NOW,
+    );
+    expect(await store.isProcessed("evt_no_cust")).toBe(true);
   });
 });
 
 describe("WebhookEventStore — out-of-order protection", () => {
-  it("isOutOfOrder returns false when no prior state for customer", () => {
+  it("isOutOfOrder returns false when no prior state for customer", async () => {
     const store = makeWebhookStore();
-    expect(store.isOutOfOrder(CUSTOMER, NOW)).toBe(false);
+    expect(await store.isOutOfOrder(CUSTOMER, NOW)).toBe(false);
   });
 
-  it("isOutOfOrder returns false when event is newer than recorded", () => {
+  it("isOutOfOrder returns false when event is newer than recorded", async () => {
     const store = makeWebhookStore();
-    store.markProcessed(
+    await store.markProcessed(
       "evt_first",
       "customer.subscription.updated",
       CUSTOMER,
       NOW,
     );
-    expect(store.isOutOfOrder(CUSTOMER, NOW + 1)).toBe(false);
+    expect(await store.isOutOfOrder(CUSTOMER, NOW + 1)).toBe(false);
   });
 
-  it("isOutOfOrder returns false when event is same timestamp as recorded", () => {
+  it("isOutOfOrder returns false when event is same timestamp as recorded", async () => {
     const store = makeWebhookStore();
-    store.markProcessed(
+    await store.markProcessed(
       "evt_same",
       "customer.subscription.updated",
       CUSTOMER,
       NOW,
     );
-    expect(store.isOutOfOrder(CUSTOMER, NOW)).toBe(false);
+    expect(await store.isOutOfOrder(CUSTOMER, NOW)).toBe(false);
   });
 
-  it("isOutOfOrder returns true when event is strictly older than recorded", () => {
+  it("isOutOfOrder returns true when event is strictly older than recorded", async () => {
     const store = makeWebhookStore();
-    store.markProcessed(
+    await store.markProcessed(
       "evt_newer",
       "customer.subscription.updated",
       CUSTOMER,
       NOW + 10,
     );
-    expect(store.isOutOfOrder(CUSTOMER, NOW + 5)).toBe(true);
+    expect(await store.isOutOfOrder(CUSTOMER, NOW + 5)).toBe(true);
   });
 
-  it("last_event_created_at advances to MAX — older event does not roll it back", () => {
+  it("last_event_created_at advances to MAX — older event does not roll it back", async () => {
     const store = makeWebhookStore();
-    store.markProcessed(
+    await store.markProcessed(
       "evt_t10",
       "customer.subscription.updated",
       CUSTOMER,
       NOW + 10,
     );
-    store.markProcessed("evt_t5", "invoice.payment_failed", CUSTOMER, NOW + 5);
+    await store.markProcessed(
+      "evt_t5",
+      "invoice.payment_failed",
+      CUSTOMER,
+      NOW + 5,
+    );
     // After inserting an older event, the newer timestamp is preserved
-    expect(store.isOutOfOrder(CUSTOMER, NOW + 8)).toBe(true);
+    expect(await store.isOutOfOrder(CUSTOMER, NOW + 8)).toBe(true);
   });
 
-  it("different customers have independent state", () => {
+  it("different customers have independent state", async () => {
     const store = makeWebhookStore();
     const cust1 = "cus_aaa";
     const cust2 = "cus_bbb";
-    store.markProcessed(
+    await store.markProcessed(
       "evt_c1",
       "customer.subscription.updated",
       cust1,
       NOW + 100,
     );
     // cust2 has no state yet
-    expect(store.isOutOfOrder(cust2, NOW)).toBe(false);
+    expect(await store.isOutOfOrder(cust2, NOW)).toBe(false);
     // cust1 would reject an older event
-    expect(store.isOutOfOrder(cust1, NOW)).toBe(true);
+    expect(await store.isOutOfOrder(cust1, NOW)).toBe(true);
   });
 });
 
 describe("Webhook idempotency — duplicate delivery produces single side effect", () => {
-  it("processing same checkout.session.completed twice leaves one subscription record", () => {
+  it("processing same checkout.session.completed twice leaves one subscription record", async () => {
     const subStore = makeSubStore();
     const whStore = makeWebhookStore();
     const EVENT_ID = "evt_checkout_dup";
 
-    function processCheckout() {
-      if (whStore.isProcessed(EVENT_ID)) return false;
-      subStore.upsert({
+    async function processCheckout() {
+      if (await whStore.isProcessed(EVENT_ID)) return false;
+      await subStore.upsert({
         username: "alice",
         stripeCustomerId: CUSTOMER,
         stripeSubscriptionId: "sub_1",
         status: "active",
         currentPeriodEnd: NOW + 30 * 86400,
+        cancelAtPeriodEnd: false,
+        cancelAt: null,
         updatedAt: Date.now(),
       });
-      whStore.markProcessed(
+      await whStore.markProcessed(
         EVENT_ID,
         "checkout.session.completed",
         CUSTOMER,
@@ -153,17 +170,17 @@ describe("Webhook idempotency — duplicate delivery produces single side effect
       return true;
     }
 
-    const first = processCheckout();
-    const second = processCheckout();
+    const first = await processCheckout();
+    const second = await processCheckout();
 
     expect(first).toBe(true);
     expect(second).toBe(false);
-    expect(subStore.getByUsername("alice")?.status).toBe("active");
+    expect((await subStore.getByUsername("alice"))?.status).toBe("active");
   });
 });
 
 describe("Webhook out-of-order — past_due-after-active stays active", () => {
-  it("late-arriving past_due event after active is rejected; state remains active", () => {
+  it("late-arriving past_due event after active is rejected; state remains active", async () => {
     const subStore = makeSubStore();
     const whStore = makeWebhookStore();
 
@@ -171,7 +188,7 @@ describe("Webhook out-of-order — past_due-after-active stays active", () => {
     const T_PAST_DUE = NOW + 50; // earlier timestamp — arrives second (late)
 
     // 1. Process the active event (arrives first, as expected)
-    subStore.upsert({
+    await subStore.upsert({
       username: "bob",
       stripeCustomerId: CUSTOMER,
       stripeSubscriptionId: "sub_2",
@@ -181,7 +198,7 @@ describe("Webhook out-of-order — past_due-after-active stays active", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    whStore.markProcessed(
+    await whStore.markProcessed(
       "evt_active",
       "customer.subscription.updated",
       CUSTOMER,
@@ -189,26 +206,30 @@ describe("Webhook out-of-order — past_due-after-active stays active", () => {
     );
 
     // 2. Out-of-order past_due arrives — should be rejected
-    const isOOO = whStore.isOutOfOrder(CUSTOMER, T_PAST_DUE);
+    const isOOO = await whStore.isOutOfOrder(CUSTOMER, T_PAST_DUE);
     expect(isOOO).toBe(true);
 
     if (!isOOO) {
       // Would have executed side effect (not reached in this test)
-      const record = subStore.getByUsername("bob")!;
-      subStore.upsert({ ...record, status: "past_due", updatedAt: Date.now() });
+      const record = (await subStore.getByUsername("bob"))!;
+      await subStore.upsert({
+        ...record,
+        status: "past_due",
+        updatedAt: Date.now(),
+      });
     }
 
     // State must remain active
-    expect(subStore.getByUsername("bob")?.status).toBe("active");
+    expect((await subStore.getByUsername("bob"))?.status).toBe("active");
   });
 });
 
 describe("Webhook cancel_at_period_end — persisted and reflected in record", () => {
-  it("subscription.updated with cancel_at_period_end=true persists fields", () => {
+  it("subscription.updated with cancel_at_period_end=true persists fields", async () => {
     const subStore = makeSubStore();
     const CANCEL_AT = NOW + 30 * 86400;
 
-    subStore.upsert({
+    await subStore.upsert({
       username: "dana",
       stripeCustomerId: CUSTOMER,
       stripeSubscriptionId: "sub_cancel",
@@ -220,25 +241,25 @@ describe("Webhook cancel_at_period_end — persisted and reflected in record", (
     });
 
     // Simulate webhook handler updating with cancel_at_period_end=true
-    const record = subStore.getByCustomerId(CUSTOMER)!;
-    subStore.upsert({
+    const record = (await subStore.getByCustomerId(CUSTOMER))!;
+    await subStore.upsert({
       ...record,
       cancelAtPeriodEnd: true,
       cancelAt: CANCEL_AT,
       updatedAt: Date.now(),
     });
 
-    const updated = subStore.getByUsername("dana");
+    const updated = await subStore.getByUsername("dana");
     expect(updated?.cancelAtPeriodEnd).toBe(true);
     expect(updated?.cancelAt).toBe(CANCEL_AT);
     expect(updated?.status).toBe("active");
   });
 
-  it("subscription.updated clearing cancel_at_period_end resets fields", () => {
+  it("subscription.updated clearing cancel_at_period_end resets fields", async () => {
     const subStore = makeSubStore();
     const CANCEL_AT = NOW + 30 * 86400;
 
-    subStore.upsert({
+    await subStore.upsert({
       username: "evan",
       stripeCustomerId: "cus_evan",
       stripeSubscriptionId: "sub_evan",
@@ -249,15 +270,15 @@ describe("Webhook cancel_at_period_end — persisted and reflected in record", (
       updatedAt: Date.now(),
     });
 
-    const record = subStore.getByCustomerId("cus_evan")!;
-    subStore.upsert({
+    const record = (await subStore.getByCustomerId("cus_evan"))!;
+    await subStore.upsert({
       ...record,
       cancelAtPeriodEnd: false,
       cancelAt: null,
       updatedAt: Date.now(),
     });
 
-    const updated = subStore.getByUsername("evan");
+    const updated = await subStore.getByUsername("evan");
     expect(updated?.cancelAtPeriodEnd).toBe(false);
     expect(updated?.cancelAt).toBeNull();
   });

--- a/services/api/subscriptions.test.ts
+++ b/services/api/subscriptions.test.ts
@@ -20,7 +20,9 @@ function makeTempDbPath() {
   };
 }
 
-function captureStdout<T>(run: () => T): { result: T; output: string } {
+async function captureStdout<T>(
+  run: () => T | Promise<T>,
+): Promise<{ result: T; output: string }> {
   const writes: string[] = [];
   const originalWrite = process.stdout.write;
 
@@ -43,7 +45,7 @@ function captureStdout<T>(run: () => T): { result: T; output: string } {
   };
 
   try {
-    return { result: run(), output: writes.join("") };
+    return { result: await run(), output: writes.join("") };
   } finally {
     (process.stdout as { write: typeof process.stdout.write }).write =
       originalWrite;
@@ -56,9 +58,9 @@ const recentEnd = now - 1 * 24 * 60 * 60; // 1 day ago (within buffer)
 const expiredEnd = now - 4 * 24 * 60 * 60; // 4 days ago (past 3-day buffer)
 
 describe("SubscriptionStore", () => {
-  it("upserts and retrieves by username", () => {
+  it("upserts and retrieves by username", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "alice",
       stripeCustomerId: "cus_1",
       stripeSubscriptionId: "sub_1",
@@ -68,14 +70,14 @@ describe("SubscriptionStore", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("alice");
+    const record = await store.getByUsername("alice");
     expect(record?.status).toBe("active");
     expect(record?.stripeCustomerId).toBe("cus_1");
   });
 
-  it("upserts and retrieves by customer ID", () => {
+  it("upserts and retrieves by customer ID", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "bob",
       stripeCustomerId: "cus_2",
       stripeSubscriptionId: "sub_2",
@@ -85,13 +87,13 @@ describe("SubscriptionStore", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByCustomerId("cus_2");
+    const record = await store.getByCustomerId("cus_2");
     expect(record?.username).toBe("bob");
   });
 
-  it("updates on conflict", () => {
+  it("updates on conflict", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "carol",
       stripeCustomerId: "cus_3",
       stripeSubscriptionId: "sub_3",
@@ -101,7 +103,7 @@ describe("SubscriptionStore", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    store.upsert({
+    await store.upsert({
       username: "carol",
       stripeCustomerId: "cus_3",
       stripeSubscriptionId: "sub_3",
@@ -111,13 +113,13 @@ describe("SubscriptionStore", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("carol");
+    const record = await store.getByUsername("carol");
     expect(record?.status).toBe("canceled");
   });
 
-  it("rebinds a username to a new stripe customer and clears the old customer lookup", () => {
+  it("rebinds a username to a new stripe customer and clears the old customer lookup", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "carol",
       stripeCustomerId: "cus_old",
       stripeSubscriptionId: "sub_old",
@@ -128,7 +130,7 @@ describe("SubscriptionStore", () => {
       updatedAt: 1,
     });
 
-    store.upsert({
+    await store.upsert({
       username: "carol",
       stripeCustomerId: "cus_new",
       stripeSubscriptionId: "sub_new",
@@ -139,16 +141,16 @@ describe("SubscriptionStore", () => {
       updatedAt: 2,
     });
 
-    expect(store.getByCustomerId("cus_old")).toBeNull();
+    expect(await store.getByCustomerId("cus_old")).toBeNull();
 
-    const rebound = store.getByCustomerId("cus_new");
+    const rebound = await store.getByCustomerId("cus_new");
     expect(rebound?.username).toBe("carol");
     expect(rebound?.stripeSubscriptionId).toBe("sub_new");
   });
 
-  it("replaces all persisted billing fields on username conflict", () => {
+  it("replaces all persisted billing fields on username conflict", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "drew",
       stripeCustomerId: "cus_drew_1",
       stripeSubscriptionId: "sub_drew_1",
@@ -159,7 +161,7 @@ describe("SubscriptionStore", () => {
       updatedAt: 10,
     });
 
-    store.upsert({
+    await store.upsert({
       username: "drew",
       stripeCustomerId: "cus_drew_2",
       stripeSubscriptionId: "sub_drew_2",
@@ -170,7 +172,7 @@ describe("SubscriptionStore", () => {
       updatedAt: 20,
     });
 
-    const record = store.getByUsername("drew");
+    const record = await store.getByUsername("drew");
     expect(record).toEqual({
       username: "drew",
       stripeCustomerId: "cus_drew_2",
@@ -183,14 +185,14 @@ describe("SubscriptionStore", () => {
     });
   });
 
-  it("returns null for unknown username", () => {
+  it("returns null for unknown username", async () => {
     const store = makeStore();
-    expect(store.getByUsername("nobody")).toBeNull();
+    expect(await store.getByUsername("nobody")).toBeNull();
   });
 
-  it("rejects rebinding an existing Stripe customer to a different username", () => {
+  it("rejects rebinding an existing Stripe customer to a different username", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "alice",
       stripeCustomerId: "cus_shared",
       stripeSubscriptionId: "sub_alice",
@@ -201,8 +203,8 @@ describe("SubscriptionStore", () => {
       updatedAt: 100,
     });
 
-    const { output } = captureStdout(() => {
-      expect(() =>
+    const { output } = await captureStdout(async () => {
+      await expect(
         store.upsert({
           username: "bob",
           stripeCustomerId: "cus_shared",
@@ -213,17 +215,17 @@ describe("SubscriptionStore", () => {
           cancelAt: null,
           updatedAt: 101,
         }),
-      ).toThrow(/already bound to alice/i);
+      ).rejects.toThrow(/already bound to alice/i);
     });
 
-    expect(store.getByCustomerId("cus_shared")?.username).toBe("alice");
-    expect(store.getByUsername("bob")).toBeNull();
+    expect((await store.getByCustomerId("cus_shared"))?.username).toBe("alice");
+    expect(await store.getByUsername("bob")).toBeNull();
     expect(output).toContain("Rejected Stripe customer rebind attempt");
     expect(output).toContain('"existingUsername":"alice"');
     expect(output).toContain('"attemptedUsername":"bob"');
   });
 
-  it("deduplicates legacy customer bindings during migration and recreates the unique index", () => {
+  it("deduplicates legacy customer bindings during migration and recreates the unique index", async () => {
     const tempDb = makeTempDbPath();
 
     try {
@@ -298,12 +300,12 @@ describe("SubscriptionStore", () => {
         );
       legacyDb.close();
 
-      const { result: store, output } = captureStdout(
+      const { result: store, output } = await captureStdout(
         () => new SubscriptionStore(tempDb.path),
       );
 
-      expect(store.getByUsername("alice")).toBeNull();
-      expect(store.getByCustomerId("cus_dup")).toEqual({
+      expect(await store.getByUsername("alice")).toBeNull();
+      expect(await store.getByCustomerId("cus_dup")).toEqual({
         username: "bob",
         stripeCustomerId: "cus_dup",
         stripeSubscriptionId: "sub_new",
@@ -351,9 +353,9 @@ describe("hasActiveSubscription — expiry logic", () => {
   //
   // For the expiry tests we import and call a fresh store directly.
 
-  it("active with future currentPeriodEnd → active", () => {
+  it("active with future currentPeriodEnd → active", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "u1",
       stripeCustomerId: "cus_u1",
       stripeSubscriptionId: "sub_u1",
@@ -363,7 +365,7 @@ describe("hasActiveSubscription — expiry logic", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("u1");
+    const record = await store.getByUsername("u1");
     expect(record?.status).toBe("active");
     // Verify the expiry guard logic directly:
     const bufferSeconds = 3 * 24 * 60 * 60;
@@ -373,9 +375,9 @@ describe("hasActiveSubscription — expiry logic", () => {
     expect(expired).toBe(false);
   });
 
-  it("active with currentPeriodEnd 4 days ago → expired (beyond 3-day buffer)", () => {
+  it("active with currentPeriodEnd 4 days ago → expired (beyond 3-day buffer)", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "u2",
       stripeCustomerId: "cus_u2",
       stripeSubscriptionId: "sub_u2",
@@ -385,7 +387,7 @@ describe("hasActiveSubscription — expiry logic", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("u2");
+    const record = await store.getByUsername("u2");
     const bufferSeconds = 3 * 24 * 60 * 60;
     const expired =
       record!.currentPeriodEnd !== null &&
@@ -393,9 +395,9 @@ describe("hasActiveSubscription — expiry logic", () => {
     expect(expired).toBe(true);
   });
 
-  it("active with currentPeriodEnd 1 day ago → still valid (within 3-day buffer)", () => {
+  it("active with currentPeriodEnd 1 day ago → still valid (within 3-day buffer)", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "u3",
       stripeCustomerId: "cus_u3",
       stripeSubscriptionId: "sub_u3",
@@ -405,7 +407,7 @@ describe("hasActiveSubscription — expiry logic", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("u3");
+    const record = await store.getByUsername("u3");
     const bufferSeconds = 3 * 24 * 60 * 60;
     const expired =
       record!.currentPeriodEnd !== null &&
@@ -413,9 +415,9 @@ describe("hasActiveSubscription — expiry logic", () => {
     expect(expired).toBe(false);
   });
 
-  it("active with null currentPeriodEnd → not expired", () => {
+  it("active with null currentPeriodEnd → not expired", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "u4",
       stripeCustomerId: "cus_u4",
       stripeSubscriptionId: "sub_u4",
@@ -425,7 +427,7 @@ describe("hasActiveSubscription — expiry logic", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("u4");
+    const record = await store.getByUsername("u4");
     const bufferSeconds = 3 * 24 * 60 * 60;
     const expired =
       record!.currentPeriodEnd !== null &&
@@ -433,9 +435,9 @@ describe("hasActiveSubscription — expiry logic", () => {
     expect(expired).toBe(false);
   });
 
-  it("trialing with future currentPeriodEnd → not expired", () => {
+  it("trialing with future currentPeriodEnd → not expired", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "u5",
       stripeCustomerId: "cus_u5",
       stripeSubscriptionId: "sub_u5",
@@ -445,7 +447,7 @@ describe("hasActiveSubscription — expiry logic", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("u5");
+    const record = await store.getByUsername("u5");
     expect(record?.status).toBe("trialing");
     const bufferSeconds = 3 * 24 * 60 * 60;
     const expired =
@@ -454,9 +456,9 @@ describe("hasActiveSubscription — expiry logic", () => {
     expect(expired).toBe(false);
   });
 
-  it("past_due status → not active regardless of period end", () => {
+  it("past_due status → not active regardless of period end", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "u6",
       stripeCustomerId: "cus_u6",
       stripeSubscriptionId: "sub_u6",
@@ -466,15 +468,15 @@ describe("hasActiveSubscription — expiry logic", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("u6");
+    const record = await store.getByUsername("u6");
     expect(record?.status === "active" || record?.status === "trialing").toBe(
       false,
     );
   });
 
-  it("canceled status → not active", () => {
+  it("canceled status → not active", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "u7",
       stripeCustomerId: "cus_u7",
       stripeSubscriptionId: "sub_u7",
@@ -484,23 +486,23 @@ describe("hasActiveSubscription — expiry logic", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("u7");
+    const record = await store.getByUsername("u7");
     expect(record?.status === "active" || record?.status === "trialing").toBe(
       false,
     );
   });
 
-  it("no record → not active", () => {
+  it("no record → not active", async () => {
     const store = makeStore();
-    expect(store.getByUsername("nonexistent")).toBeNull();
+    expect(await store.getByUsername("nonexistent")).toBeNull();
   });
 });
 
 describe("SubscriptionStore — cancel_at_period_end", () => {
-  it("persists cancelAtPeriodEnd=true and cancelAt timestamp", () => {
+  it("persists cancelAtPeriodEnd=true and cancelAt timestamp", async () => {
     const store = makeStore();
     const cancelTs = futureEnd;
-    store.upsert({
+    await store.upsert({
       username: "v1",
       stripeCustomerId: "cus_v1",
       stripeSubscriptionId: "sub_v1",
@@ -510,14 +512,14 @@ describe("SubscriptionStore — cancel_at_period_end", () => {
       cancelAt: cancelTs,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("v1");
+    const record = await store.getByUsername("v1");
     expect(record?.cancelAtPeriodEnd).toBe(true);
     expect(record?.cancelAt).toBe(cancelTs);
   });
 
-  it("cancelAtPeriodEnd defaults to false when stored as 0", () => {
+  it("cancelAtPeriodEnd defaults to false when stored as 0", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "v2",
       stripeCustomerId: "cus_v2",
       stripeSubscriptionId: "sub_v2",
@@ -527,14 +529,14 @@ describe("SubscriptionStore — cancel_at_period_end", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("v2");
+    const record = await store.getByUsername("v2");
     expect(record?.cancelAtPeriodEnd).toBe(false);
     expect(record?.cancelAt).toBeNull();
   });
 
-  it("upsert clears cancelAtPeriodEnd when subscription renews", () => {
+  it("upsert clears cancelAtPeriodEnd when subscription renews", async () => {
     const store = makeStore();
-    store.upsert({
+    await store.upsert({
       username: "v3",
       stripeCustomerId: "cus_v3",
       stripeSubscriptionId: "sub_v3",
@@ -544,7 +546,7 @@ describe("SubscriptionStore — cancel_at_period_end", () => {
       cancelAt: futureEnd,
       updatedAt: Date.now(),
     });
-    store.upsert({
+    await store.upsert({
       username: "v3",
       stripeCustomerId: "cus_v3",
       stripeSubscriptionId: "sub_v3",
@@ -554,17 +556,17 @@ describe("SubscriptionStore — cancel_at_period_end", () => {
       cancelAt: null,
       updatedAt: Date.now(),
     });
-    const record = store.getByUsername("v3");
+    const record = await store.getByUsername("v3");
     expect(record?.cancelAtPeriodEnd).toBe(false);
     expect(record?.cancelAt).toBeNull();
   });
 });
 
 describe("SubscriptionStore — admin overrides", () => {
-  it("persists override reason and updater metadata", () => {
+  it("persists override reason and updater metadata", async () => {
     const store = makeStore();
 
-    store.putAccessOverride({
+    await store.putAccessOverride({
       username: "override-user",
       access: "grant",
       reason: "manual comp",
@@ -572,7 +574,7 @@ describe("SubscriptionStore — admin overrides", () => {
       updatedAt: 123,
     });
 
-    expect(store.getAccessOverride("override-user")).toEqual({
+    expect(await store.getAccessOverride("override-user")).toEqual({
       username: "override-user",
       access: "grant",
       reason: "manual comp",
@@ -581,10 +583,10 @@ describe("SubscriptionStore — admin overrides", () => {
     });
   });
 
-  it("revoke overrides Stripe-backed access until the override is removed", () => {
+  it("revoke overrides Stripe-backed access until the override is removed", async () => {
     const store = makeStore();
 
-    store.upsert({
+    await store.upsert({
       username: "stripe-user",
       stripeCustomerId: "cus_override",
       stripeSubscriptionId: "sub_override",
@@ -594,7 +596,7 @@ describe("SubscriptionStore — admin overrides", () => {
       cancelAt: null,
       updatedAt: 100,
     });
-    store.putAccessOverride({
+    await store.putAccessOverride({
       username: "stripe-user",
       access: "revoke",
       reason: "manual review hold",
@@ -602,7 +604,7 @@ describe("SubscriptionStore — admin overrides", () => {
       updatedAt: 200,
     });
 
-    expect(store.resolveAccess("stripe-user")).toEqual({
+    expect(await store.resolveAccess("stripe-user")).toEqual({
       username: "stripe-user",
       hasAccess: false,
       source: "admin_revoke",
@@ -618,9 +620,9 @@ describe("SubscriptionStore — admin overrides", () => {
       },
     });
 
-    store.deleteAccessOverride("stripe-user");
+    await store.deleteAccessOverride("stripe-user");
 
-    expect(store.resolveAccess("stripe-user")).toEqual({
+    expect(await store.resolveAccess("stripe-user")).toEqual({
       username: "stripe-user",
       hasAccess: true,
       source: "stripe",
@@ -631,10 +633,10 @@ describe("SubscriptionStore — admin overrides", () => {
     });
   });
 
-  it("lists known access states for Stripe-only and override-only users", () => {
+  it("lists known access states for Stripe-only and override-only users", async () => {
     const store = makeStore();
 
-    store.upsert({
+    await store.upsert({
       username: "stripe-only",
       stripeCustomerId: "cus_list",
       stripeSubscriptionId: "sub_list",
@@ -644,7 +646,7 @@ describe("SubscriptionStore — admin overrides", () => {
       cancelAt: null,
       updatedAt: 10,
     });
-    store.putAccessOverride({
+    await store.putAccessOverride({
       username: "override-only",
       access: "grant",
       reason: null,
@@ -652,7 +654,7 @@ describe("SubscriptionStore — admin overrides", () => {
       updatedAt: 20,
     });
 
-    expect(store.listKnownAccessStates()).toEqual(
+    expect(await store.listKnownAccessStates()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           username: "override-only",

--- a/services/api/subscriptions.ts
+++ b/services/api/subscriptions.ts
@@ -107,27 +107,29 @@ function hasStripeBackedAccess(record: SubscriptionRecord | null): boolean {
 // secondary-index lookup, UNION across two tables, and a uniqueness invariant
 // enforced via transaction.
 export interface SubscriptionBackend {
-  getByUsername(username: string): SubscriptionRecord | null;
-  getByCustomerId(customerId: string): SubscriptionRecord | null;
-  upsert(record: SubscriptionRecord): void;
-  getAccessOverride(username: string): SubscriptionAccessOverrideRecord | null;
-  putAccessOverride(record: SubscriptionAccessOverrideRecord): void;
-  deleteAccessOverride(username: string): void;
-  resolveAccess(username: string): EffectiveSubscriptionAccess;
-  listKnownAccessStates(): EffectiveSubscriptionAccess[];
+  getByUsername(username: string): Promise<SubscriptionRecord | null>;
+  getByCustomerId(customerId: string): Promise<SubscriptionRecord | null>;
+  upsert(record: SubscriptionRecord): Promise<void>;
+  getAccessOverride(
+    username: string,
+  ): Promise<SubscriptionAccessOverrideRecord | null>;
+  putAccessOverride(record: SubscriptionAccessOverrideRecord): Promise<void>;
+  deleteAccessOverride(username: string): Promise<void>;
+  resolveAccess(username: string): Promise<EffectiveSubscriptionAccess>;
+  listKnownAccessStates(): Promise<EffectiveSubscriptionAccess[]>;
 }
 
 // Backend-agnostic interface for Stripe webhook idempotency + ordering checks.
-// SQLite today; DynamoDB or Postgres viable — pure key-value with TTL.
+// SQLite today; Postgres planned — pure key-value with TTL.
 export interface WebhookEventBackend {
-  isProcessed(eventId: string): boolean;
-  isOutOfOrder(customerId: string, eventCreated: number): boolean;
+  isProcessed(eventId: string): Promise<boolean>;
+  isOutOfOrder(customerId: string, eventCreated: number): Promise<boolean>;
   markProcessed(
     eventId: string,
     eventType: string,
     customerId: string | null,
     eventCreated: number,
-  ): void;
+  ): Promise<void>;
 }
 
 export class SubscriptionCustomerConflictError extends Error {
@@ -171,7 +173,7 @@ export class SubscriptionStore implements SubscriptionBackend {
     this.enforceUniqueCustomerBindings();
   }
 
-  getByUsername(username: string): SubscriptionRecord | null {
+  async getByUsername(username: string): Promise<SubscriptionRecord | null> {
     const row = this.db
       .query<
         SubscriptionRow,
@@ -181,7 +183,9 @@ export class SubscriptionStore implements SubscriptionBackend {
     return row ? rowToRecord(row) : null;
   }
 
-  getByCustomerId(customerId: string): SubscriptionRecord | null {
+  async getByCustomerId(
+    customerId: string,
+  ): Promise<SubscriptionRecord | null> {
     const row = this.db
       .query<
         SubscriptionRow,
@@ -191,8 +195,8 @@ export class SubscriptionStore implements SubscriptionBackend {
     return row ? rowToRecord(row) : null;
   }
 
-  upsert(record: SubscriptionRecord): void {
-    const existingCustomerRecord = this.getByCustomerId(
+  async upsert(record: SubscriptionRecord): Promise<void> {
+    const existingCustomerRecord = await this.getByCustomerId(
       record.stripeCustomerId,
     );
     if (
@@ -250,7 +254,9 @@ export class SubscriptionStore implements SubscriptionBackend {
       );
   }
 
-  getAccessOverride(username: string): SubscriptionAccessOverrideRecord | null {
+  async getAccessOverride(
+    username: string,
+  ): Promise<SubscriptionAccessOverrideRecord | null> {
     const row = this.db
       .query<
         SubscriptionAccessOverrideRow,
@@ -260,7 +266,9 @@ export class SubscriptionStore implements SubscriptionBackend {
     return row ? rowToOverride(row) : null;
   }
 
-  putAccessOverride(record: SubscriptionAccessOverrideRecord): void {
+  async putAccessOverride(
+    record: SubscriptionAccessOverrideRecord,
+  ): Promise<void> {
     this.db
       .query<
         void,
@@ -283,7 +291,7 @@ export class SubscriptionStore implements SubscriptionBackend {
       );
   }
 
-  deleteAccessOverride(username: string): void {
+  async deleteAccessOverride(username: string): Promise<void> {
     this.db
       .query<
         void,
@@ -292,9 +300,9 @@ export class SubscriptionStore implements SubscriptionBackend {
       .run(username);
   }
 
-  resolveAccess(username: string): EffectiveSubscriptionAccess {
-    const subscription = this.getByUsername(username);
-    const override = this.getAccessOverride(username);
+  async resolveAccess(username: string): Promise<EffectiveSubscriptionAccess> {
+    const subscription = await this.getByUsername(username);
+    const override = await this.getAccessOverride(username);
 
     if (override?.access === "grant") {
       return {
@@ -335,7 +343,7 @@ export class SubscriptionStore implements SubscriptionBackend {
     };
   }
 
-  listKnownAccessStates(): EffectiveSubscriptionAccess[] {
+  async listKnownAccessStates(): Promise<EffectiveSubscriptionAccess[]> {
     const usernames = this.db
       .query<{ username: string }, []>(
         `SELECT username
@@ -348,7 +356,9 @@ export class SubscriptionStore implements SubscriptionBackend {
       .all()
       .map((row) => row.username);
 
-    return usernames.map((username) => this.resolveAccess(username));
+    return Promise.all(
+      usernames.map((username) => this.resolveAccess(username)),
+    );
   }
 
   private enforceUniqueCustomerBindings(): void {
@@ -430,7 +440,7 @@ export class WebhookEventStore implements WebhookEventBackend {
     `);
   }
 
-  isProcessed(eventId: string): boolean {
+  async isProcessed(eventId: string): Promise<boolean> {
     const row = this.db
       .query<
         { event_id: string },
@@ -440,7 +450,10 @@ export class WebhookEventStore implements WebhookEventBackend {
     return row !== null;
   }
 
-  isOutOfOrder(customerId: string, eventCreated: number): boolean {
+  async isOutOfOrder(
+    customerId: string,
+    eventCreated: number,
+  ): Promise<boolean> {
     const row = this.db
       .query<
         { last_event_created_at: number },
@@ -451,12 +464,12 @@ export class WebhookEventStore implements WebhookEventBackend {
     return eventCreated < row.last_event_created_at;
   }
 
-  markProcessed(
+  async markProcessed(
     eventId: string,
     eventType: string,
     customerId: string | null,
     eventCreated: number,
-  ): void {
+  ): Promise<void> {
     this.db
       .query<void, [string, string, string | null, number, number]>(
         `INSERT OR IGNORE INTO processed_webhook_events (event_id, event_type, customer_id, created_at, processed_at)
@@ -498,11 +511,11 @@ class LazyWebhookEventStore implements WebhookEventBackend {
     return this._store;
   }
 
-  isProcessed(eventId: string): boolean {
+  isProcessed(eventId: string): Promise<boolean> {
     return this.store.isProcessed(eventId);
   }
 
-  isOutOfOrder(customerId: string, eventCreated: number): boolean {
+  isOutOfOrder(customerId: string, eventCreated: number): Promise<boolean> {
     return this.store.isOutOfOrder(customerId, eventCreated);
   }
 
@@ -511,8 +524,13 @@ class LazyWebhookEventStore implements WebhookEventBackend {
     eventType: string,
     customerId: string | null,
     eventCreated: number,
-  ): void {
-    this.store.markProcessed(eventId, eventType, customerId, eventCreated);
+  ): Promise<void> {
+    return this.store.markProcessed(
+      eventId,
+      eventType,
+      customerId,
+      eventCreated,
+    );
   }
 }
 
@@ -539,41 +557,45 @@ class LazySubscriptionStore implements SubscriptionBackend {
     return this._store;
   }
 
-  getByUsername(username: string): SubscriptionRecord | null {
+  getByUsername(username: string): Promise<SubscriptionRecord | null> {
     return this.store.getByUsername(username);
   }
 
-  getByCustomerId(customerId: string): SubscriptionRecord | null {
+  getByCustomerId(customerId: string): Promise<SubscriptionRecord | null> {
     return this.store.getByCustomerId(customerId);
   }
 
-  upsert(record: SubscriptionRecord): void {
-    this.store.upsert(record);
+  upsert(record: SubscriptionRecord): Promise<void> {
+    return this.store.upsert(record);
   }
 
-  getAccessOverride(username: string): SubscriptionAccessOverrideRecord | null {
+  getAccessOverride(
+    username: string,
+  ): Promise<SubscriptionAccessOverrideRecord | null> {
     return this.store.getAccessOverride(username);
   }
 
-  putAccessOverride(record: SubscriptionAccessOverrideRecord): void {
-    this.store.putAccessOverride(record);
+  putAccessOverride(record: SubscriptionAccessOverrideRecord): Promise<void> {
+    return this.store.putAccessOverride(record);
   }
 
-  deleteAccessOverride(username: string): void {
-    this.store.deleteAccessOverride(username);
+  deleteAccessOverride(username: string): Promise<void> {
+    return this.store.deleteAccessOverride(username);
   }
 
-  resolveAccess(username: string): EffectiveSubscriptionAccess {
+  resolveAccess(username: string): Promise<EffectiveSubscriptionAccess> {
     return this.store.resolveAccess(username);
   }
 
-  listKnownAccessStates(): EffectiveSubscriptionAccess[] {
+  listKnownAccessStates(): Promise<EffectiveSubscriptionAccess[]> {
     return this.store.listKnownAccessStates();
   }
 }
 
 export const subscriptionStore = new LazySubscriptionStore();
 
-export function hasActiveSubscription(username: string): boolean {
-  return subscriptionStore.resolveAccess(username).hasAccess;
+export async function hasActiveSubscription(
+  username: string,
+): Promise<boolean> {
+  return (await subscriptionStore.resolveAccess(username)).hasAccess;
 }


### PR DESCRIPTION
## Summary

Convert the three API backend interfaces (`SessionBackend`, `SubscriptionBackend`, `WebhookEventBackend`) to return Promises so a Postgres implementation can be slotted in for #224. SQLite implementations stay — `bun:sqlite` is still synchronous, so they wrap returns in `Promise.resolve` — and call sites are updated to `await`.

This is the **first of three PRs** preparing `services/api` for the serverless cutover (#224):

1. **This PR — async refactor** (SQLite remains the only backend).
2. Next: Postgres implementations + `BINDERSNAP_DB_BACKEND=postgres` flag + schema-version startup probe.
3. After: SQLite → Postgres migration script.

## Scope

- `services/api/sessions.ts` — interface + `SessionStore` + lazy wrapper now async.
- `services/api/subscriptions.ts` — `SubscriptionBackend`, `WebhookEventBackend`, both stores, lazy wrappers, `hasActiveSubscription` now async.
- `services/api/server.ts` — ~30 call sites updated; `getSessionFromRequest`, `requireSession`, `requireSubscription`, `createSession`, `revokeAndDeleteSession`, `resolveSubscriptionAccessSource`, `resolveSubscriptionAccessState`, `buildAdminSubscriptionAccessEntry`, `buildLegacyAdminSubscriptionAccessState`, `cleanupExpiredSessions` propagate async.
- `scripts/reconcile-stripe-customer.ts` — single `await store.upsert`.
- All affected tests (`sessions.test.ts`, `subscriptions.test.ts`, `server.test.ts`, `server-search.test.ts`, `document-permissions.test.ts`, `reconcile-stripe-customer.test.ts`, `stripe/webhook-idempotency.test.ts`) updated.

No behavior change.

## Test plan

- [x] `bun run test:ops` — 241/241 pass
- [x] `bun run test:app` — 78/78 pass
- [x] `bunx tsc --noEmit` — net error count went down by 1 (pre-existing baseline; no new errors introduced by this branch)

## Workflow evidence

- Issue read method: existing context from PR #249 follow-up (#224)
- Branch creation: local `git checkout -b development/api-async-backends`
- Commits: c8ba051 (single commit on branch)
- PR creation: `mcp__github__create_pull_request`
- Fallbacks used: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)