### PR TITLE
infra(#224): Postgres backends + BINDERSNAP_DB_BACKEND flag + startup version probe

### DIFF
--- a/services/api/config.test.ts
+++ b/services/api/config.test.ts
@@ -109,4 +109,44 @@ describe("API config", () => {
     expect(config.appOrigin).toBe("https://bindersnap.com");
     expect(config.logLevel).toBe("warn");
   });
+
+  test("dbBackend defaults to sqlite and accepts postgres alias", () => {
+    const url = "postgres://u:p@localhost:5432/db";
+    expect(initializeConfig({}).dbBackend).toBe("sqlite");
+    expect(
+      initializeConfig({
+        BINDERSNAP_DB_BACKEND: "POSTGRES",
+        BINDERSNAP_DATABASE_URL: url,
+      }).dbBackend,
+    ).toBe("postgres");
+    expect(
+      initializeConfig({
+        BINDERSNAP_DB_BACKEND: "postgresql",
+        BINDERSNAP_DATABASE_URL: url,
+      }).dbBackend,
+    ).toBe("postgres");
+  });
+
+  test("dbBackend rejects unknown values", () => {
+    expect(() => initializeConfig({ BINDERSNAP_DB_BACKEND: "mysql" })).toThrow(
+      "BINDERSNAP_DB_BACKEND must be one of sqlite or postgres.",
+    );
+  });
+
+  test("postgres backend requires BINDERSNAP_DATABASE_URL", () => {
+    expect(() =>
+      initializeConfig({ BINDERSNAP_DB_BACKEND: "postgres" }),
+    ).toThrow(
+      "BINDERSNAP_DATABASE_URL is required when BINDERSNAP_DB_BACKEND=postgres.",
+    );
+
+    const config = initializeConfig({
+      BINDERSNAP_DB_BACKEND: "postgres",
+      BINDERSNAP_DATABASE_URL: "postgres://user:pw@localhost:5432/bindersnap",
+    });
+    expect(config.dbBackend).toBe("postgres");
+    expect(config.databaseUrl).toBe(
+      "postgres://user:pw@localhost:5432/bindersnap",
+    );
+  });
 });

--- a/services/api/config.ts
+++ b/services/api/config.ts
@@ -1,5 +1,6 @@
 export type LogLevel = "debug" | "info" | "warn" | "error";
 export type SessionCookieSameSite = "Strict" | "Lax" | "None";
+export type DbBackend = "sqlite" | "postgres";
 
 // The complete configuration of the API server.
 export interface ApiConfig {
@@ -32,6 +33,8 @@ export interface ApiConfig {
   sessionCookieDomain: string | null;
   sessionCookieSameSite: SessionCookieSameSite;
   sessionsDbPath: string;
+  dbBackend: DbBackend;
+  databaseUrl: string;
   logLevel: LogLevel;
 }
 
@@ -69,6 +72,8 @@ const STRING_ENV: Record<string, StringSpec> = {
   BINDERSNAP_SESSION_COOKIE_DOMAIN: { default: "" },
   BINDERSNAP_SESSION_COOKIE_SAME_SITE: { default: "Lax" },
   BINDERSNAP_SESSIONS_DB_PATH: { default: "/var/lib/bindersnap/sessions.db" },
+  BINDERSNAP_DB_BACKEND: { default: "sqlite" },
+  BINDERSNAP_DATABASE_URL: { default: "" },
   LOG_LEVEL: { default: "" },
 };
 
@@ -247,6 +252,39 @@ function resolveCookieSameSite(
   }
 }
 
+function resolveDbBackend(
+  env: NodeJS.ProcessEnv,
+  isProduction: boolean,
+): DbBackend {
+  const raw = parseString(env, "BINDERSNAP_DB_BACKEND", isProduction);
+  switch (raw.toLowerCase()) {
+    case "":
+    case "sqlite":
+      return "sqlite";
+    case "postgres":
+    case "postgresql":
+      return "postgres";
+    default:
+      throw new Error(
+        "BINDERSNAP_DB_BACKEND must be one of sqlite or postgres.",
+      );
+  }
+}
+
+function resolveDatabaseUrl(
+  env: NodeJS.ProcessEnv,
+  isProduction: boolean,
+  backend: DbBackend,
+): string {
+  const value = parseString(env, "BINDERSNAP_DATABASE_URL", isProduction);
+  if (backend === "postgres" && value === "") {
+    throw new Error(
+      "BINDERSNAP_DATABASE_URL is required when BINDERSNAP_DB_BACKEND=postgres.",
+    );
+  }
+  return value;
+}
+
 function resolveLogLevel(
   env: NodeJS.ProcessEnv,
   isProduction: boolean,
@@ -311,6 +349,8 @@ export function initializeConfig(
   );
 
   validateProductionOrigins(isProduction, allowedOriginsRaw, appOriginRaw);
+
+  const dbBackend = resolveDbBackend(resolvedEnv, isProduction);
 
   return {
     nodeEnv,
@@ -419,6 +459,8 @@ export function initializeConfig(
       "BINDERSNAP_SESSIONS_DB_PATH",
       isProduction,
     ),
+    dbBackend: dbBackend,
+    databaseUrl: resolveDatabaseUrl(resolvedEnv, isProduction, dbBackend),
     logLevel: resolveLogLevel(resolvedEnv, isProduction),
   };
 }

--- a/services/api/db/README.md
+++ b/services/api/db/README.md
@@ -7,24 +7,27 @@ Drizzle schema, migrations, and Postgres backend implementations for the API ser
 
 ## Layout
 
-| Path          | Purpose                                                                                                                                         |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `schema.ts`   | Drizzle schema for `sessions`, `subscriptions`, `subscription_access_overrides`, webhook tables, and `schema_versions`. Single source of truth. |
-| `migrations/` | Generated SQL migrations. Hand-edits forbidden — run `bun run db:generate`.                                                                     |
-| `client.ts`   | Lazy Postgres connection used by the runtime backends. Reads `BINDERSNAP_DATABASE_URL`.                                                         |
-| `version.ts`  | The `EXPECTED_SCHEMA_VERSION` constant + the startup probe helper.                                                                              |
-| `migrate/`    | Standalone migration runner. Co-located here, but **not imported** by anything in `services/api/`.                                              |
+| Path                        | Purpose                                                                                                                                         |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schema.ts`                 | Drizzle schema for `sessions`, `subscriptions`, `subscription_access_overrides`, webhook tables, and `schema_versions`. Single source of truth. |
+| `migrations/`               | Generated SQL migrations. Hand-edits forbidden — run `bun run db:generate`.                                                                     |
+| `client.ts`                 | Lazy Postgres connection used by the runtime backends. Reads `BINDERSNAP_DATABASE_URL`.                                                         |
+| `version.ts`                | The `EXPECTED_SCHEMA_VERSION` constant + the startup probe helper.                                                                              |
+| `configure.ts`              | Startup hook that selects the backend trio and runs the schema-version probe when `BINDERSNAP_DB_BACKEND=postgres`.                             |
+| `postgres-sessions.ts`      | `PostgresSessionBackend` — drizzle-backed `SessionBackend`.                                                                                     |
+| `postgres-subscriptions.ts` | `PostgresSubscriptionBackend` + `PostgresWebhookEventBackend`.                                                                                  |
+| `migrate/`                  | Standalone migration runner. Co-located here, but **not imported** by anything in `services/api/`.                                              |
 
-> Postgres `SessionBackend`/`SubscriptionBackend`/`WebhookEventBackend` implementations land in the follow-up PR. They require flipping the existing sync interfaces to async because `postgres-js` is async; that touches every call site and is its own slice.
+## Selecting the backend at runtime
 
-## Selecting the backend at runtime (planned)
-
-Once the Postgres backend implementations land, the API will pick a backend at startup based on `BINDERSNAP_DB_BACKEND`:
+The API picks a backend at startup based on `BINDERSNAP_DB_BACKEND`:
 
 - `sqlite` (default): existing on-disk SQLite store. Used in dev, tests, and the EC2 deployment until cutover.
 - `postgres`: Postgres backends from this directory. Requires `BINDERSNAP_DATABASE_URL`.
 
-When `postgres` is selected the API will run the schema-version probe (see `version.ts`) on first connection and refuse to start if the database schema does not match the version this code was built against. The probe code is in place; the wiring to call it lands with the runtime backends.
+When `postgres` is selected, `configureBackends()` calls `assertSchemaVersionMatches` against the database before installing the lazy-store factories. If the `schema_versions` row does not match `EXPECTED_SCHEMA_VERSION`, startup fails with a `SchemaVersionMismatchError` and the API never serves traffic. Run `bun run db:migrate` (or the equivalent CI step) to bring the database forward.
+
+Cutover from SQLite to Postgres is the next slice — a one-shot migration script that reads the existing `sessions.db` from the EC2 host and copies rows into Postgres.
 
 ## Migration policy
 

--- a/services/api/db/client.ts
+++ b/services/api/db/client.ts
@@ -1,11 +1,12 @@
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { config } from "../config";
 
 // Lazy Postgres connection used by the runtime backends in this directory.
 // One connection pool per process; created on first call.
 //
-// The connection string is read from BINDERSNAP_DATABASE_URL, which is only
-// consulted when the API is configured with BINDERSNAP_DB_BACKEND=postgres.
+// The connection string is read from BINDERSNAP_DATABASE_URL (via config),
+// which is only consulted when BINDERSNAP_DB_BACKEND=postgres.
 
 let client: ReturnType<typeof postgres> | null = null;
 let db: PostgresJsDatabase | null = null;
@@ -19,7 +20,7 @@ export function getPostgresDb(
   options: PostgresClientOptions = {},
 ): PostgresJsDatabase {
   if (db) return db;
-  const url = options.url ?? process.env.BINDERSNAP_DATABASE_URL;
+  const url = options.url ?? config.databaseUrl;
   if (!url) {
     throw new Error(
       "BINDERSNAP_DATABASE_URL is required when BINDERSNAP_DB_BACKEND=postgres.",
@@ -28,6 +29,16 @@ export function getPostgresDb(
   client = postgres(url, { max: options.max ?? 10, prepare: false });
   db = drizzle(client);
   return db;
+}
+
+// Test-only: install a pre-built drizzle DB and underlying client so tests can
+// share one connection across backends without paying connection cost per test.
+export function __setPostgresDbForTests(
+  newDb: PostgresJsDatabase,
+  newClient: ReturnType<typeof postgres>,
+): void {
+  client = newClient;
+  db = newDb;
 }
 
 export async function closePostgresDb(): Promise<void> {

--- a/services/api/db/configure.test.ts
+++ b/services/api/db/configure.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import type { ApiConfig } from "../config";
+import { configureBackends } from "./configure";
+
+const sqliteConfig = {
+  dbBackend: "sqlite",
+  databaseUrl: "",
+} as unknown as ApiConfig;
+
+describe("configureBackends", () => {
+  test("sqlite path is a no-op and reports sqlite", async () => {
+    const chosen = await configureBackends(sqliteConfig);
+    expect(chosen).toBe("sqlite");
+  });
+});

--- a/services/api/db/configure.ts
+++ b/services/api/db/configure.ts
@@ -1,0 +1,36 @@
+import { config, type ApiConfig } from "../config";
+import { setSessionBackendFactory } from "../sessions";
+import {
+  setSubscriptionBackendFactory,
+  setWebhookEventBackendFactory,
+} from "../subscriptions";
+import { getPostgresDb } from "./client";
+import { PostgresSessionBackend } from "./postgres-sessions";
+import {
+  PostgresSubscriptionBackend,
+  PostgresWebhookEventBackend,
+} from "./postgres-subscriptions";
+import { assertSchemaVersionMatches } from "./version";
+
+// Picks the backend trio at startup. Called from server.ts before Bun.serve so
+// the lazy stores resolve to the right backend on first use.
+//
+// Postgres path additionally runs the schema-version probe so the API refuses
+// to serve traffic against a database the migration runner has not brought up
+// to date. Returns the chosen backend so callers can log it.
+export async function configureBackends(
+  apiConfig: ApiConfig = config,
+): Promise<"sqlite" | "postgres"> {
+  if (apiConfig.dbBackend === "sqlite") {
+    return "sqlite";
+  }
+
+  const db = getPostgresDb({ url: apiConfig.databaseUrl });
+  await assertSchemaVersionMatches(db);
+
+  setSessionBackendFactory(() => new PostgresSessionBackend(db));
+  setSubscriptionBackendFactory(() => new PostgresSubscriptionBackend(db));
+  setWebhookEventBackendFactory(() => new PostgresWebhookEventBackend(db));
+
+  return "postgres";
+}

--- a/services/api/db/postgres-sessions.ts
+++ b/services/api/db/postgres-sessions.ts
@@ -1,0 +1,79 @@
+import { eq, lte } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { type SessionBackend, type SessionRecord } from "../sessions";
+import { getPostgresDb } from "./client";
+import { sessions } from "./schema";
+
+// Postgres-backed SessionBackend. Uses the shared lazy client unless an
+// explicit drizzle instance is passed in (tests). Schema is owned by the
+// migration runner — this file only reads/writes rows.
+export class PostgresSessionBackend implements SessionBackend {
+  private readonly db: PostgresJsDatabase;
+
+  constructor(db?: PostgresJsDatabase) {
+    this.db = db ?? getPostgresDb();
+  }
+
+  async get(id: string): Promise<SessionRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.id, id))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      username: row.username,
+      giteaToken: row.giteaToken,
+      giteaTokenName: row.giteaTokenName,
+      createdAt: row.createdAt,
+      expiresAt: row.expiresAt,
+    };
+  }
+
+  async put(session: SessionRecord): Promise<void> {
+    await this.db
+      .insert(sessions)
+      .values({
+        id: session.id,
+        username: session.username,
+        giteaToken: session.giteaToken,
+        giteaTokenName: session.giteaTokenName,
+        createdAt: session.createdAt,
+        expiresAt: session.expiresAt,
+      })
+      .onConflictDoUpdate({
+        target: sessions.id,
+        set: {
+          username: session.username,
+          giteaToken: session.giteaToken,
+          giteaTokenName: session.giteaTokenName,
+          createdAt: session.createdAt,
+          expiresAt: session.expiresAt,
+        },
+      });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.delete(sessions).where(eq(sessions.id, id));
+  }
+
+  // DELETE ... RETURNING * collapses the legacy two-statement (SELECT then
+  // DELETE) reap to a single round trip and removes the race where a session
+  // could be returned by SELECT but deleted concurrently before the DELETE.
+  async reap(now: number): Promise<SessionRecord[]> {
+    const rows = await this.db
+      .delete(sessions)
+      .where(lte(sessions.expiresAt, now))
+      .returning();
+    return rows.map((row) => ({
+      id: row.id,
+      username: row.username,
+      giteaToken: row.giteaToken,
+      giteaTokenName: row.giteaTokenName,
+      createdAt: row.createdAt,
+      expiresAt: row.expiresAt,
+    }));
+  }
+}

--- a/services/api/db/postgres-subscriptions.ts
+++ b/services/api/db/postgres-subscriptions.ts
@@ -1,0 +1,310 @@
+import { eq, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { logger } from "../logger";
+import {
+  SubscriptionCustomerConflictError,
+  type EffectiveSubscriptionAccess,
+  type SubscriptionAccessOverrideRecord,
+  type SubscriptionBackend,
+  type SubscriptionRecord,
+  type WebhookEventBackend,
+} from "../subscriptions";
+import { getPostgresDb } from "./client";
+import {
+  processedWebhookEvents,
+  subscriptionAccessOverrides,
+  subscriptions,
+  webhookCustomerState,
+} from "./schema";
+
+// 3-day grace window for currentPeriodEnd: defense-in-depth against missed
+// webhook delivery, mirroring the SQLite backend exactly.
+const CURRENT_PERIOD_END_GRACE_SECONDS = 3 * 24 * 60 * 60;
+
+function rowToSubscription(
+  row: typeof subscriptions.$inferSelect,
+): SubscriptionRecord {
+  return {
+    username: row.username,
+    stripeCustomerId: row.stripeCustomerId,
+    stripeSubscriptionId: row.stripeSubscriptionId,
+    status: row.status,
+    currentPeriodEnd: row.currentPeriodEnd,
+    cancelAtPeriodEnd: row.cancelAtPeriodEnd,
+    cancelAt: row.cancelAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function rowToOverride(
+  row: typeof subscriptionAccessOverrides.$inferSelect,
+): SubscriptionAccessOverrideRecord {
+  return {
+    username: row.username,
+    access: row.access,
+    reason: row.reason,
+    updatedBy: row.updatedBy,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function hasStripeBackedAccess(record: SubscriptionRecord | null): boolean {
+  if (!record) return false;
+  if (record.status !== "active" && record.status !== "trialing") return false;
+  if (record.currentPeriodEnd !== null) {
+    if (
+      record.currentPeriodEnd + CURRENT_PERIOD_END_GRACE_SECONDS <
+      Math.floor(Date.now() / 1000)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export class PostgresSubscriptionBackend implements SubscriptionBackend {
+  private readonly db: PostgresJsDatabase;
+
+  constructor(db?: PostgresJsDatabase) {
+    this.db = db ?? getPostgresDb();
+  }
+
+  async getByUsername(username: string): Promise<SubscriptionRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(subscriptions)
+      .where(eq(subscriptions.username, username))
+      .limit(1);
+    return rows[0] ? rowToSubscription(rows[0]) : null;
+  }
+
+  async getByCustomerId(
+    customerId: string,
+  ): Promise<SubscriptionRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(subscriptions)
+      .where(eq(subscriptions.stripeCustomerId, customerId))
+      .limit(1);
+    return rows[0] ? rowToSubscription(rows[0]) : null;
+  }
+
+  // Customer-uniqueness invariant: in Postgres this is enforced both by the
+  // UNIQUE INDEX on stripe_customer_id (created in the initial migration) and
+  // by an explicit pre-check inside a transaction so we can return a typed
+  // SubscriptionCustomerConflictError instead of a raw 23505 from the driver.
+  async upsert(record: SubscriptionRecord): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      const existing = await tx
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeCustomerId, record.stripeCustomerId))
+        .limit(1);
+      const conflict = existing[0];
+      if (conflict && conflict.username !== record.username) {
+        logger.error("Rejected Stripe customer rebind attempt", {
+          stripeCustomerId: record.stripeCustomerId,
+          existingUsername: conflict.username,
+          attemptedUsername: record.username,
+          existingSubscriptionId: conflict.stripeSubscriptionId,
+          attemptedSubscriptionId: record.stripeSubscriptionId,
+        });
+        throw new SubscriptionCustomerConflictError(
+          record.stripeCustomerId,
+          conflict.username,
+          record.username,
+        );
+      }
+
+      await tx
+        .insert(subscriptions)
+        .values({
+          username: record.username,
+          stripeCustomerId: record.stripeCustomerId,
+          stripeSubscriptionId: record.stripeSubscriptionId,
+          status: record.status,
+          currentPeriodEnd: record.currentPeriodEnd,
+          cancelAtPeriodEnd: record.cancelAtPeriodEnd,
+          cancelAt: record.cancelAt,
+          updatedAt: record.updatedAt,
+        })
+        .onConflictDoUpdate({
+          target: subscriptions.username,
+          set: {
+            stripeCustomerId: record.stripeCustomerId,
+            stripeSubscriptionId: record.stripeSubscriptionId,
+            status: record.status,
+            currentPeriodEnd: record.currentPeriodEnd,
+            cancelAtPeriodEnd: record.cancelAtPeriodEnd,
+            cancelAt: record.cancelAt,
+            updatedAt: record.updatedAt,
+          },
+        });
+    });
+  }
+
+  async getAccessOverride(
+    username: string,
+  ): Promise<SubscriptionAccessOverrideRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(subscriptionAccessOverrides)
+      .where(eq(subscriptionAccessOverrides.username, username))
+      .limit(1);
+    return rows[0] ? rowToOverride(rows[0]) : null;
+  }
+
+  async putAccessOverride(
+    record: SubscriptionAccessOverrideRecord,
+  ): Promise<void> {
+    await this.db
+      .insert(subscriptionAccessOverrides)
+      .values({
+        username: record.username,
+        access: record.access,
+        reason: record.reason,
+        updatedBy: record.updatedBy,
+        updatedAt: record.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: subscriptionAccessOverrides.username,
+        set: {
+          access: record.access,
+          reason: record.reason,
+          updatedBy: record.updatedBy,
+          updatedAt: record.updatedAt,
+        },
+      });
+  }
+
+  async deleteAccessOverride(username: string): Promise<void> {
+    await this.db
+      .delete(subscriptionAccessOverrides)
+      .where(eq(subscriptionAccessOverrides.username, username));
+  }
+
+  async resolveAccess(username: string): Promise<EffectiveSubscriptionAccess> {
+    const subscription = await this.getByUsername(username);
+    const override = await this.getAccessOverride(username);
+
+    if (override?.access === "grant") {
+      return {
+        username,
+        hasAccess: true,
+        source: "admin_grant",
+        subscription,
+        override,
+      };
+    }
+
+    if (override?.access === "revoke") {
+      return {
+        username,
+        hasAccess: false,
+        source: "admin_revoke",
+        subscription,
+        override,
+      };
+    }
+
+    if (hasStripeBackedAccess(subscription)) {
+      return {
+        username,
+        hasAccess: true,
+        source: "stripe",
+        subscription,
+        override,
+      };
+    }
+
+    return {
+      username,
+      hasAccess: false,
+      source: "none",
+      subscription,
+      override,
+    };
+  }
+
+  // SQLite uses `ORDER BY username COLLATE NOCASE`; Postgres has no NOCASE
+  // collation by default so sort case-insensitively via LOWER() to keep
+  // listings stable across backends.
+  async listKnownAccessStates(): Promise<EffectiveSubscriptionAccess[]> {
+    const result = await this.db.execute<{ username: string }>(sql`
+      SELECT username FROM ${subscriptions}
+      UNION
+      SELECT username FROM ${subscriptionAccessOverrides}
+      ORDER BY LOWER(username) ASC
+    `);
+    const usernames = (result as unknown as { username: string }[]).map(
+      (row) => row.username,
+    );
+    return Promise.all(
+      usernames.map((username) => this.resolveAccess(username)),
+    );
+  }
+}
+
+export class PostgresWebhookEventBackend implements WebhookEventBackend {
+  private readonly db: PostgresJsDatabase;
+
+  constructor(db?: PostgresJsDatabase) {
+    this.db = db ?? getPostgresDb();
+  }
+
+  async isProcessed(eventId: string): Promise<boolean> {
+    const rows = await this.db
+      .select({ eventId: processedWebhookEvents.eventId })
+      .from(processedWebhookEvents)
+      .where(eq(processedWebhookEvents.eventId, eventId))
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  async isOutOfOrder(
+    customerId: string,
+    eventCreated: number,
+  ): Promise<boolean> {
+    const rows = await this.db
+      .select({ last: webhookCustomerState.lastEventCreatedAt })
+      .from(webhookCustomerState)
+      .where(eq(webhookCustomerState.customerId, customerId))
+      .limit(1);
+    const last = rows[0]?.last;
+    if (last === undefined) return false;
+    return eventCreated < last;
+  }
+
+  async markProcessed(
+    eventId: string,
+    eventType: string,
+    customerId: string | null,
+    eventCreated: number,
+  ): Promise<void> {
+    await this.db
+      .insert(processedWebhookEvents)
+      .values({
+        eventId,
+        eventType,
+        customerId,
+        createdAt: eventCreated,
+        processedAt: Date.now(),
+      })
+      .onConflictDoNothing({ target: processedWebhookEvents.eventId });
+
+    if (customerId !== null) {
+      await this.db
+        .insert(webhookCustomerState)
+        .values({
+          customerId,
+          lastEventCreatedAt: eventCreated,
+        })
+        .onConflictDoUpdate({
+          target: webhookCustomerState.customerId,
+          set: {
+            lastEventCreatedAt: sql`GREATEST(${webhookCustomerState.lastEventCreatedAt}, EXCLUDED.last_event_created_at)`,
+          },
+        });
+    }
+  }
+}

--- a/services/api/db/version.test.ts
+++ b/services/api/db/version.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { EXPECTED_SCHEMA_VERSION, SchemaVersionMismatchError } from "./version";
+
+describe("schema version", () => {
+  test("EXPECTED_SCHEMA_VERSION is non-empty", () => {
+    expect(EXPECTED_SCHEMA_VERSION.length).toBeGreaterThan(0);
+  });
+
+  test("mismatch error names both expected and actual", () => {
+    const err = new SchemaVersionMismatchError("0001_x", "0000_y");
+    expect(err.message).toContain("0001_x");
+    expect(err.message).toContain("0000_y");
+    expect(err.name).toBe("SchemaVersionMismatchError");
+  });
+
+  test("missing-row mismatch tells the operator to run the migration runner", () => {
+    const err = new SchemaVersionMismatchError("0001_x", null);
+    expect(err.message).toContain(
+      "Run the migration runner before starting the API",
+    );
+    expect(err.message).toContain("0001_x");
+  });
+});

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 
 import { config, type SessionCookieSameSite } from "./config";
+import { configureBackends } from "./db/configure";
 import { logger } from "./logger";
 import { sessionStore, type SessionRecord } from "./sessions";
 import {
@@ -4009,14 +4010,18 @@ export function createApiServer() {
   });
 }
 
-export const server = import.meta.main ? createApiServer() : null;
-
-if (import.meta.main && server) {
+if (import.meta.main) {
+  // configureBackends must run before Bun.serve so the lazy stores resolve to
+  // the right backend on the first request, and so the schema-version probe
+  // can refuse to start the API against an unmigrated Postgres.
+  const chosen = await configureBackends();
+  const server = createApiServer();
   startCleanupTimer();
   logger.info("Bindersnap API listening", {
     url: `http://localhost:${server.port}`,
     port: server.port,
     env: config.nodeEnv,
+    dbBackend: chosen,
   });
   if (config.devFeaturesEnabled) {
     logger.warn(


### PR DESCRIPTION
## Summary

Continues #224. Lands the runtime Postgres backends behind the async interfaces from #250, plus the env-var switch and the schema-version startup probe.

- `BINDERSNAP_DB_BACKEND=sqlite` (default) — unchanged on-disk store
- `BINDERSNAP_DB_BACKEND=postgres` — drizzle/postgres-js, requires `BINDERSNAP_DATABASE_URL`

When `postgres` is selected, `configureBackends()` calls `assertSchemaVersionMatches` against the database before installing the lazy-store factories. If `schema_versions.version` ≠ `EXPECTED_SCHEMA_VERSION`, startup throws a `SchemaVersionMismatchError` and the API never serves traffic. Operators run `bun run db:migrate` to bring the database forward.

## What's in this PR

| File | Purpose |
| --- | --- |
| `services/api/db/postgres-sessions.ts` | `PostgresSessionBackend`. Reap is `DELETE ... RETURNING` — single round trip, no race between `SELECT` and `DELETE`. |
| `services/api/db/postgres-subscriptions.ts` | `PostgresSubscriptionBackend` + `PostgresWebhookEventBackend`. Customer-uniqueness invariant pre-check inside a transaction so we keep the typed `SubscriptionCustomerConflictError` on top of the UNIQUE INDEX. |
| `services/api/db/configure.ts` | `configureBackends()` — sqlite path is a no-op; postgres path probes schema version and installs the three factories. |
| `services/api/server.ts` | Bootstrap awaits `configureBackends()` before `Bun.serve` and logs the chosen backend. |
| `services/api/config.ts` (+ tests) | `dbBackend` + `databaseUrl` fields with validation. |
| `services/api/db/configure.test.ts`, `db/version.test.ts` | Unit tests for sqlite-path no-op + version-mismatch error format. |

## Notes

- `EXPECTED_SCHEMA_VERSION` is still `0000_initial`; no schema change in this PR.
- The `listKnownAccessStates` UNION uses `LOWER(username)` to mirror SQLite's `COLLATE NOCASE` ordering.
- `markProcessed` upsert on `webhook_customer_state` uses `GREATEST(...)` — the Postgres equivalent of SQLite's `MAX(...)` in the existing impl.

## Out of scope

- One-shot SQLite → Postgres copy script — next slice.
- Token-at-rest envelope encryption on `gitea_token` — planned for the cutover slice.

## Test plan

- [x] `bun run test:ops` — 248/248 pass
- [x] `bun run test:app` — 78/78 pass
- [x] `bunx tsc --noEmit` — no new errors in changed files
- [x] `bun run format`
- [ ] Live Postgres smoke (deferred to migration-script PR which sets up the test DB)

## Workflow evidence

- Branch created locally (`git checkout -b infra/224-postgres-backends`)
- Issue context fetched via `mcp__github__issue_read`
- PR created via `mcp__github__create_pull_request`
- Push via `git push -u origin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)