### PR TITLE
infra(#224): token-at-rest envelope encryption on gitea_token

### DIFF
--- a/scripts/migrate-sqlite-to-postgres.test.ts
+++ b/scripts/migrate-sqlite-to-postgres.test.ts
@@ -163,12 +163,15 @@ describe("parseCliArgs", () => {
       "/tmp/s.db",
       "--database-url",
       "postgres://x",
+      "--token-encryption-key",
+      "abc=",
       "--dry-run",
       "--allow-non-empty",
     ]);
     expect(args).toEqual({
       sqlitePath: "/tmp/s.db",
       databaseUrl: "postgres://x",
+      tokenEncryptionKey: "abc=",
       dryRun: true,
       allowNonEmpty: true,
     });
@@ -182,6 +185,7 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs([])).toEqual({
       sqlitePath: null,
       databaseUrl: null,
+      tokenEncryptionKey: null,
       dryRun: false,
       allowNonEmpty: false,
     });

--- a/scripts/migrate-sqlite-to-postgres.ts
+++ b/scripts/migrate-sqlite-to-postgres.ts
@@ -12,11 +12,15 @@
 // Usage:
 //   bun run scripts/migrate-sqlite-to-postgres.ts \
 //     --sqlite-path /var/lib/bindersnap/sessions.db \
-//     --database-url "$BINDERSNAP_DATABASE_URL"
+//     --database-url "$BINDERSNAP_DATABASE_URL" \
+//     --token-encryption-key "$BINDERSNAP_TOKEN_ENCRYPTION_KEY"
 //
 // Flags:
 //   --sqlite-path <path>     Source SQLite file. Required.
 //   --database-url <url>     Target Postgres URL. Defaults to env BINDERSNAP_DATABASE_URL.
+//   --token-encryption-key <b64>
+//                            Master key for token-at-rest envelope encryption.
+//                            Defaults to env BINDERSNAP_TOKEN_ENCRYPTION_KEY.
 //   --dry-run                Read + plan only; no writes.
 //   --allow-non-empty        Allow writing into tables that already have rows.
 //                            By default the script refuses, since it is meant
@@ -44,6 +48,10 @@ import {
   EXPECTED_SCHEMA_VERSION,
   assertSchemaVersionMatches,
 } from "../services/api/db/version";
+import {
+  LocalTokenCrypto,
+  type TokenCrypto,
+} from "../services/api/token-crypto";
 
 export interface SourceSessionRow {
   id: string;
@@ -107,6 +115,11 @@ export interface MigrationPlan {
 export interface MigrationOptions {
   sqlitePath: string;
   databaseUrl: string;
+  // Master key for token-at-rest envelope encryption. Required unless
+  // `tokenCrypto` is passed explicitly (tests). Base64 of 32 bytes.
+  tokenEncryptionKey?: string;
+  // Override for tests so we don't have to round-trip a base64 string.
+  tokenCrypto?: TokenCrypto;
   dryRun?: boolean;
   allowNonEmpty?: boolean;
   now?: number;
@@ -398,9 +411,14 @@ export class DestinationNotEmptyError extends Error {
 // Writes the plan into Postgres inside a single transaction. ON CONFLICT DO
 // NOTHING means re-running the script after a partial success is safe — rows
 // already present are not overwritten.
+//
+// Session rows are envelope-encrypted before insertion: each row gets a
+// per-session DEK wrapped by the master key supplied via `crypto`. The raw
+// plaintext giteaToken from SQLite never lands in Postgres.
 export async function writePlan(
   db: PostgresJsDatabase,
   plan: MigrationPlan,
+  crypto: TokenCrypto,
 ): Promise<MigrationResult["written"]> {
   const written: MigrationResult["written"] = {
     sessions: 0,
@@ -410,11 +428,26 @@ export async function writePlan(
     webhookCustomerState: 0,
   };
 
+  const encryptedSessionRows = await Promise.all(
+    plan.sessions.map(async (row) => {
+      const { ciphertext, wrappedDek } = await crypto.encrypt(row.giteaToken);
+      return {
+        id: row.id,
+        username: row.username,
+        giteaTokenCiphertext: ciphertext,
+        giteaTokenDek: wrappedDek,
+        giteaTokenName: row.giteaTokenName,
+        createdAt: row.createdAt,
+        expiresAt: row.expiresAt,
+      };
+    }),
+  );
+
   await db.transaction(async (tx) => {
-    if (plan.sessions.length > 0) {
+    if (encryptedSessionRows.length > 0) {
       const inserted = await tx
         .insert(sessions)
-        .values(plan.sessions)
+        .values(encryptedSessionRows)
         .onConflictDoNothing({ target: sessions.id })
         .returning({ id: sessions.id });
       written.sessions = inserted.length;
@@ -466,6 +499,17 @@ export async function runMigration(
   const log = options.logger ?? ((line) => console.log(line));
   const now = options.now ?? Date.now();
 
+  const crypto =
+    options.tokenCrypto ??
+    (options.tokenEncryptionKey
+      ? LocalTokenCrypto.fromBase64(options.tokenEncryptionKey)
+      : null);
+  if (!crypto) {
+    throw new Error(
+      "tokenEncryptionKey (or tokenCrypto) is required to copy sessions into Postgres.",
+    );
+  }
+
   const snapshot = readSqliteSnapshot(options.sqlitePath);
   const plan = buildPlan(snapshot, now);
 
@@ -516,7 +560,7 @@ export async function runMigration(
       };
     }
 
-    const written = await writePlan(db, plan);
+    const written = await writePlan(db, plan, crypto);
 
     log(
       `Wrote: sessions=${written.sessions}, subscriptions=${written.subscriptions}, ` +
@@ -542,6 +586,7 @@ export async function runMigration(
 interface CliArgs {
   sqlitePath: string | null;
   databaseUrl: string | null;
+  tokenEncryptionKey: string | null;
   dryRun: boolean;
   allowNonEmpty: boolean;
 }
@@ -550,6 +595,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
   const args: CliArgs = {
     sqlitePath: null,
     databaseUrl: null,
+    tokenEncryptionKey: null,
     dryRun: false,
     allowNonEmpty: false,
   };
@@ -559,6 +605,8 @@ export function parseCliArgs(argv: string[]): CliArgs {
       args.sqlitePath = argv[++i] ?? null;
     } else if (arg === "--database-url") {
       args.databaseUrl = argv[++i] ?? null;
+    } else if (arg === "--token-encryption-key") {
+      args.tokenEncryptionKey = argv[++i] ?? null;
     } else if (arg === "--dry-run") {
       args.dryRun = true;
     } else if (arg === "--allow-non-empty") {
@@ -574,6 +622,8 @@ if (import.meta.main) {
   const cli = parseCliArgs(process.argv.slice(2));
   const sqlitePath = cli.sqlitePath;
   const databaseUrl = cli.databaseUrl ?? process.env.BINDERSNAP_DATABASE_URL;
+  const tokenEncryptionKey =
+    cli.tokenEncryptionKey ?? process.env.BINDERSNAP_TOKEN_ENCRYPTION_KEY;
   if (!sqlitePath) {
     console.error("--sqlite-path is required.");
     process.exit(1);
@@ -582,9 +632,16 @@ if (import.meta.main) {
     console.error("--database-url or BINDERSNAP_DATABASE_URL is required.");
     process.exit(1);
   }
+  if (!tokenEncryptionKey) {
+    console.error(
+      "--token-encryption-key or BINDERSNAP_TOKEN_ENCRYPTION_KEY is required.",
+    );
+    process.exit(1);
+  }
   runMigration({
     sqlitePath,
     databaseUrl,
+    tokenEncryptionKey,
     dryRun: cli.dryRun,
     allowNonEmpty: cli.allowNonEmpty,
   })

--- a/services/api/config.test.ts
+++ b/services/api/config.test.ts
@@ -112,17 +112,20 @@ describe("API config", () => {
 
   test("dbBackend defaults to sqlite and accepts postgres alias", () => {
     const url = "postgres://u:p@localhost:5432/db";
+    const key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
     expect(initializeConfig({}).dbBackend).toBe("sqlite");
     expect(
       initializeConfig({
         BINDERSNAP_DB_BACKEND: "POSTGRES",
         BINDERSNAP_DATABASE_URL: url,
+        BINDERSNAP_TOKEN_ENCRYPTION_KEY: key,
       }).dbBackend,
     ).toBe("postgres");
     expect(
       initializeConfig({
         BINDERSNAP_DB_BACKEND: "postgresql",
         BINDERSNAP_DATABASE_URL: url,
+        BINDERSNAP_TOKEN_ENCRYPTION_KEY: key,
       }).dbBackend,
     ).toBe("postgres");
   });
@@ -143,10 +146,23 @@ describe("API config", () => {
     const config = initializeConfig({
       BINDERSNAP_DB_BACKEND: "postgres",
       BINDERSNAP_DATABASE_URL: "postgres://user:pw@localhost:5432/bindersnap",
+      BINDERSNAP_TOKEN_ENCRYPTION_KEY:
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
     });
     expect(config.dbBackend).toBe("postgres");
     expect(config.databaseUrl).toBe(
       "postgres://user:pw@localhost:5432/bindersnap",
+    );
+  });
+
+  test("postgres backend requires BINDERSNAP_TOKEN_ENCRYPTION_KEY", () => {
+    expect(() =>
+      initializeConfig({
+        BINDERSNAP_DB_BACKEND: "postgres",
+        BINDERSNAP_DATABASE_URL: "postgres://user:pw@localhost:5432/bindersnap",
+      }),
+    ).toThrow(
+      "BINDERSNAP_TOKEN_ENCRYPTION_KEY is required when BINDERSNAP_DB_BACKEND=postgres.",
     );
   });
 });

--- a/services/api/config.ts
+++ b/services/api/config.ts
@@ -35,6 +35,7 @@ export interface ApiConfig {
   sessionsDbPath: string;
   dbBackend: DbBackend;
   databaseUrl: string;
+  tokenEncryptionKey: string;
   logLevel: LogLevel;
 }
 
@@ -74,6 +75,7 @@ const STRING_ENV: Record<string, StringSpec> = {
   BINDERSNAP_SESSIONS_DB_PATH: { default: "/var/lib/bindersnap/sessions.db" },
   BINDERSNAP_DB_BACKEND: { default: "sqlite" },
   BINDERSNAP_DATABASE_URL: { default: "" },
+  BINDERSNAP_TOKEN_ENCRYPTION_KEY: { default: "" },
   LOG_LEVEL: { default: "" },
 };
 
@@ -285,6 +287,29 @@ function resolveDatabaseUrl(
   return value;
 }
 
+// Master key for token-at-rest envelope encryption. Required whenever the
+// Postgres backend is selected; ignored when running the SQLite backend on the
+// local-dev host. Value is the base64 encoding of 32 random bytes (e.g.,
+// `openssl rand -base64 32`); the LocalTokenCrypto constructor enforces the
+// decoded length.
+function resolveTokenEncryptionKey(
+  env: NodeJS.ProcessEnv,
+  isProduction: boolean,
+  backend: DbBackend,
+): string {
+  const value = parseString(
+    env,
+    "BINDERSNAP_TOKEN_ENCRYPTION_KEY",
+    isProduction,
+  );
+  if (backend === "postgres" && value === "") {
+    throw new Error(
+      "BINDERSNAP_TOKEN_ENCRYPTION_KEY is required when BINDERSNAP_DB_BACKEND=postgres.",
+    );
+  }
+  return value;
+}
+
 function resolveLogLevel(
   env: NodeJS.ProcessEnv,
   isProduction: boolean,
@@ -461,6 +486,11 @@ export function initializeConfig(
     ),
     dbBackend: dbBackend,
     databaseUrl: resolveDatabaseUrl(resolvedEnv, isProduction, dbBackend),
+    tokenEncryptionKey: resolveTokenEncryptionKey(
+      resolvedEnv,
+      isProduction,
+      dbBackend,
+    ),
     logLevel: resolveLogLevel(resolvedEnv, isProduction),
   };
 }

--- a/services/api/db/configure.ts
+++ b/services/api/db/configure.ts
@@ -4,6 +4,7 @@ import {
   setSubscriptionBackendFactory,
   setWebhookEventBackendFactory,
 } from "../subscriptions";
+import { LocalTokenCrypto, type TokenCrypto } from "../token-crypto";
 import { getPostgresDb } from "./client";
 import { PostgresSessionBackend } from "./postgres-sessions";
 import {
@@ -17,9 +18,12 @@ import { assertSchemaVersionMatches } from "./version";
 //
 // Postgres path additionally runs the schema-version probe so the API refuses
 // to serve traffic against a database the migration runner has not brought up
-// to date. Returns the chosen backend so callers can log it.
+// to date, and builds the TokenCrypto from BINDERSNAP_TOKEN_ENCRYPTION_KEY so
+// every session row is envelope-encrypted at rest. Returns the chosen backend
+// so callers can log it.
 export async function configureBackends(
   apiConfig: ApiConfig = config,
+  cryptoOverride?: TokenCrypto,
 ): Promise<"sqlite" | "postgres"> {
   if (apiConfig.dbBackend === "sqlite") {
     return "sqlite";
@@ -28,7 +32,10 @@ export async function configureBackends(
   const db = getPostgresDb({ url: apiConfig.databaseUrl });
   await assertSchemaVersionMatches(db);
 
-  setSessionBackendFactory(() => new PostgresSessionBackend(db));
+  const crypto =
+    cryptoOverride ?? LocalTokenCrypto.fromBase64(apiConfig.tokenEncryptionKey);
+
+  setSessionBackendFactory(() => new PostgresSessionBackend(crypto, db));
   setSubscriptionBackendFactory(() => new PostgresSubscriptionBackend(db));
   setWebhookEventBackendFactory(() => new PostgresWebhookEventBackend(db));
 

--- a/services/api/db/migrations/0001_token_envelope_encryption.sql
+++ b/services/api/db/migrations/0001_token_envelope_encryption.sql
@@ -1,0 +1,20 @@
+-- Replace plaintext `sessions.gitea_token` with envelope-encrypted columns.
+--
+-- `gitea_token_ciphertext` holds the gitea_token sealed with a per-session DEK
+-- (AES-256-GCM). `gitea_token_dek` holds that DEK wrapped by the master key
+-- (KMS CMK in production; BINDERSNAP_TOKEN_ENCRYPTION_KEY in local/dev). See
+-- services/api/token-crypto.ts for the framing.
+--
+-- Destructive: any rows present in `sessions` at apply time are deleted. This
+-- is acceptable because no Postgres deployment has been promoted to production
+-- yet — SQLite remains authoritative until the cutover slice. The one-shot
+-- migration script (scripts/migrate-sqlite-to-postgres.ts) re-encrypts session
+-- rows with the configured TokenCrypto when it copies them across.
+
+DELETE FROM "sessions";
+--> statement-breakpoint
+ALTER TABLE "sessions" DROP COLUMN "gitea_token";
+--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "gitea_token_ciphertext" bytea NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "gitea_token_dek" bytea NOT NULL;

--- a/services/api/db/migrations/meta/0001_snapshot.json
+++ b/services/api/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,310 @@
+{
+  "id": "4f9b7c1e-8a62-4a3b-b1e0-1bc7f3e62a01",
+  "prevId": "122e47a4-6d35-4d65-8598-dd3b8ca0a139",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.processed_webhook_events": {
+      "name": "processed_webhook_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schema_versions": {
+      "name": "schema_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_token_ciphertext": {
+          "name": "gitea_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_token_dek": {
+          "name": "gitea_token_dek",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_token_name": {
+          "name": "gitea_token_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires": {
+          "name": "idx_sessions_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_access_overrides": {
+      "name": "subscription_access_overrides",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access": {
+          "name": "access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_customer": {
+          "name": "idx_subscriptions_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_customer_state": {
+      "name": "webhook_customer_state",
+      "schema": "",
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_created_at": {
+          "name": "last_event_created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/db/migrations/meta/_journal.json
+++ b/services/api/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1778203217592,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1778808600000,
+      "tag": "0001_token_envelope_encryption",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/db/postgres-sessions.ts
+++ b/services/api/db/postgres-sessions.ts
@@ -1,16 +1,24 @@
 import { eq, lte } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { type SessionBackend, type SessionRecord } from "../sessions";
+import type { TokenCrypto } from "../token-crypto";
 import { getPostgresDb } from "./client";
 import { sessions } from "./schema";
 
-// Postgres-backed SessionBackend. Uses the shared lazy client unless an
-// explicit drizzle instance is passed in (tests). Schema is owned by the
-// migration runner — this file only reads/writes rows.
+// Postgres-backed SessionBackend. Stores `gitea_token` envelope-encrypted at
+// rest (see token-crypto.ts): each row carries a per-session DEK (wrapped by
+// the master key) plus a GCM-sealed token ciphertext. A pg_dump of `sessions`
+// therefore contains neither plaintext tokens nor unwrapped DEKs.
+//
+// Schema ownership stays with the migration runner — this file only
+// reads/writes rows. The shared lazy client is used unless an explicit drizzle
+// instance is passed (tests).
 export class PostgresSessionBackend implements SessionBackend {
   private readonly db: PostgresJsDatabase;
+  private readonly crypto: TokenCrypto;
 
-  constructor(db?: PostgresJsDatabase) {
+  constructor(crypto: TokenCrypto, db?: PostgresJsDatabase) {
+    this.crypto = crypto;
     this.db = db ?? getPostgresDb();
   }
 
@@ -22,23 +30,20 @@ export class PostgresSessionBackend implements SessionBackend {
       .limit(1);
     const row = rows[0];
     if (!row) return null;
-    return {
-      id: row.id,
-      username: row.username,
-      giteaToken: row.giteaToken,
-      giteaTokenName: row.giteaTokenName,
-      createdAt: row.createdAt,
-      expiresAt: row.expiresAt,
-    };
+    return this.rowToRecord(row);
   }
 
   async put(session: SessionRecord): Promise<void> {
+    const { ciphertext, wrappedDek } = await this.crypto.encrypt(
+      session.giteaToken,
+    );
     await this.db
       .insert(sessions)
       .values({
         id: session.id,
         username: session.username,
-        giteaToken: session.giteaToken,
+        giteaTokenCiphertext: ciphertext,
+        giteaTokenDek: wrappedDek,
         giteaTokenName: session.giteaTokenName,
         createdAt: session.createdAt,
         expiresAt: session.expiresAt,
@@ -47,7 +52,8 @@ export class PostgresSessionBackend implements SessionBackend {
         target: sessions.id,
         set: {
           username: session.username,
-          giteaToken: session.giteaToken,
+          giteaTokenCiphertext: ciphertext,
+          giteaTokenDek: wrappedDek,
           giteaTokenName: session.giteaTokenName,
           createdAt: session.createdAt,
           expiresAt: session.expiresAt,
@@ -67,13 +73,33 @@ export class PostgresSessionBackend implements SessionBackend {
       .delete(sessions)
       .where(lte(sessions.expiresAt, now))
       .returning();
-    return rows.map((row) => ({
+    const records: SessionRecord[] = [];
+    for (const row of rows) {
+      records.push(await this.rowToRecord(row));
+    }
+    return records;
+  }
+
+  private async rowToRecord(row: {
+    id: string;
+    username: string;
+    giteaTokenCiphertext: Buffer;
+    giteaTokenDek: Buffer;
+    giteaTokenName: string;
+    createdAt: number;
+    expiresAt: number;
+  }): Promise<SessionRecord> {
+    const giteaToken = await this.crypto.decrypt(
+      row.giteaTokenCiphertext,
+      row.giteaTokenDek,
+    );
+    return {
       id: row.id,
       username: row.username,
-      giteaToken: row.giteaToken,
+      giteaToken,
       giteaTokenName: row.giteaTokenName,
       createdAt: row.createdAt,
       expiresAt: row.expiresAt,
-    }));
+    };
   }
 }

--- a/services/api/db/schema.ts
+++ b/services/api/db/schema.ts
@@ -6,7 +6,17 @@ import {
   index,
   uniqueIndex,
   integer,
+  customType,
 } from "drizzle-orm/pg-core";
+
+// Postgres bytea, surfaced as a Buffer in TypeScript. Used for the envelope-
+// encrypted gitea_token blobs in `sessions`. postgres-js handles the binary
+// transport natively; drizzle just needs to know the column type name.
+export const bytea = customType<{ data: Buffer; default: false }>({
+  dataType() {
+    return "bytea";
+  },
+});
 
 // Single source of truth for the API service's Postgres schema.
 // Mirrors the SQLite shapes in services/api/sessions.ts and subscriptions.ts.
@@ -20,7 +30,12 @@ export const sessions = pgTable(
   {
     id: text("id").primaryKey(),
     username: text("username").notNull(),
-    giteaToken: text("gitea_token").notNull(),
+    // Envelope-encrypted token at rest. `gitea_token_ciphertext` holds the
+    // gitea_token sealed with a per-session DEK; `gitea_token_dek` holds that
+    // DEK wrapped by the master key (KMS CMK in prod, BINDERSNAP_TOKEN_ENCRYPTION_KEY
+    // in local/dev). See services/api/token-crypto.ts.
+    giteaTokenCiphertext: bytea("gitea_token_ciphertext").notNull(),
+    giteaTokenDek: bytea("gitea_token_dek").notNull(),
     giteaTokenName: text("gitea_token_name").notNull(),
     createdAt: bigint("created_at", { mode: "number" }).notNull(),
     expiresAt: bigint("expires_at", { mode: "number" }).notNull(),

--- a/services/api/db/version.ts
+++ b/services/api/db/version.ts
@@ -8,7 +8,7 @@ import { schemaVersions } from "./schema";
 //
 // Format: ISO-like string keyed to the migration journal entry that introduced
 // the change. Keep in sync with the latest entry in db/migrations/meta/_journal.json.
-export const EXPECTED_SCHEMA_VERSION = "0000_initial";
+export const EXPECTED_SCHEMA_VERSION = "0001_token_envelope_encryption";
 
 export class SchemaVersionMismatchError extends Error {
   constructor(

--- a/services/api/token-crypto.test.ts
+++ b/services/api/token-crypto.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { LocalTokenCrypto } from "./token-crypto";
+
+function freshCrypto(): LocalTokenCrypto {
+  return new LocalTokenCrypto(randomBytes(32));
+}
+
+describe("LocalTokenCrypto", () => {
+  test("round-trips a token", async () => {
+    const crypto = freshCrypto();
+    const { ciphertext, wrappedDek } = await crypto.encrypt("tok_abc123");
+    const out = await crypto.decrypt(ciphertext, wrappedDek);
+    expect(out).toBe("tok_abc123");
+  });
+
+  test("ciphertext does not contain the plaintext", async () => {
+    const crypto = freshCrypto();
+    const plaintext = "tok_super_secret_value_42";
+    const { ciphertext, wrappedDek } = await crypto.encrypt(plaintext);
+    expect(ciphertext.toString("utf8")).not.toContain(plaintext);
+    expect(wrappedDek.toString("utf8")).not.toContain(plaintext);
+  });
+
+  test("each encrypt produces a different DEK and IV", async () => {
+    const crypto = freshCrypto();
+    const a = await crypto.encrypt("tok");
+    const b = await crypto.encrypt("tok");
+    expect(a.ciphertext.equals(b.ciphertext)).toBe(false);
+    expect(a.wrappedDek.equals(b.wrappedDek)).toBe(false);
+  });
+
+  test("ciphertext tampering is rejected by the GCM auth tag", async () => {
+    const crypto = freshCrypto();
+    const { ciphertext, wrappedDek } = await crypto.encrypt("tok_abc123");
+    const lastIdx = ciphertext.length - 1;
+    ciphertext[lastIdx] = (ciphertext[lastIdx] ?? 0) ^ 0xff;
+    await expect(crypto.decrypt(ciphertext, wrappedDek)).rejects.toThrow();
+  });
+
+  test("wrappedDek tampering is rejected", async () => {
+    const crypto = freshCrypto();
+    const { ciphertext, wrappedDek } = await crypto.encrypt("tok_abc123");
+    const lastIdx = wrappedDek.length - 1;
+    wrappedDek[lastIdx] = (wrappedDek[lastIdx] ?? 0) ^ 0xff;
+    await expect(crypto.decrypt(ciphertext, wrappedDek)).rejects.toThrow();
+  });
+
+  test("a different master key cannot decrypt", async () => {
+    const a = freshCrypto();
+    const b = freshCrypto();
+    const { ciphertext, wrappedDek } = await a.encrypt("tok_abc123");
+    await expect(b.decrypt(ciphertext, wrappedDek)).rejects.toThrow();
+  });
+
+  test("fromBase64 requires 32 decoded bytes", () => {
+    expect(() => LocalTokenCrypto.fromBase64("dG9vc2hvcnQ=")).toThrow(
+      /32 bytes/,
+    );
+    const valid = randomBytes(32).toString("base64");
+    expect(() => LocalTokenCrypto.fromBase64(valid)).not.toThrow();
+  });
+
+  test("constructor rejects wrong-sized keys", () => {
+    expect(() => new LocalTokenCrypto(randomBytes(16))).toThrow(/32 bytes/);
+  });
+});

--- a/services/api/token-crypto.ts
+++ b/services/api/token-crypto.ts
@@ -1,0 +1,122 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  type CipherGCM,
+  type DecipherGCM,
+} from "node:crypto";
+
+// Envelope-encryption primitive for `gitea_token` at rest in Postgres.
+//
+// Encrypt path:
+//   1. Generate a random 32-byte DEK (data-encryption key) per session.
+//   2. AES-256-GCM encrypt the token with the DEK → `ciphertext` blob.
+//   3. Wrap the DEK by AES-256-GCM encrypting it with a master key → `wrappedDek`.
+//   4. Persist `ciphertext` and `wrappedDek` side by side; the master key never
+//      lands in the database, and the DEK never lands unwrapped.
+//
+// Decrypt path runs in reverse. A pg_dump of the sessions table therefore
+// reveals neither plaintext tokens nor unwrapped DEKs.
+//
+// The current LocalTokenCrypto holds the master key in process memory, loaded
+// from BINDERSNAP_TOKEN_ENCRYPTION_KEY (base64-encoded 32 bytes). Issue #224
+// will swap this for an AWS-KMS-backed adapter in the Lambda cutover slice:
+// KMS.GenerateDataKey replaces our random DEK + manual wrap step, and
+// KMS.Decrypt replaces the manual unwrap. The interface and on-disk blob
+// shapes stay identical so the swap doesn't require a data migration.
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTES = 32; // AES-256
+const IV_BYTES = 12; // GCM standard 96-bit nonce
+const TAG_BYTES = 16; // GCM auth tag
+
+export interface EncryptedToken {
+  ciphertext: Buffer;
+  wrappedDek: Buffer;
+}
+
+export interface TokenCrypto {
+  encrypt(plaintext: string): Promise<EncryptedToken>;
+  decrypt(ciphertext: Buffer, wrappedDek: Buffer): Promise<string>;
+}
+
+// Frame: iv (12 bytes) || tag (16 bytes) || ciphertext (n bytes).
+// Same wire format is used for both the DEK wrap and the token ciphertext so
+// they can be unwrapped with the same primitive.
+function sealWithKey(key: Buffer, plaintext: Buffer): Buffer {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv) as CipherGCM;
+  const ct = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ct]);
+}
+
+function openWithKey(key: Buffer, framed: Buffer): Buffer {
+  if (framed.length < IV_BYTES + TAG_BYTES) {
+    throw new Error("encrypted blob is too short to be a valid AES-GCM frame");
+  }
+  const iv = framed.subarray(0, IV_BYTES);
+  const tag = framed.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
+  const ct = framed.subarray(IV_BYTES + TAG_BYTES);
+  const decipher = createDecipheriv(ALGORITHM, key, iv) as DecipherGCM;
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]);
+}
+
+// Master-key-in-memory implementation. Suitable for local dev, integration
+// tests, and a stop-gap production deployment where the master key is loaded
+// from Secrets Manager into the Lambda environment. The KMS adapter (future)
+// will share this class's public interface but call KMS.GenerateDataKey /
+// KMS.Decrypt instead of doing the wrap step locally.
+export class LocalTokenCrypto implements TokenCrypto {
+  constructor(private readonly masterKey: Buffer) {
+    if (masterKey.length !== KEY_BYTES) {
+      throw new Error(
+        `LocalTokenCrypto master key must be ${KEY_BYTES} bytes; got ${masterKey.length}`,
+      );
+    }
+  }
+
+  static fromBase64(masterKeyBase64: string): LocalTokenCrypto {
+    const key = Buffer.from(masterKeyBase64, "base64");
+    if (key.length !== KEY_BYTES) {
+      throw new Error(
+        `BINDERSNAP_TOKEN_ENCRYPTION_KEY must decode to ${KEY_BYTES} bytes; got ${key.length}`,
+      );
+    }
+    return new LocalTokenCrypto(key);
+  }
+
+  async encrypt(plaintext: string): Promise<EncryptedToken> {
+    const dek = randomBytes(KEY_BYTES);
+    const ciphertext = sealWithKey(dek, Buffer.from(plaintext, "utf8"));
+    const wrappedDek = sealWithKey(this.masterKey, dek);
+    return { ciphertext, wrappedDek };
+  }
+
+  async decrypt(ciphertext: Buffer, wrappedDek: Buffer): Promise<string> {
+    const dek = openWithKey(this.masterKey, wrappedDek);
+    try {
+      const plaintext = openWithKey(dek, ciphertext);
+      return plaintext.toString("utf8");
+    } finally {
+      dek.fill(0);
+    }
+  }
+}
+
+// Identity adapter used by the SQLite session backend, which still stores the
+// token as plaintext in a local file. Keeps the type signature of
+// PostgresSessionBackend uniform without forcing SQLite to pay for a wrap.
+export class NoopTokenCrypto implements TokenCrypto {
+  async encrypt(plaintext: string): Promise<EncryptedToken> {
+    return {
+      ciphertext: Buffer.from(plaintext, "utf8"),
+      wrappedDek: Buffer.alloc(0),
+    };
+  }
+
+  async decrypt(ciphertext: Buffer): Promise<string> {
+    return ciphertext.toString("utf8");
+  }
+}


### PR DESCRIPTION
Closes one acceptance criterion on #224: token-at-rest envelope encryption is preserved on the Postgres backend.

## What

- New primitive: `services/api/token-crypto.ts`
  - `LocalTokenCrypto` generates a random AES-256 DEK per session, AES-GCM-encrypts the gitea_token with the DEK, then AES-GCM-wraps the DEK with a master key.
  - Interface matches AWS KMS `GenerateDataKey` / `Decrypt` so a future `KmsTokenCrypto` drops in with no schema or wire-format change.
- Schema (`0001_token_envelope_encryption`): drop `gitea_token`, add `gitea_token_ciphertext bytea NOT NULL` + `gitea_token_dek bytea NOT NULL`. `EXPECTED_SCHEMA_VERSION` bumped. Destructive — Postgres is not yet authoritative anywhere.
- `PostgresSessionBackend` now takes a `TokenCrypto`, encrypts on put, decrypts on get/reap.
- `configureBackends` builds a `LocalTokenCrypto` from `BINDERSNAP_TOKEN_ENCRYPTION_KEY`; required when `BINDERSNAP_DB_BACKEND=postgres`.
- `scripts/migrate-sqlite-to-postgres.ts` encrypts each session row while copying. New `--token-encryption-key` flag (defaults to env).

## Why

Acceptance criterion from the 2026-05-07 comment thread on #224:

> Token-at-rest envelope encryption preserved: `gitea_token_ciphertext` + `gitea_token_dek` columns wrapped by a KMS CMK; a `pg_dump` reveals no plaintext tokens.

The KMS-backed adapter is the next slice (it requires the AWS SDK, which Lambda will already pull in). The local adapter holds the master key in process memory, sourced from Secrets Manager in production — the schema and crypto envelope are identical, so swapping in KMS is a one-class change.

## Tests

- `services/api/token-crypto.test.ts` — round-trip, plaintext-absence-in-ciphertext, GCM tampering rejection on both ciphertext and wrapped DEK, wrong-master-key rejection, key-size validation.
- Updated `config.test.ts` for the new env var.
- Full suite: 267 tests pass (`bun run test:ops`).

## Workflow evidence

- Issue read: `mcp__github__issue_read` (#224 body + 3 comments)
- Branch creation: local `git checkout -b` (working-tree operation)
- Commit SHA: `c797d2da2b9eb14dadcc4c9b2100d38542343470`
- PR creation: `mcp__github__create_pull_request`
- No fallbacks used

Refs #224.