### PR TITLE
infra(#224): extract session reaper for out-of-process invocation

### DIFF
--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import { config, type SessionCookieSameSite } from "./config";
 import { configureBackends } from "./db/configure";
 import { logger } from "./logger";
+import { runSessionReaper } from "./session-reaper";
 import { sessionStore, type SessionRecord } from "./sessions";
 import {
   subscriptionStore,
@@ -3667,13 +3668,12 @@ async function handleBillingPortal(
 
 async function cleanupExpiredSessions(): Promise<void> {
   const now = Date.now();
-  const expired = await sessionStore.reap(now);
-
-  if (expired.length > 0) {
-    await Promise.allSettled(
-      expired.map((session) => revokeUserToken(session)),
-    );
-  }
+  await runSessionReaper({
+    sessionStore,
+    revoke: revokeUserToken,
+    now,
+    logger,
+  });
 
   for (const [key, entry] of authAttempts.entries()) {
     if (entry.resetAt <= now) {

--- a/services/api/session-reaper.integration.test.ts
+++ b/services/api/session-reaper.integration.test.ts
@@ -1,0 +1,220 @@
+// Integration tests for the session reaper composed with a real
+// SessionBackend implementation. The unit tests in session-reaper.test.ts
+// cover orchestration with a mock backend; these exercise the actual
+// SQL/round-trips:
+//
+//   - real SessionStore (in-memory SQLite) — always runs
+//   - real PostgresSessionBackend — runs only when BINDERSNAP_TEST_DATABASE_URL
+//     is set, since we don't carry a PGlite dep yet. The local Compose stack
+//     and CI can opt in.
+//
+// What "integration" means here:
+//   - rows are actually inserted via the backend's put() path,
+//   - reap() actually deletes them in SQL,
+//   - the reaper calls revoke() with whatever the backend hands back
+//     (important for Postgres, where the token is decrypted from the
+//     envelope on its way out).
+
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import postgres from "postgres";
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
+import { runSessionReaper } from "./session-reaper";
+import { SessionStore, type SessionRecord } from "./sessions";
+import { PostgresSessionBackend } from "./db/postgres-sessions";
+import { LocalTokenCrypto } from "./token-crypto";
+
+function makeSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  const now = 1_700_000_000_000;
+  return {
+    id: `sess-${Math.random().toString(36).slice(2, 10)}`,
+    username: "alice",
+    giteaToken: "tok_plain_xyz",
+    giteaTokenName: "bindersnap-session",
+    createdAt: now,
+    expiresAt: now + 60_000,
+    ...overrides,
+  };
+}
+
+describe("session reaper × SessionStore (SQLite, integration)", () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore(":memory:");
+  });
+
+  test("reaps only expired rows and leaves live ones in place", async () => {
+    const live = makeSession({ id: "live-1", expiresAt: 10_000 });
+    const expiredA = makeSession({
+      id: "expired-a",
+      username: "alice",
+      expiresAt: 1_000,
+    });
+    const expiredB = makeSession({
+      id: "expired-b",
+      username: "bob",
+      expiresAt: 1_500,
+    });
+    await store.put(live);
+    await store.put(expiredA);
+    await store.put(expiredB);
+
+    const revoked: string[] = [];
+    const result = await runSessionReaper({
+      sessionStore: store,
+      revoke: async (s) => {
+        revoked.push(s.id);
+      },
+      now: 5_000,
+    });
+
+    expect(result).toEqual({ reaped: 2, revokeErrors: 0 });
+    expect(revoked.sort()).toEqual(["expired-a", "expired-b"]);
+    expect(await store.get("live-1")).not.toBeNull();
+    expect(await store.get("expired-a")).toBeNull();
+    expect(await store.get("expired-b")).toBeNull();
+  });
+
+  test("revoke receives the round-tripped session record", async () => {
+    const sess = makeSession({
+      id: "rt-1",
+      username: "carol",
+      giteaToken: "tok_unique_carol",
+      giteaTokenName: "carol-tok",
+      expiresAt: 1_000,
+    });
+    await store.put(sess);
+
+    let observed: SessionRecord | null = null;
+    await runSessionReaper({
+      sessionStore: store,
+      revoke: async (s) => {
+        observed = s;
+      },
+      now: 5_000,
+    });
+
+    expect(observed).not.toBeNull();
+    expect(observed!).toMatchObject({
+      id: "rt-1",
+      username: "carol",
+      giteaToken: "tok_unique_carol",
+      giteaTokenName: "carol-tok",
+    });
+  });
+
+  test("revoke failures still result in rows being deleted", async () => {
+    const sess = makeSession({ id: "rev-fail", expiresAt: 1_000 });
+    await store.put(sess);
+
+    const result = await runSessionReaper({
+      sessionStore: store,
+      revoke: async () => {
+        throw new Error("gitea unreachable");
+      },
+      now: 5_000,
+    });
+
+    expect(result).toEqual({ reaped: 1, revokeErrors: 1 });
+    // SessionStore.reap() deletes inside the same call that returns the rows;
+    // a failing revoke must not resurrect the row.
+    expect(await store.get("rev-fail")).toBeNull();
+  });
+
+  test("empty table is a no-op", async () => {
+    const result = await runSessionReaper({
+      sessionStore: store,
+      revoke: async () => {
+        throw new Error("revoke must not be called");
+      },
+      now: 5_000,
+    });
+    expect(result).toEqual({ reaped: 0, revokeErrors: 0 });
+  });
+
+  test("a row whose expires_at equals now is reaped (boundary)", async () => {
+    const sess = makeSession({ id: "boundary", expiresAt: 5_000 });
+    await store.put(sess);
+
+    const result = await runSessionReaper({
+      sessionStore: store,
+      revoke: async () => {},
+      now: 5_000,
+    });
+    expect(result.reaped).toBe(1);
+    expect(await store.get("boundary")).toBeNull();
+  });
+});
+
+const POSTGRES_URL = process.env.BINDERSNAP_TEST_DATABASE_URL;
+const describePg = POSTGRES_URL ? describe : describe.skip;
+
+describePg("session reaper × PostgresSessionBackend (integration)", () => {
+  // Skip-when-env-unset pattern: gives the local Compose stack and CI a path
+  // to exercise the production backend without forcing every contributor to
+  // run Postgres. CI sets BINDERSNAP_TEST_DATABASE_URL against a throwaway db.
+  let client: ReturnType<typeof postgres>;
+  let db: PostgresJsDatabase;
+  let backend: PostgresSessionBackend;
+
+  beforeEach(async () => {
+    client = postgres(POSTGRES_URL!, { max: 2, prepare: false });
+    db = drizzle(client);
+    // Tests are responsible for a clean slate. The migration runner is the
+    // canonical schema source; we assume it has been run against the test DB.
+    await db.execute(sql`TRUNCATE TABLE sessions`);
+    const masterKey = Buffer.alloc(32, 0xab);
+    backend = new PostgresSessionBackend(new LocalTokenCrypto(masterKey), db);
+  });
+
+  afterAll(async () => {
+    await client?.end({ timeout: 5 });
+  });
+
+  test("reaps only expired rows and decrypts tokens for revoke", async () => {
+    const live = makeSession({ id: "pg-live", expiresAt: 10_000 });
+    const expired = makeSession({
+      id: "pg-expired",
+      username: "dora",
+      giteaToken: "tok_pg_secret",
+      expiresAt: 1_000,
+    });
+    await backend.put(live);
+    await backend.put(expired);
+
+    const handed: SessionRecord[] = [];
+    const result = await runSessionReaper({
+      sessionStore: backend,
+      revoke: async (s) => {
+        handed.push(s);
+      },
+      now: 5_000,
+    });
+
+    expect(result).toEqual({ reaped: 1, revokeErrors: 0 });
+    expect(handed).toHaveLength(1);
+    expect(handed[0]!.id).toBe("pg-expired");
+    // Critical: the reaper must hand the *decrypted* token to revoke, not the
+    // ciphertext blob. Otherwise the Gitea DELETE would never authenticate.
+    expect(handed[0]!.giteaToken).toBe("tok_pg_secret");
+    expect(await backend.get("pg-live")).not.toBeNull();
+    expect(await backend.get("pg-expired")).toBeNull();
+  });
+
+  test("revoke failure still removes the row (DELETE ... RETURNING semantics)", async () => {
+    const sess = makeSession({ id: "pg-rev-fail", expiresAt: 1_000 });
+    await backend.put(sess);
+
+    const result = await runSessionReaper({
+      sessionStore: backend,
+      revoke: async () => {
+        throw new Error("gitea 500");
+      },
+      now: 5_000,
+    });
+
+    expect(result).toEqual({ reaped: 1, revokeErrors: 1 });
+    expect(await backend.get("pg-rev-fail")).toBeNull();
+  });
+});

--- a/services/api/session-reaper.test.ts
+++ b/services/api/session-reaper.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "bun:test";
+import { runSessionReaper } from "./session-reaper";
+import type { SessionRecord } from "./sessions";
+
+function makeSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: "sess-1",
+    username: "alice",
+    giteaToken: "tok",
+    giteaTokenName: "bindersnap-session",
+    createdAt: 1_000,
+    expiresAt: 2_000,
+    ...overrides,
+  };
+}
+
+describe("runSessionReaper", () => {
+  test("returns zero counts when no rows are expired", async () => {
+    const result = await runSessionReaper({
+      sessionStore: { reap: async () => [] },
+      revoke: async () => {
+        throw new Error("revoke must not be called");
+      },
+      now: 5_000,
+    });
+    expect(result).toEqual({ reaped: 0, revokeErrors: 0 });
+  });
+
+  test("revokes each reaped session and reports the count", async () => {
+    const reaped = [
+      makeSession({ id: "a", username: "alice" }),
+      makeSession({ id: "b", username: "bob" }),
+    ];
+    const revoked: string[] = [];
+
+    const result = await runSessionReaper({
+      sessionStore: { reap: async () => reaped },
+      revoke: async (s) => {
+        revoked.push(s.username);
+      },
+      now: 5_000,
+    });
+
+    expect(result).toEqual({ reaped: 2, revokeErrors: 0 });
+    expect(revoked.sort()).toEqual(["alice", "bob"]);
+  });
+
+  test("revoke failures are counted but do not throw", async () => {
+    const reaped = [
+      makeSession({ id: "a" }),
+      makeSession({ id: "b" }),
+      makeSession({ id: "c" }),
+    ];
+    const warnings: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+
+    const result = await runSessionReaper({
+      sessionStore: { reap: async () => reaped },
+      revoke: async (s) => {
+        if (s.id !== "b") throw new Error("gitea down");
+      },
+      logger: {
+        info: () => {},
+        warn: (msg, meta) => warnings.push({ msg, meta }),
+      },
+    });
+
+    expect(result.reaped).toBe(3);
+    expect(result.revokeErrors).toBe(2);
+    expect(warnings.length).toBe(2);
+    expect(warnings[0]?.meta?.error).toBe("gitea down");
+  });
+
+  test("uses Date.now() when now is not provided", async () => {
+    let observed = -1;
+    await runSessionReaper({
+      sessionStore: {
+        reap: async (now) => {
+          observed = now;
+          return [];
+        },
+      },
+      revoke: async () => {},
+    });
+    expect(observed).toBeGreaterThan(0);
+    expect(Math.abs(observed - Date.now())).toBeLessThan(1_000);
+  });
+});

--- a/services/api/session-reaper.ts
+++ b/services/api/session-reaper.ts
@@ -1,0 +1,62 @@
+import type { SessionBackend, SessionRecord } from "./sessions";
+
+export interface SessionReaperLogger {
+  info: (msg: string, meta?: Record<string, unknown>) => void;
+  warn: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+export interface SessionReaperDeps {
+  sessionStore: Pick<SessionBackend, "reap">;
+  revoke: (session: SessionRecord) => Promise<void>;
+  now?: number;
+  logger?: SessionReaperLogger;
+}
+
+export interface SessionReaperResult {
+  reaped: number;
+  revokeErrors: number;
+}
+
+// Extracted from server.ts's in-process cleanup loop so the same logic can run
+// out-of-process (scheduled Lambda via EventBridge, see #224). The Postgres
+// session table has no native TTL — something has to call this on a schedule.
+//
+// Behavior:
+//   - Deletes expired session rows in a single round-trip (backend-specific).
+//   - Best-effort revokes each expired session's Gitea token. Revoke failures
+//     are counted and logged but never throw — a transient Gitea outage must
+//     not leave stale rows in the DB.
+export async function runSessionReaper(
+  deps: SessionReaperDeps,
+): Promise<SessionReaperResult> {
+  const now = deps.now ?? Date.now();
+  const expired = await deps.sessionStore.reap(now);
+
+  if (expired.length === 0) {
+    return { reaped: 0, revokeErrors: 0 };
+  }
+
+  const results = await Promise.allSettled(
+    expired.map((session) => deps.revoke(session)),
+  );
+
+  let revokeErrors = 0;
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r && r.status === "rejected") {
+      revokeErrors += 1;
+      const reason: unknown = r.reason;
+      deps.logger?.warn("Session token revoke failed during reap", {
+        username: expired[i]?.username,
+        error: reason instanceof Error ? reason.message : String(reason),
+      });
+    }
+  }
+
+  deps.logger?.info("Session reaper run complete", {
+    reaped: expired.length,
+    revokeErrors,
+  });
+
+  return { reaped: expired.length, revokeErrors };
+}


### PR DESCRIPTION
## Summary

Refs #224.

Pulls the body of `cleanupExpiredSessions` (reap expired rows + best-effort Gitea token revoke) into a pure `runSessionReaper(deps)` in `services/api/session-reaper.ts`. The in-process timer in `server.ts` now calls it — behavior on EC2/local dev is unchanged.

Why: Acceptance criteria from the 2026-05-07 architecture comment require a reaper that works under Lambda. Postgres has no native TTL and `setInterval` won't fire reliably in a function that freezes between invocations, so the reaper has to be invokable as a standalone unit. A pure function with injected deps (`sessionStore`, `revoke`, `now`, `logger`) is what a scheduled-Lambda entry point will call in the follow-up infra PR.

What this PR is **not**: it does not add the EventBridge schedule, the Lambda handler, or pg_cron. Those land alongside `infra/api-service/` (next step).

## Scope Check

- [x] Changes are focused on one issue/task
- [x] No unrelated refactors or formatting-only churn included

## Validation

- [x] Local validation/tests run
- Commands run:
  - `bun test services/api/session-reaper.test.ts` → 4 pass
  - `bun test services/api/server.test.ts services/api/sessions.test.ts` → 23 pass (no regressions)
  - `bunx tsc --noEmit` → no new errors introduced (pre-existing unrelated error in `server.ts` for `SubscriptionAccessOverrideRecord` is untouched)
  - `bun run format` → clean

## Merge Gate

- [x] Any fallback is explicitly documented and justified — no fallbacks used. Branch created and pushed locally; PR created via `mcp__github__create_pull_request`.

## Workflow evidence

- Issue read: `mcp__github__issue_read` (#224 comments)
- Branch created: local `git checkout -b`
- Commit SHA: `0c82912`
- PR creation: `mcp__github__create_pull_request`
