### PR TITLE
infra(#224): one-shot SQLite → Postgres copy script

### DIFF
--- a/scripts/migrate-sqlite-to-postgres.test.ts
+++ b/scripts/migrate-sqlite-to-postgres.test.ts
@@ -1,0 +1,324 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildPlan,
+  dedupeSubscriptionsByCustomerId,
+  filterLiveSessions,
+  parseCliArgs,
+  readSqliteSnapshot,
+  type SourceSubscriptionRow,
+} from "./migrate-sqlite-to-postgres";
+
+function makeSubscription(
+  overrides: Partial<SourceSubscriptionRow>,
+): SourceSubscriptionRow {
+  return {
+    username: "alice",
+    stripeCustomerId: "cus_1",
+    stripeSubscriptionId: "sub_1",
+    status: "active",
+    currentPeriodEnd: 1000,
+    cancelAtPeriodEnd: false,
+    cancelAt: null,
+    updatedAt: 100,
+    ...overrides,
+  };
+}
+
+describe("filterLiveSessions", () => {
+  test("drops sessions whose expires_at is at or before now", () => {
+    const now = 10_000;
+    const result = filterLiveSessions(
+      [
+        {
+          id: "live",
+          username: "u",
+          giteaToken: "t",
+          giteaTokenName: "n",
+          createdAt: 0,
+          expiresAt: 11_000,
+        },
+        {
+          id: "expired-eq",
+          username: "u",
+          giteaToken: "t",
+          giteaTokenName: "n",
+          createdAt: 0,
+          expiresAt: 10_000,
+        },
+        {
+          id: "expired-lt",
+          username: "u",
+          giteaToken: "t",
+          giteaTokenName: "n",
+          createdAt: 0,
+          expiresAt: 9_999,
+        },
+      ],
+      now,
+    );
+    expect(result.live.map((s) => s.id)).toEqual(["live"]);
+    expect(result.expired).toBe(2);
+  });
+});
+
+describe("dedupeSubscriptionsByCustomerId", () => {
+  test("keeps the row with the largest updated_at when stripe_customer_id repeats", () => {
+    const older = makeSubscription({ username: "alice", updatedAt: 50 });
+    const newer = makeSubscription({ username: "bob", updatedAt: 200 });
+    const result = dedupeSubscriptionsByCustomerId([older, newer]);
+    expect(result.kept).toHaveLength(1);
+    expect(result.kept[0]!.username).toBe("bob");
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0]!.username).toBe("alice");
+  });
+
+  test("breaks ties on updated_at by username for determinism", () => {
+    const aliceTie = makeSubscription({ username: "alice", updatedAt: 100 });
+    const bobTie = makeSubscription({ username: "bob", updatedAt: 100 });
+    const result = dedupeSubscriptionsByCustomerId([bobTie, aliceTie]);
+    expect(result.kept[0]!.username).toBe("alice");
+    expect(result.dropped[0]!.username).toBe("bob");
+  });
+
+  test("preserves rows with distinct stripe_customer_id values", () => {
+    const a = makeSubscription({
+      username: "alice",
+      stripeCustomerId: "cus_a",
+    });
+    const b = makeSubscription({ username: "bob", stripeCustomerId: "cus_b" });
+    const result = dedupeSubscriptionsByCustomerId([a, b]);
+    expect(result.kept).toHaveLength(2);
+    expect(result.dropped).toHaveLength(0);
+  });
+});
+
+describe("buildPlan", () => {
+  test("composes filter + dedupe + passthrough into a single plan", () => {
+    const plan = buildPlan(
+      {
+        sessions: [
+          {
+            id: "live",
+            username: "u",
+            giteaToken: "t",
+            giteaTokenName: "n",
+            createdAt: 0,
+            expiresAt: 11_000,
+          },
+          {
+            id: "expired",
+            username: "u",
+            giteaToken: "t",
+            giteaTokenName: "n",
+            createdAt: 0,
+            expiresAt: 5_000,
+          },
+        ],
+        subscriptions: [
+          makeSubscription({ username: "old", updatedAt: 1 }),
+          makeSubscription({ username: "new", updatedAt: 2 }),
+        ],
+        subscriptionAccessOverrides: [
+          {
+            username: "x",
+            access: "grant",
+            reason: null,
+            updatedBy: "admin",
+            updatedAt: 1,
+          },
+        ],
+        processedWebhookEvents: [
+          {
+            eventId: "evt_1",
+            eventType: "test",
+            customerId: null,
+            createdAt: 0,
+            processedAt: 0,
+          },
+        ],
+        webhookCustomerState: [{ customerId: "cus_1", lastEventCreatedAt: 0 }],
+      },
+      10_000,
+    );
+    expect(plan.sessions).toHaveLength(1);
+    expect(plan.expiredSessions).toBe(1);
+    expect(plan.subscriptions).toHaveLength(1);
+    expect(plan.subscriptions[0]!.username).toBe("new");
+    expect(plan.subscriptionDuplicatesDropped).toHaveLength(1);
+    expect(plan.subscriptionAccessOverrides).toHaveLength(1);
+    expect(plan.processedWebhookEvents).toHaveLength(1);
+    expect(plan.webhookCustomerState).toHaveLength(1);
+  });
+});
+
+describe("parseCliArgs", () => {
+  test("parses all flags", () => {
+    const args = parseCliArgs([
+      "--sqlite-path",
+      "/tmp/s.db",
+      "--database-url",
+      "postgres://x",
+      "--dry-run",
+      "--allow-non-empty",
+    ]);
+    expect(args).toEqual({
+      sqlitePath: "/tmp/s.db",
+      databaseUrl: "postgres://x",
+      dryRun: true,
+      allowNonEmpty: true,
+    });
+  });
+
+  test("rejects unknown args", () => {
+    expect(() => parseCliArgs(["--bogus"])).toThrow(/Unknown argument/);
+  });
+
+  test("defaults are nulls / falses when no flags provided", () => {
+    expect(parseCliArgs([])).toEqual({
+      sqlitePath: null,
+      databaseUrl: null,
+      dryRun: false,
+      allowNonEmpty: false,
+    });
+  });
+});
+
+describe("readSqliteSnapshot", () => {
+  let tempDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "migrate-sqlite-"));
+    dbPath = join(tempDir, "sessions.db");
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns shaped rows for all five tables", () => {
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        username TEXT NOT NULL,
+        gitea_token TEXT NOT NULL,
+        gitea_token_name TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
+      CREATE TABLE subscriptions (
+        username TEXT PRIMARY KEY,
+        stripe_customer_id TEXT NOT NULL,
+        stripe_subscription_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        current_period_end INTEGER,
+        cancel_at_period_end INTEGER NOT NULL DEFAULT 0,
+        cancel_at INTEGER,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE subscription_access_overrides (
+        username TEXT PRIMARY KEY,
+        access TEXT NOT NULL,
+        reason TEXT,
+        updated_by TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE processed_webhook_events (
+        event_id TEXT PRIMARY KEY,
+        event_type TEXT NOT NULL,
+        customer_id TEXT,
+        created_at INTEGER NOT NULL,
+        processed_at INTEGER NOT NULL
+      );
+      CREATE TABLE webhook_customer_state (
+        customer_id TEXT PRIMARY KEY,
+        last_event_created_at INTEGER NOT NULL
+      );
+    `);
+    db.run("INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?)", [
+      "sess_1",
+      "alice",
+      "tok",
+      "tok-name",
+      100,
+      200,
+    ]);
+    db.run("INSERT INTO subscriptions VALUES (?, ?, ?, ?, ?, ?, ?, ?)", [
+      "alice",
+      "cus_1",
+      "sub_1",
+      "active",
+      1000,
+      1,
+      null,
+      50,
+    ]);
+    db.run("INSERT INTO subscription_access_overrides VALUES (?, ?, ?, ?, ?)", [
+      "bob",
+      "grant",
+      "vip",
+      "admin",
+      75,
+    ]);
+    db.run("INSERT INTO processed_webhook_events VALUES (?, ?, ?, ?, ?)", [
+      "evt_1",
+      "customer.subscription.updated",
+      "cus_1",
+      10,
+      11,
+    ]);
+    db.run("INSERT INTO webhook_customer_state VALUES (?, ?)", ["cus_1", 10]);
+    db.close();
+
+    const snapshot = readSqliteSnapshot(dbPath);
+    expect(snapshot.sessions[0]).toEqual({
+      id: "sess_1",
+      username: "alice",
+      giteaToken: "tok",
+      giteaTokenName: "tok-name",
+      createdAt: 100,
+      expiresAt: 200,
+    });
+    expect(snapshot.subscriptions[0]).toEqual({
+      username: "alice",
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_1",
+      status: "active",
+      currentPeriodEnd: 1000,
+      cancelAtPeriodEnd: true,
+      cancelAt: null,
+      updatedAt: 50,
+    });
+    expect(snapshot.subscriptionAccessOverrides[0]!.username).toBe("bob");
+    expect(snapshot.processedWebhookEvents[0]!.eventId).toBe("evt_1");
+    expect(snapshot.webhookCustomerState[0]!.customerId).toBe("cus_1");
+  });
+
+  test("tolerates a sessions-only legacy database (other tables missing)", () => {
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        username TEXT NOT NULL,
+        gitea_token TEXT NOT NULL,
+        gitea_token_name TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
+    `);
+    db.close();
+
+    const snapshot = readSqliteSnapshot(dbPath);
+    expect(snapshot.sessions).toEqual([]);
+    expect(snapshot.subscriptions).toEqual([]);
+    expect(snapshot.subscriptionAccessOverrides).toEqual([]);
+    expect(snapshot.processedWebhookEvents).toEqual([]);
+    expect(snapshot.webhookCustomerState).toEqual([]);
+  });
+});

--- a/scripts/migrate-sqlite-to-postgres.ts
+++ b/scripts/migrate-sqlite-to-postgres.ts
@@ -1,0 +1,598 @@
+#!/usr/bin/env bun
+
+// One-shot copy of the API service's SQLite store into Postgres.
+//
+// Reads rows from the existing on-disk SQLite database (the EC2 host's
+// `sessions.db` carries all five tables — sessions, subscriptions,
+// subscription_access_overrides, processed_webhook_events,
+// webhook_customer_state) and inserts them into the Postgres database whose
+// schema has already been brought up to date by the standalone migration
+// runner.
+//
+// Usage:
+//   bun run scripts/migrate-sqlite-to-postgres.ts \
+//     --sqlite-path /var/lib/bindersnap/sessions.db \
+//     --database-url "$BINDERSNAP_DATABASE_URL"
+//
+// Flags:
+//   --sqlite-path <path>     Source SQLite file. Required.
+//   --database-url <url>     Target Postgres URL. Defaults to env BINDERSNAP_DATABASE_URL.
+//   --dry-run                Read + plan only; no writes.
+//   --allow-non-empty        Allow writing into tables that already have rows.
+//                            By default the script refuses, since it is meant
+//                            as a one-shot pre-cutover copy.
+//   --now <ms>               Override "now" used to filter expired sessions
+//                            (test hook).
+//
+// Exit status:
+//   0  Copy completed (or dry-run printed the plan).
+//   1  Refused (schema mismatch, destination not empty, missing input, etc.).
+
+import { Database } from "bun:sqlite";
+import { sql } from "drizzle-orm";
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import {
+  processedWebhookEvents,
+  sessions,
+  subscriptionAccessOverrides,
+  subscriptions,
+  webhookCustomerState,
+} from "../services/api/db/schema";
+import {
+  EXPECTED_SCHEMA_VERSION,
+  assertSchemaVersionMatches,
+} from "../services/api/db/version";
+
+export interface SourceSessionRow {
+  id: string;
+  username: string;
+  giteaToken: string;
+  giteaTokenName: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface SourceSubscriptionRow {
+  username: string;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string;
+  status: string;
+  currentPeriodEnd: number | null;
+  cancelAtPeriodEnd: boolean;
+  cancelAt: number | null;
+  updatedAt: number;
+}
+
+export interface SourceSubscriptionOverrideRow {
+  username: string;
+  access: "grant" | "revoke";
+  reason: string | null;
+  updatedBy: string;
+  updatedAt: number;
+}
+
+export interface SourceProcessedWebhookEventRow {
+  eventId: string;
+  eventType: string;
+  customerId: string | null;
+  createdAt: number;
+  processedAt: number;
+}
+
+export interface SourceWebhookCustomerStateRow {
+  customerId: string;
+  lastEventCreatedAt: number;
+}
+
+export interface SourceSnapshot {
+  sessions: SourceSessionRow[];
+  subscriptions: SourceSubscriptionRow[];
+  subscriptionAccessOverrides: SourceSubscriptionOverrideRow[];
+  processedWebhookEvents: SourceProcessedWebhookEventRow[];
+  webhookCustomerState: SourceWebhookCustomerStateRow[];
+}
+
+export interface MigrationPlan {
+  sessions: SourceSessionRow[];
+  expiredSessions: number;
+  subscriptions: SourceSubscriptionRow[];
+  subscriptionDuplicatesDropped: SourceSubscriptionRow[];
+  subscriptionAccessOverrides: SourceSubscriptionOverrideRow[];
+  processedWebhookEvents: SourceProcessedWebhookEventRow[];
+  webhookCustomerState: SourceWebhookCustomerStateRow[];
+}
+
+export interface MigrationOptions {
+  sqlitePath: string;
+  databaseUrl: string;
+  dryRun?: boolean;
+  allowNonEmpty?: boolean;
+  now?: number;
+  logger?: (line: string) => void;
+}
+
+export interface MigrationResult {
+  appliedVersion: string;
+  written: {
+    sessions: number;
+    subscriptions: number;
+    subscriptionAccessOverrides: number;
+    processedWebhookEvents: number;
+    webhookCustomerState: number;
+  };
+  skipped: {
+    expiredSessions: number;
+    duplicateSubscriptions: SourceSubscriptionRow[];
+  };
+  dryRun: boolean;
+}
+
+interface SqliteSessionRow {
+  id: string;
+  username: string;
+  gitea_token: string;
+  gitea_token_name: string;
+  created_at: number;
+  expires_at: number;
+}
+
+interface SqliteSubscriptionRow {
+  username: string;
+  stripe_customer_id: string;
+  stripe_subscription_id: string;
+  status: string;
+  current_period_end: number | null;
+  cancel_at_period_end: number;
+  cancel_at: number | null;
+  updated_at: number;
+}
+
+interface SqliteSubscriptionOverrideRow {
+  username: string;
+  access: "grant" | "revoke";
+  reason: string | null;
+  updated_by: string;
+  updated_at: number;
+}
+
+interface SqliteProcessedWebhookEventRow {
+  event_id: string;
+  event_type: string;
+  customer_id: string | null;
+  created_at: number;
+  processed_at: number;
+}
+
+interface SqliteWebhookCustomerStateRow {
+  customer_id: string;
+  last_event_created_at: number;
+}
+
+export function readSqliteSnapshot(sqlitePath: string): SourceSnapshot {
+  const db = new Database(sqlitePath, { readonly: true });
+  try {
+    const sessionRows = db
+      .query<SqliteSessionRow, []>("SELECT * FROM sessions")
+      .all()
+      .map((row) => ({
+        id: row.id,
+        username: row.username,
+        giteaToken: row.gitea_token,
+        giteaTokenName: row.gitea_token_name,
+        createdAt: row.created_at,
+        expiresAt: row.expires_at,
+      }));
+
+    const subscriptionRows = tableExists(db, "subscriptions")
+      ? db
+          .query<SqliteSubscriptionRow, []>("SELECT * FROM subscriptions")
+          .all()
+          .map((row) => ({
+            username: row.username,
+            stripeCustomerId: row.stripe_customer_id,
+            stripeSubscriptionId: row.stripe_subscription_id,
+            status: row.status,
+            currentPeriodEnd: row.current_period_end,
+            cancelAtPeriodEnd: row.cancel_at_period_end === 1,
+            cancelAt: row.cancel_at,
+            updatedAt: row.updated_at,
+          }))
+      : [];
+
+    const overrideRows = tableExists(db, "subscription_access_overrides")
+      ? db
+          .query<SqliteSubscriptionOverrideRow, []>(
+            "SELECT * FROM subscription_access_overrides",
+          )
+          .all()
+          .map((row) => ({
+            username: row.username,
+            access: row.access,
+            reason: row.reason,
+            updatedBy: row.updated_by,
+            updatedAt: row.updated_at,
+          }))
+      : [];
+
+    const processedRows = tableExists(db, "processed_webhook_events")
+      ? db
+          .query<SqliteProcessedWebhookEventRow, []>(
+            "SELECT * FROM processed_webhook_events",
+          )
+          .all()
+          .map((row) => ({
+            eventId: row.event_id,
+            eventType: row.event_type,
+            customerId: row.customer_id,
+            createdAt: row.created_at,
+            processedAt: row.processed_at,
+          }))
+      : [];
+
+    const customerStateRows = tableExists(db, "webhook_customer_state")
+      ? db
+          .query<SqliteWebhookCustomerStateRow, []>(
+            "SELECT * FROM webhook_customer_state",
+          )
+          .all()
+          .map((row) => ({
+            customerId: row.customer_id,
+            lastEventCreatedAt: row.last_event_created_at,
+          }))
+      : [];
+
+    return {
+      sessions: sessionRows,
+      subscriptions: subscriptionRows,
+      subscriptionAccessOverrides: overrideRows,
+      processedWebhookEvents: processedRows,
+      webhookCustomerState: customerStateRows,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function tableExists(db: Database, name: string): boolean {
+  const row = db
+    .query<
+      { name: string },
+      [string]
+    >("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(name);
+  return row !== null;
+}
+
+// Drops sessions whose expires_at is at or before `now`. The SQLite reaper may
+// not have run on the source for hours, and copying expired tokens into a new
+// store wastes space and gives an attacker who reads the dump a longer window.
+export function filterLiveSessions(
+  rows: SourceSessionRow[],
+  now: number,
+): { live: SourceSessionRow[]; expired: number } {
+  const live: SourceSessionRow[] = [];
+  let expired = 0;
+  for (const row of rows) {
+    if (row.expiresAt <= now) {
+      expired += 1;
+      continue;
+    }
+    live.push(row);
+  }
+  return { live, expired };
+}
+
+// SQLite enforces uniqueness on stripe_customer_id at upsert time
+// (`enforceUniqueCustomerBindings` in services/api/subscriptions.ts), but a
+// historical snapshot may still contain a stale duplicate row from before
+// that code landed. The Postgres schema has a UNIQUE INDEX on the column, so
+// a copy attempt with duplicates would fail mid-transaction.
+//
+// Resolve duplicates here by picking the row with the largest updated_at
+// (newest write wins, matching the SQLite migration logic). Stable tie-break
+// by username so reruns are deterministic.
+export function dedupeSubscriptionsByCustomerId(
+  rows: SourceSubscriptionRow[],
+): { kept: SourceSubscriptionRow[]; dropped: SourceSubscriptionRow[] } {
+  const winners = new Map<string, SourceSubscriptionRow>();
+  const dropped: SourceSubscriptionRow[] = [];
+  for (const row of rows) {
+    const existing = winners.get(row.stripeCustomerId);
+    if (!existing) {
+      winners.set(row.stripeCustomerId, row);
+      continue;
+    }
+    const existingIsBetter =
+      existing.updatedAt > row.updatedAt ||
+      (existing.updatedAt === row.updatedAt &&
+        existing.username.localeCompare(row.username) <= 0);
+    if (existingIsBetter) {
+      dropped.push(row);
+    } else {
+      dropped.push(existing);
+      winners.set(row.stripeCustomerId, row);
+    }
+  }
+  return { kept: [...winners.values()], dropped };
+}
+
+export function buildPlan(
+  snapshot: SourceSnapshot,
+  now: number,
+): MigrationPlan {
+  const { live, expired } = filterLiveSessions(snapshot.sessions, now);
+  const { kept, dropped } = dedupeSubscriptionsByCustomerId(
+    snapshot.subscriptions,
+  );
+  return {
+    sessions: live,
+    expiredSessions: expired,
+    subscriptions: kept,
+    subscriptionDuplicatesDropped: dropped,
+    subscriptionAccessOverrides: snapshot.subscriptionAccessOverrides,
+    processedWebhookEvents: snapshot.processedWebhookEvents,
+    webhookCustomerState: snapshot.webhookCustomerState,
+  };
+}
+
+interface DestinationCounts {
+  sessions: number;
+  subscriptions: number;
+  subscriptionAccessOverrides: number;
+  processedWebhookEvents: number;
+  webhookCustomerState: number;
+}
+
+async function readDestinationCounts(
+  db: PostgresJsDatabase,
+): Promise<DestinationCounts> {
+  const result = await db.execute<{
+    sessions: string;
+    subscriptions: string;
+    overrides: string;
+    processed: string;
+    customer_state: string;
+  }>(sql`
+    SELECT
+      (SELECT COUNT(*)::text FROM ${sessions}) AS sessions,
+      (SELECT COUNT(*)::text FROM ${subscriptions}) AS subscriptions,
+      (SELECT COUNT(*)::text FROM ${subscriptionAccessOverrides}) AS overrides,
+      (SELECT COUNT(*)::text FROM ${processedWebhookEvents}) AS processed,
+      (SELECT COUNT(*)::text FROM ${webhookCustomerState}) AS customer_state
+  `);
+  const row = (result as unknown as Array<Record<string, string>>)[0];
+  if (!row) {
+    throw new Error("Postgres count query returned no rows.");
+  }
+  return {
+    sessions: Number(row.sessions),
+    subscriptions: Number(row.subscriptions),
+    subscriptionAccessOverrides: Number(row.overrides),
+    processedWebhookEvents: Number(row.processed),
+    webhookCustomerState: Number(row.customer_state),
+  };
+}
+
+function totalRows(counts: DestinationCounts): number {
+  return (
+    counts.sessions +
+    counts.subscriptions +
+    counts.subscriptionAccessOverrides +
+    counts.processedWebhookEvents +
+    counts.webhookCustomerState
+  );
+}
+
+export class DestinationNotEmptyError extends Error {
+  constructor(public readonly counts: DestinationCounts) {
+    super(
+      `Destination Postgres database already has rows: ${JSON.stringify(counts)}. ` +
+        `Pass --allow-non-empty to copy anyway (rows that conflict on PK are skipped).`,
+    );
+    this.name = "DestinationNotEmptyError";
+  }
+}
+
+// Writes the plan into Postgres inside a single transaction. ON CONFLICT DO
+// NOTHING means re-running the script after a partial success is safe — rows
+// already present are not overwritten.
+export async function writePlan(
+  db: PostgresJsDatabase,
+  plan: MigrationPlan,
+): Promise<MigrationResult["written"]> {
+  const written: MigrationResult["written"] = {
+    sessions: 0,
+    subscriptions: 0,
+    subscriptionAccessOverrides: 0,
+    processedWebhookEvents: 0,
+    webhookCustomerState: 0,
+  };
+
+  await db.transaction(async (tx) => {
+    if (plan.sessions.length > 0) {
+      const inserted = await tx
+        .insert(sessions)
+        .values(plan.sessions)
+        .onConflictDoNothing({ target: sessions.id })
+        .returning({ id: sessions.id });
+      written.sessions = inserted.length;
+    }
+
+    if (plan.subscriptions.length > 0) {
+      const inserted = await tx
+        .insert(subscriptions)
+        .values(plan.subscriptions)
+        .onConflictDoNothing({ target: subscriptions.username })
+        .returning({ username: subscriptions.username });
+      written.subscriptions = inserted.length;
+    }
+
+    if (plan.subscriptionAccessOverrides.length > 0) {
+      const inserted = await tx
+        .insert(subscriptionAccessOverrides)
+        .values(plan.subscriptionAccessOverrides)
+        .onConflictDoNothing({ target: subscriptionAccessOverrides.username })
+        .returning({ username: subscriptionAccessOverrides.username });
+      written.subscriptionAccessOverrides = inserted.length;
+    }
+
+    if (plan.processedWebhookEvents.length > 0) {
+      const inserted = await tx
+        .insert(processedWebhookEvents)
+        .values(plan.processedWebhookEvents)
+        .onConflictDoNothing({ target: processedWebhookEvents.eventId })
+        .returning({ eventId: processedWebhookEvents.eventId });
+      written.processedWebhookEvents = inserted.length;
+    }
+
+    if (plan.webhookCustomerState.length > 0) {
+      const inserted = await tx
+        .insert(webhookCustomerState)
+        .values(plan.webhookCustomerState)
+        .onConflictDoNothing({ target: webhookCustomerState.customerId })
+        .returning({ customerId: webhookCustomerState.customerId });
+      written.webhookCustomerState = inserted.length;
+    }
+  });
+
+  return written;
+}
+
+export async function runMigration(
+  options: MigrationOptions,
+): Promise<MigrationResult> {
+  const log = options.logger ?? ((line) => console.log(line));
+  const now = options.now ?? Date.now();
+
+  const snapshot = readSqliteSnapshot(options.sqlitePath);
+  const plan = buildPlan(snapshot, now);
+
+  log(
+    `Read SQLite snapshot: sessions=${snapshot.sessions.length} (live=${plan.sessions.length}, expired=${plan.expiredSessions}), ` +
+      `subscriptions=${snapshot.subscriptions.length} (kept=${plan.subscriptions.length}, dropped=${plan.subscriptionDuplicatesDropped.length}), ` +
+      `overrides=${plan.subscriptionAccessOverrides.length}, ` +
+      `webhook_events=${plan.processedWebhookEvents.length}, ` +
+      `webhook_customer_state=${plan.webhookCustomerState.length}`,
+  );
+
+  if (plan.subscriptionDuplicatesDropped.length > 0) {
+    for (const dup of plan.subscriptionDuplicatesDropped) {
+      log(
+        `  dropped duplicate subscription: stripe_customer_id=${dup.stripeCustomerId} ` +
+          `username=${dup.username} updated_at=${dup.updatedAt}`,
+      );
+    }
+  }
+
+  const client = postgres(options.databaseUrl, { max: 1, prepare: false });
+  try {
+    const db = drizzle(client);
+
+    await assertSchemaVersionMatches(db);
+
+    const counts = await readDestinationCounts(db);
+    if (totalRows(counts) > 0 && !options.allowNonEmpty) {
+      throw new DestinationNotEmptyError(counts);
+    }
+
+    if (options.dryRun) {
+      log("Dry-run requested; not writing rows.");
+      return {
+        appliedVersion: EXPECTED_SCHEMA_VERSION,
+        written: {
+          sessions: 0,
+          subscriptions: 0,
+          subscriptionAccessOverrides: 0,
+          processedWebhookEvents: 0,
+          webhookCustomerState: 0,
+        },
+        skipped: {
+          expiredSessions: plan.expiredSessions,
+          duplicateSubscriptions: plan.subscriptionDuplicatesDropped,
+        },
+        dryRun: true,
+      };
+    }
+
+    const written = await writePlan(db, plan);
+
+    log(
+      `Wrote: sessions=${written.sessions}, subscriptions=${written.subscriptions}, ` +
+        `overrides=${written.subscriptionAccessOverrides}, ` +
+        `webhook_events=${written.processedWebhookEvents}, ` +
+        `webhook_customer_state=${written.webhookCustomerState}`,
+    );
+
+    return {
+      appliedVersion: EXPECTED_SCHEMA_VERSION,
+      written,
+      skipped: {
+        expiredSessions: plan.expiredSessions,
+        duplicateSubscriptions: plan.subscriptionDuplicatesDropped,
+      },
+      dryRun: false,
+    };
+  } finally {
+    await client.end({ timeout: 5 });
+  }
+}
+
+interface CliArgs {
+  sqlitePath: string | null;
+  databaseUrl: string | null;
+  dryRun: boolean;
+  allowNonEmpty: boolean;
+}
+
+export function parseCliArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    sqlitePath: null,
+    databaseUrl: null,
+    dryRun: false,
+    allowNonEmpty: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--sqlite-path") {
+      args.sqlitePath = argv[++i] ?? null;
+    } else if (arg === "--database-url") {
+      args.databaseUrl = argv[++i] ?? null;
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
+    } else if (arg === "--allow-non-empty") {
+      args.allowNonEmpty = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+if (import.meta.main) {
+  const cli = parseCliArgs(process.argv.slice(2));
+  const sqlitePath = cli.sqlitePath;
+  const databaseUrl = cli.databaseUrl ?? process.env.BINDERSNAP_DATABASE_URL;
+  if (!sqlitePath) {
+    console.error("--sqlite-path is required.");
+    process.exit(1);
+  }
+  if (!databaseUrl) {
+    console.error("--database-url or BINDERSNAP_DATABASE_URL is required.");
+    process.exit(1);
+  }
+  runMigration({
+    sqlitePath,
+    databaseUrl,
+    dryRun: cli.dryRun,
+    allowNonEmpty: cli.allowNonEmpty,
+  })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+    })
+    .catch((err) => {
+      console.error(err instanceof Error ? err.message : err);
+      process.exit(1);
+    });
+}

--- a/services/api/db/README.md
+++ b/services/api/db/README.md
@@ -27,7 +27,7 @@ The API picks a backend at startup based on `BINDERSNAP_DB_BACKEND`:
 
 When `postgres` is selected, `configureBackends()` calls `assertSchemaVersionMatches` against the database before installing the lazy-store factories. If the `schema_versions` row does not match `EXPECTED_SCHEMA_VERSION`, startup fails with a `SchemaVersionMismatchError` and the API never serves traffic. Run `bun run db:migrate` (or the equivalent CI step) to bring the database forward.
 
-Cutover from SQLite to Postgres is the next slice — a one-shot migration script that reads the existing `sessions.db` from the EC2 host and copies rows into Postgres.
+Cutover from SQLite to Postgres is performed by the one-shot copy script at `scripts/migrate-sqlite-to-postgres.ts`. It reads the existing `sessions.db` from the EC2 host, asserts the destination's `schema_versions` row matches `EXPECTED_SCHEMA_VERSION`, then copies all five tables in a single transaction with `ON CONFLICT DO NOTHING`. Re-running is safe; the script refuses by default if the destination already has rows (override with `--allow-non-empty`).
 
 ## Migration policy
 


### PR DESCRIPTION
## Summary

Adds `scripts/migrate-sqlite-to-postgres.ts`, the one-shot copy that runs once per environment between the migration runner (#249) bringing the Postgres schema up and the API (#251) being flipped to `BINDERSNAP_DB_BACKEND=postgres`.

Reads the EC2 host's existing `sessions.db` (carries all five tables — `sessions`, `subscriptions`, `subscription_access_overrides`, `processed_webhook_events`, `webhook_customer_state`) and copies rows into Postgres in a single transaction with `ON CONFLICT DO NOTHING`, so a partial-failure rerun is safe.

## Behavior

- **Schema-version pre-flight.** Calls the same `assertSchemaVersionMatches` the API uses at startup. If the destination is not at `EXPECTED_SCHEMA_VERSION`, the script aborts before reading any rows.
- **Non-empty destination guard.** Refuses to write if any of the five tables already has rows. Override with `--allow-non-empty` (rerun-after-partial-success path).
- **`--dry-run`.** Reads + plans + prints counts; no writes, no transaction opened.
- **Expired-session drop.** Sessions whose `expires_at <= now` are skipped — copying expired tokens just expands the blast radius of any future leak.
- **Subscription dedup by `stripe_customer_id`.** Postgres has a UNIQUE INDEX on the column. SQLite's `enforceUniqueCustomerBindings` deduplicates at write time, but a historical snapshot may still contain a stale duplicate row. Winner = max `updated_at`; ties broken deterministically by username. Dropped rows are logged.

## Files

- `scripts/migrate-sqlite-to-postgres.ts` — module + CLI.
- `scripts/migrate-sqlite-to-postgres.test.ts` — 10 tests covering `filterLiveSessions`, `dedupeSubscriptionsByCustomerId`, `buildPlan`, `parseCliArgs`, and `readSqliteSnapshot` against a real on-disk SQLite (including the legacy sessions-only schema).
- `services/api/db/README.md` — points at the new script instead of describing it as the next slice.

## Test plan

- [x] `bun test scripts/migrate-sqlite-to-postgres.test.ts` — 10/10 pass.
- [x] `bun run test:ops` — 258/258 pass.
- [x] `bunx tsc --noEmit` — no new errors in changed files.
- [ ] Wet-run dry-run against a real prod SQLite snapshot copied to a scratch box (deferred to cutover slice).

## Workflow evidence

- Issue read: `mcp__github__issue_read get` + `get_comments` on #224.
- Branch created locally off `development/api-going-serverless`; pushed as `infra/224-sqlite-postgres-copy`.
- Commit SHA: `46501e3`.
- PR created via `mcp__github__create_pull_request`.

## Out of scope (next slice)

Token-at-rest envelope encryption on `gitea_token` — planned for the cutover slice. The copy script writes the SQLite plaintext value verbatim into the Postgres column, so the Postgres schema does not yet need split `_ciphertext` / `_dek` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)