### PR TITLE
infra(#224): fill in api-service TF resources + LWA in API Dockerfile

### DIFF
--- a/infra/api-service/apigw.tf
+++ b/infra/api-service/apigw.tf
@@ -1,7 +1,7 @@
 # API Gateway HTTP API fronting the Lambda function.
 #
 # Why HTTP API not REST API:
-#   Cheaper ($1/M requests vs $3.50/M), lower latency, native JWT/Lambda
+#   Cheaper ($1/M requests vs $3.50/M), lower latency, native Lambda
 #   integration. We don't need REST API features (request validation,
 #   API keys, usage plans) — auth is owned by the API itself.
 #
@@ -13,27 +13,122 @@
 #   var.api_domain_name (e.g., api.bindersnap.example.com)
 #   ACM cert from var.acm_certificate_arn (must be in same region as the
 #   API — HTTP APIs are regional, no us-east-1 quirk)
-#   Route53 alias points the domain at the API Gateway custom-domain
-#   regional endpoint.
+#   Route53 alias optionally created when var.route53_zone_id is set.
 #
 # CORS:
 #   Configured at the API Gateway layer (allowed origins from
 #   var.cors_allowed_origins) so OPTIONS preflights short-circuit before
 #   hitting Lambda. Saves invocations on every cross-origin browser request.
 #
-# Throttling:
-#   Default account limits are fine for solo-dev. Per-route throttle on
-#   /auth/login + /auth/signup at e.g. 5 req/s burst once we have any
-#   public traffic.
-#
 # Cost: $0 idle, $1 per million requests, free 1M/month for first 12
 # months on a fresh account.
-#
-# TODO(#224):
-#   aws_apigatewayv2_api.api
-#   aws_apigatewayv2_integration.lambda
-#   aws_apigatewayv2_route.proxy
-#   aws_apigatewayv2_stage.default (auto-deploy)
-#   aws_apigatewayv2_domain_name.api
-#   aws_apigatewayv2_api_mapping.api
-#   aws_lambda_permission.apigw_invoke
+
+variable "route53_zone_id" {
+  description = "Optional Route53 hosted zone ID for var.api_domain_name. When set, an A-alias record is created pointing at the API Gateway regional endpoint. Leave null to manage DNS out-of-band."
+  type        = string
+  default     = null
+}
+
+resource "aws_apigatewayv2_api" "api" {
+  name          = local.name_prefix
+  protocol_type = "HTTP"
+  description   = "Bindersnap API (Lambda + API Gateway) — issue #224"
+
+  cors_configuration {
+    allow_origins     = var.cors_allowed_origins
+    allow_methods     = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+    allow_headers     = ["authorization", "content-type", "x-requested-with"]
+    expose_headers    = ["content-type"]
+    allow_credentials = true
+    max_age           = 600
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.api.invoke_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+  timeout_milliseconds   = 29000
+}
+
+resource "aws_apigatewayv2_route" "proxy" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "ANY /{proxy+}"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.api.id
+  name        = "$default"
+  auto_deploy = true
+
+  default_route_settings {
+    throttling_burst_limit = 100
+    throttling_rate_limit  = 50
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_lambda_permission" "apigw_invoke" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
+}
+
+# ---------- Custom domain ----------
+
+resource "aws_apigatewayv2_domain_name" "api" {
+  domain_name = var.api_domain_name
+
+  domain_name_configuration {
+    certificate_arn = var.acm_certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_apigatewayv2_api_mapping" "api" {
+  api_id      = aws_apigatewayv2_api.api.id
+  domain_name = aws_apigatewayv2_domain_name.api.id
+  stage       = aws_apigatewayv2_stage.default.id
+}
+
+resource "aws_route53_record" "api" {
+  count = var.route53_zone_id == null ? 0 : 1
+
+  zone_id = var.route53_zone_id
+  name    = var.api_domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# ---------- Outputs ----------
+
+output "api_gateway_endpoint" {
+  description = "API Gateway default endpoint (use as a fallback if custom domain DNS isn't wired yet)."
+  value       = aws_apigatewayv2_api.api.api_endpoint
+}
+
+output "api_gateway_target_domain_name" {
+  description = "Regional target domain to CNAME/alias var.api_domain_name to (only needed when route53_zone_id is null)."
+  value       = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].target_domain_name
+}
+
+output "api_public_url" {
+  description = "Public URL the SPA should point at."
+  value       = "https://${var.api_domain_name}"
+}

--- a/infra/api-service/aurora.tf
+++ b/infra/api-service/aurora.tf
@@ -7,44 +7,117 @@
 #   processed_webhook_events        — event_id PK, processed_at index for cleanup
 #   webhook_customer_state          — customer_id PK
 #
-# DDL applied by a migration job, not by Terraform.
-#
-# Why one Postgres instead of Postgres + DynamoDB:
-#   - One IAM/networking surface, one backup story, one credential rotation.
-#   - At solo-dev volume the per-DB fixed cost dominates; consolidation wins.
-#   - Sessions are pure KV but Postgres handles that fine; we lose DynamoDB's
-#     native TTL but a tiny reap job (or pg_cron) replaces it.
-#
-# Networking:
-#   Lives in private subnets in the same VPC as the Lambda function and the
-#   Gitea EC2 instance. No public IP, no public accessibility. Lambda
-#   reaches it directly over the private network using a long-lived
-#   connection pool.
-#
-#   We are NOT using the RDS Data API. Lambda is VPC-attached, so a normal
-#   Postgres connection over port 5432 is the right path: lower latency, no
-#   per-request Data API fee, full transaction support without the
-#   Begin/Commit/Rollback API dance. The Data API path was considered and
-#   rejected in favor of keeping Lambda inside the VPC (see issue #224
-#   discussion thread).
+# DDL applied by the standalone migration runner (services/api/db/migrate.ts),
+# NOT by Terraform.
 #
 # Capacity (chosen for cost — see README "Cold-start tradeoff"):
 #   min_capacity = 0      # true auto-pause; ~$0 idle, ~5-15s wake-up on first request
 #   max_capacity = 1      # solo-dev cap; raise when load justifies it
 #
-# Token-at-rest for sessions:
-#   gitea_token is wrapped with a per-session DEK encrypted by a KMS CMK
-#   (envelope encryption). Stored as gitea_token_ciphertext + gitea_token_dek
-#   columns. A snapshot of the DB never reveals plaintext Gitea tokens.
+# Master credentials managed by RDS in Secrets Manager (auto-rotated) — see
+# `manage_master_user_password` below. Lambda reads the auto-generated
+# secret ARN from `aurora_master_secret_arn` output.
 #
-# Credentials:
-#   master password lives in Secrets Manager with rotation; Lambda fetches
-#   it at cold-start and holds a connection pool for the lifetime of the
-#   execution environment.
-#
-# TODO(#224):
-#   aws_rds_cluster.api          (engine = aurora-postgresql)
-#   aws_rds_cluster_instance.api (instance_class = db.serverless)
-#   aws_db_subnet_group.api
-#   aws_rds_cluster_parameter_group.api
-#   aws_kms_key.session_envelope
+# Networking: lives in private subnets in the same VPC as Lambda. No public
+# IP, no public accessibility. Lambda connects directly over port 5432.
+
+variable "aurora_min_capacity" {
+  description = "Aurora Serverless v2 minimum ACU. 0 = auto-pause (default); 0.5 = warm-always (~$43/mo)."
+  type        = number
+  default     = 0
+}
+
+variable "aurora_max_capacity" {
+  description = "Aurora Serverless v2 maximum ACU."
+  type        = number
+  default     = 1
+}
+
+variable "aurora_engine_version" {
+  description = "Aurora PostgreSQL engine version. Serverless v2 requires 13.12+, 14.6+, 15.2+, or 16.x."
+  type        = string
+  default     = "16.4"
+}
+
+resource "aws_db_subnet_group" "api" {
+  name        = "${local.name_prefix}-aurora"
+  description = "Aurora subnet group for ${local.name_prefix}"
+  subnet_ids  = var.private_subnet_ids
+
+  tags = local.common_tags
+}
+
+resource "aws_rds_cluster_parameter_group" "api" {
+  name        = "${local.name_prefix}-aurora-pg"
+  family      = "aurora-postgresql16"
+  description = "Cluster parameters for ${local.name_prefix} Aurora cluster"
+
+  parameter {
+    name  = "rds.force_ssl"
+    value = "1"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_rds_cluster" "api" {
+  cluster_identifier              = "${local.name_prefix}-aurora"
+  engine                          = "aurora-postgresql"
+  engine_mode                     = "provisioned"
+  engine_version                  = var.aurora_engine_version
+  database_name                   = "bindersnap"
+  master_username                 = "bindersnap"
+  manage_master_user_password     = true
+  db_subnet_group_name            = aws_db_subnet_group.api.name
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.api.name
+  vpc_security_group_ids          = [aws_security_group.aurora.id]
+
+  storage_encrypted         = true
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${local.name_prefix}-aurora-final-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  backup_retention_period   = 7
+  preferred_backup_window   = "03:00-04:00"
+  deletion_protection       = true
+
+  serverlessv2_scaling_configuration {
+    min_capacity = var.aurora_min_capacity
+    max_capacity = var.aurora_max_capacity
+  }
+
+  tags = local.common_tags
+
+  lifecycle {
+    ignore_changes = [
+      # `timestamp()` would rewrite this every plan; only the actual destroy
+      # path needs it for a unique snapshot ID.
+      final_snapshot_identifier,
+    ]
+  }
+}
+
+resource "aws_rds_cluster_instance" "api" {
+  identifier         = "${local.name_prefix}-aurora-1"
+  cluster_identifier = aws_rds_cluster.api.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.api.engine
+  engine_version     = aws_rds_cluster.api.engine_version
+
+  tags = local.common_tags
+}
+
+# ---------- Outputs ----------
+
+output "aurora_cluster_endpoint" {
+  description = "Aurora writer endpoint (Lambda connects here)."
+  value       = aws_rds_cluster.api.endpoint
+}
+
+output "aurora_master_secret_arn" {
+  description = "ARN of the RDS-managed master-user secret. Lambda fetches the password at cold-start."
+  value       = aws_rds_cluster.api.master_user_secret[0].secret_arn
+}
+
+output "aurora_database_name" {
+  description = "Default Postgres database for the API."
+  value       = aws_rds_cluster.api.database_name
+}

--- a/infra/api-service/ecr.tf
+++ b/infra/api-service/ecr.tf
@@ -9,5 +9,55 @@
 # Image format: container-image Lambda (OCI). The Dockerfile installs the
 # AWS Lambda Web Adapter binary into the image so the existing Bun.serve()
 # handler keeps working unchanged. See lambda.tf.
-#
-# TODO(#224): aws_ecr_repository.api + aws_ecr_lifecycle_policy.api
+
+resource "aws_ecr_repository" "api" {
+  name                 = local.name_prefix
+  image_tag_mutability = "MUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus      = "tagged"
+          tagPatternList = ["*"]
+          countType      = "imageCountMoreThan"
+          countNumber    = 10
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Expire untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = { type = "expire" }
+      },
+    ]
+  })
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL for the API image. Consumed by deploy-api.yml."
+  value       = aws_ecr_repository.api.repository_url
+}

--- a/infra/api-service/iam.tf
+++ b/infra/api-service/iam.tf
@@ -1,8 +1,5 @@
 # IAM role for the Lambda function.
 #
-# Single role (Lambda has no equivalent of ECS's "task execution role" vs
-# "task role" split — the function itself uses one execution role).
-#
 # Permissions:
 #
 #   Always-on AWS-managed:
@@ -10,22 +7,69 @@
 #     AWSLambdaVPCAccessExecutionRole          # ENI mgmt for VPC attachment
 #
 #   Custom:
-#     secretsmanager:GetSecretValue            # scoped to api/* secrets
-#                                                (Postgres password, Stripe
-#                                                keys, Gitea service token)
+#     secretsmanager:GetSecretValue            # scoped to this root's secrets
+#                                                + the RDS-managed master secret
 #     kms:Decrypt, kms:GenerateDataKey         # session_envelope CMK only
-#
-# What we deliberately do NOT grant:
-#   rds-data:*    — not using the RDS Data API; Lambda connects to Aurora
-#                   directly over port 5432.
-#   ecs:*         — not using ECS at all.
-#   dynamodb:*    — not using DynamoDB; all state lives in Aurora.
-#
-# Trust policy: lambda.amazonaws.com.
-#
-# TODO(#224):
-#   aws_iam_role.lambda
-#   aws_iam_role_policy.lambda_secrets
-#   aws_iam_role_policy.lambda_kms
-#   aws_iam_role_policy_attachment.lambda_basic_execution
-#   aws_iam_role_policy_attachment.lambda_vpc_access
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name               = "${local.name_prefix}-lambda"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+data "aws_iam_policy_document" "lambda_secrets" {
+  statement {
+    effect  = "Allow"
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      aws_secretsmanager_secret.stripe.arn,
+      aws_secretsmanager_secret.gitea.arn,
+      # Aurora's RDS-managed master-user secret.
+      aws_rds_cluster.api.master_user_secret[0].secret_arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_secrets" {
+  name   = "${local.name_prefix}-secrets"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.lambda_secrets.json
+}
+
+data "aws_iam_policy_document" "lambda_kms" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [aws_kms_key.session_envelope.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_kms" {
+  name   = "${local.name_prefix}-kms"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.lambda_kms.json
+}

--- a/infra/api-service/lambda.tf
+++ b/infra/api-service/lambda.tf
@@ -12,41 +12,128 @@
 #   Tagged with the commit SHA; deploy is `aws lambda update-function-code
 #   --image-uri <repo>:<sha>` followed by `aws lambda wait function-updated`.
 #
-# Why container-image Lambda instead of zip + custom runtime:
-#   Bun isn't a managed Lambda runtime. Custom runtimes via bootstrap work
-#   but require packaging Bun as a layer and writing handler glue. The
-#   container path keeps the Dockerfile we already have (one extra COPY for
-#   the LWA binary) and lets us run the same image locally for dev parity.
-#
 # Configuration:
 #   memory:        1024 MB    (Bun + Stripe SDK + pg driver headroom)
 #   timeout:       29 seconds (max useful — API Gateway HTTP API timeout is 30s)
 #   architecture:  arm64      (cheaper, Bun supports it)
 #   ephemeral:     512 MB     (default; nothing on-disk persists)
 #
-# Environment:
-#   PORT=8787                                # LWA forwards to this
-#   AWS_LWA_PORT=8787
-#   AWS_LWA_INVOKE_MODE=BUFFERED             # standard request/response
-#   BINDERSNAP_STORAGE_BACKEND=postgres
-#   DATABASE_URL                             # via Secrets Manager
-#   STRIPE_SECRET_KEY                        # via Secrets Manager
-#   STRIPE_WEBHOOK_SECRET                    # via Secrets Manager
-#   BINDERSNAP_GITEA_SERVICE_TOKEN           # via Secrets Manager
-#   BINDERSNAP_GITEA_INTERNAL_URL            # http://<gitea-eni-ip>:3000
-#                                            # (private VPC reach to Gitea)
-#
-# VPC attachment:
-#   subnets:         var.private_subnet_ids
-#   security_groups: [lambda_sg]
-#   This is required so Lambda can reach Aurora (private) and Gitea (private
-#   IP, same VPC). Outbound to Stripe traverses the Gitea-as-NAT path — see
-#   nat.tf.
-#
 # Concurrency:
 #   reserved_concurrent_executions: 10   # solo-dev cap; raise when needed
 #   provisioned_concurrency: 0           # accept ~1-2s cold-start
+
+variable "lambda_memory_mb" {
+  description = "Lambda memory in MB."
+  type        = number
+  default     = 1024
+}
+
+variable "lambda_timeout_seconds" {
+  description = "Lambda timeout in seconds. API Gateway HTTP API caps at 30s."
+  type        = number
+  default     = 29
+}
+
+variable "lambda_reserved_concurrency" {
+  description = "Reserved concurrency. Solo-dev cap; raise when needed."
+  type        = number
+  default     = 10
+}
+
+variable "lambda_log_retention_days" {
+  description = "CloudWatch Logs retention for the Lambda log group."
+  type        = number
+  default     = 14
+}
+
+# Bootstrap image used on first apply (before deploy-api.yml has pushed a
+# real SHA-tagged image). After the first CI push, the function's image_uri
+# is updated out-of-band by `aws lambda update-function-code` and we ignore
+# image_uri drift in `lifecycle.ignore_changes`.
 #
-# TODO(#224):
-#   aws_lambda_function.api
-#   aws_cloudwatch_log_group.api (retention = 14 days)
+# AWS publishes a public hello-world image at this URI; using it avoids a
+# chicken-and-egg dependency on the ECR repo having an image yet.
+locals {
+  bootstrap_image_uri = "public.ecr.aws/lambda/provided:al2023"
+  api_image_uri       = var.image_tag == "latest" || var.image_tag == "" ? local.bootstrap_image_uri : "${aws_ecr_repository.api.repository_url}:${var.image_tag}"
+}
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/aws/lambda/${local.name_prefix}"
+  retention_in_days = var.lambda_log_retention_days
+
+  tags = local.common_tags
+}
+
+resource "aws_lambda_function" "api" {
+  function_name                  = local.name_prefix
+  role                           = aws_iam_role.lambda.arn
+  package_type                   = "Image"
+  image_uri                      = local.api_image_uri
+  architectures                  = ["arm64"]
+  memory_size                    = var.lambda_memory_mb
+  timeout                        = var.lambda_timeout_seconds
+  reserved_concurrent_executions = var.lambda_reserved_concurrency
+
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+
+  environment {
+    variables = {
+      # Lambda Web Adapter — see services/api/Dockerfile.
+      AWS_LWA_PORT        = "8787"
+      AWS_LWA_INVOKE_MODE = "BUFFERED"
+      PORT                = "8787"
+
+      # Backend selection — flips the API onto Postgres (issue #224).
+      BINDERSNAP_DB_BACKEND = "postgres"
+
+      # Aurora connection. Lambda fetches the password at cold-start from
+      # AURORA_MASTER_SECRET_ARN and assembles the URL; we only pass the
+      # non-secret pieces here.
+      BINDERSNAP_PG_HOST     = aws_rds_cluster.api.endpoint
+      BINDERSNAP_PG_PORT     = "5432"
+      BINDERSNAP_PG_DATABASE = aws_rds_cluster.api.database_name
+
+      # Secret ARNs — Lambda reads them via the IAM role; not the values
+      # themselves, so a console screenshot does not leak credentials.
+      AURORA_MASTER_SECRET_ARN     = aws_rds_cluster.api.master_user_secret[0].secret_arn
+      STRIPE_SECRET_ARN            = aws_secretsmanager_secret.stripe.arn
+      GITEA_SECRET_ARN             = aws_secretsmanager_secret.gitea.arn
+      SESSION_ENVELOPE_KMS_KEY_ARN = aws_kms_key.session_envelope.arn
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.lambda_basic_execution,
+    aws_iam_role_policy_attachment.lambda_vpc_access,
+    aws_cloudwatch_log_group.api,
+  ]
+
+  lifecycle {
+    # deploy-api.yml updates image_uri out-of-band on every push to main;
+    # `terraform apply` must not roll it back to the bootstrap image.
+    ignore_changes = [image_uri]
+  }
+
+  tags = local.common_tags
+}
+
+# ---------- Outputs ----------
+
+output "lambda_function_name" {
+  description = "Lambda function name. Consumed by deploy-api.yml."
+  value       = aws_lambda_function.api.function_name
+}
+
+output "lambda_function_arn" {
+  description = "Lambda function ARN."
+  value       = aws_lambda_function.api.arn
+}
+
+output "lambda_invoke_arn" {
+  description = "Lambda invoke ARN. Consumed by API Gateway integration."
+  value       = aws_lambda_function.api.invoke_arn
+}

--- a/infra/api-service/nat.tf
+++ b/infra/api-service/nat.tf
@@ -1,67 +1,41 @@
 # NAT path for Lambda's outbound public-internet traffic.
 #
 # Lambda runs inside the VPC so it can reach Aurora and Gitea privately.
-# The only outbound public destination is api.stripe.com (checkout session
-# creation, billing portal session creation, and a handful of webhook
-# reconcile calls — see issue #224 plan-verification thread for the audit).
+# The only outbound public destination is api.stripe.com. Rather than
+# provisioning a NAT Gateway (~$32/mo) or a dedicated NAT instance, we route
+# Lambda's egress through the existing Gitea EC2 host.
 #
-# Rather than provisioning a NAT Gateway (~$32/mo) or a dedicated NAT
-# instance (~$3/mo on t4g.nano), we route Lambda's egress through the
-# existing Gitea EC2 host. It already has a public IP, is already in a
-# public subnet, and is already running. Cost: $0.
+# This file adds the route in the Lambda subnets' route tables pointing
+# 0.0.0.0/0 at the Gitea instance's primary ENI. Two complementary changes
+# live in infra/compute/ and will land in a separate PR:
 #
-# Tradeoff: when the Gitea host is down, Lambda also can't reach Stripe.
-# At solo-dev volume this is acceptable because "Gitea down" already means
-# "the application is down" — the editor and the document store both
-# depend on Gitea.
+#   1. Disable source_dest_check on the Gitea ENI.
+#   2. IP forwarding + iptables MASQUERADE in user-data for the Lambda
+#      subnet CIDRs.
 #
-# Mechanism:
-#
-#   1. Configure the Gitea instance for IP forwarding (one-time, via
-#      user-data in infra/compute/user-data.sh.tftpl):
-#
-#        echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.d/99-nat.conf
-#        sysctl --system
-#        iptables -t nat -A POSTROUTING -s <lambda_subnet_cidr> \
-#          -o eth0 -j MASQUERADE
-#        iptables-save > /etc/iptables/rules.v4
-#
-#      The exact subnet CIDR is parameterized; the rule lives on the host
-#      so the host owns its own iptables state.
-#
-#   2. Disable source/dest check on the Gitea ENI. EC2 instances drop
-#      packets they receive that aren't addressed to themselves unless
-#      this is set, which would defeat the NAT.
-#
-#        aws_network_interface_attachment ... source_dest_check = false
-#
-#      (Or modify the existing ENI in infra/compute/.)
-#
-#   3. Add a route in the Lambda subnets' route table sending
-#      0.0.0.0/0 to the Gitea instance's primary network interface:
-#
-#        aws_route.lambda_egress_to_gitea_eni
-#
-#      destination_cidr_block = "0.0.0.0/0"
-#      network_interface_id   = <gitea_primary_eni_id>
-#
-# Security group considerations:
-#   Lambda's SG egress allows 0.0.0.0/0 on 443 (so packets reach the NAT).
-#   Gitea's SG must allow ingress from the Lambda subnet for return-path
-#   processing — but since the iptables MASQUERADE conntrack rewrites the
-#   src to Gitea's own IP, return packets from Stripe arrive on Gitea's
-#   public ENI and the kernel handles the rest. No new ingress rule on
-#   the Stripe-facing path is needed.
-#
-# Failure-mode notes:
-#   - If Gitea is replaced (instance ID changes), the route in the Lambda
-#     subnet must be updated to point at the new ENI. Worth a small
-#     post-replace script in #223's host CLI.
-#   - The iptables rule is idempotent on the user-data path; re-running
-#     bootstrap is safe.
-#
-# TODO(#224):
-#   aws_route.lambda_egress_via_gitea       # 0.0.0.0/0 → gitea_eni_id
-#   data.aws_network_interface.gitea_primary
-#   modification of infra/compute/ to disable source/dest check on the
-#     Gitea ENI and add the IP-forwarding/iptables block to user-data.
+# Until those land, the route is created but packets won't successfully
+# return through Gitea. The route alone is harmless and easier to review
+# in isolation.
+
+variable "lambda_route_table_ids" {
+  description = "Route table IDs of the Lambda subnets (var.private_subnet_ids). Default route 0.0.0.0/0 is set here pointing at the Gitea ENI. Leave empty to skip the route (e.g., on first apply before the Gitea-as-NAT side has landed)."
+  type        = list(string)
+  default     = []
+}
+
+data "aws_instance" "gitea" {
+  instance_id = var.gitea_instance_id
+}
+
+resource "aws_route" "lambda_egress_via_gitea" {
+  count = length(var.lambda_route_table_ids)
+
+  route_table_id         = var.lambda_route_table_ids[count.index]
+  destination_cidr_block = "0.0.0.0/0"
+  network_interface_id   = data.aws_instance.gitea.network_interface_id
+}
+
+output "gitea_primary_eni_id" {
+  description = "Primary ENI of the Gitea instance. Used by both the egress route here and by infra/compute/ when disabling source_dest_check."
+  value       = data.aws_instance.gitea.network_interface_id
+}

--- a/infra/api-service/secrets.tf
+++ b/infra/api-service/secrets.tf
@@ -1,22 +1,91 @@
 # Secrets Manager + KMS for runtime credentials.
 #
-# Secrets:
-#   bindersnap/${env}/api/stripe          — STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_ID
-#   bindersnap/${env}/api/gitea           — BINDERSNAP_GITEA_SERVICE_TOKEN
-#   bindersnap/${env}/api/postgres        — Aurora master password (rotated)
-#   bindersnap/${env}/api/session-kms-arn — KMS CMK ARN for session token envelope encryption
+# Stripe + Gitea secrets are created here with placeholder JSON values; the
+# operator fills in real values out-of-band via `aws secretsmanager
+# put-secret-value`. The schema is documented inline so the value format is
+# unambiguous.
 #
-# Lambda fetches these at cold-start via the AWS SDK + the IAM execution
-# role (see iam.tf). They are NOT injected as plaintext environment
-# variables on the function — the function itself reads from Secrets
-# Manager at boot, so a Lambda console screenshot doesn't leak them.
+# Aurora's master credentials are NOT here — `aws_rds_cluster` is configured
+# with `manage_master_user_password = true`, which lets RDS create and
+# rotate the password in its own AWS-managed secret. Lambda fetches that
+# secret by ARN (exposed as an output).
 #
-# Rotation: enabled on the postgres secret with the standard
-# `SecretsManagerRDSPostgreSQLRotationSingleUser` template.
-#
-# TODO(#224):
-#   aws_secretsmanager_secret.stripe + version
-#   aws_secretsmanager_secret.gitea + version
-#   aws_secretsmanager_secret.postgres + version + rotation
-#   aws_kms_key.session_envelope (with key policy granting Lambda role
-#     kms:Decrypt + kms:GenerateDataKey only)
+# Session-envelope KMS CMK is also here: a customer-managed key (vs the
+# default aws/secretsmanager key) so we can grant Lambda kms:GenerateDataKey
+# without touching the account-wide default key policy.
+
+# ---------- KMS CMK for session envelope encryption ----------
+
+resource "aws_kms_key" "session_envelope" {
+  description             = "Envelope encryption for gitea_token in the sessions table"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-session-envelope" })
+}
+
+resource "aws_kms_alias" "session_envelope" {
+  name          = "alias/${local.name_prefix}-session-envelope"
+  target_key_id = aws_kms_key.session_envelope.key_id
+}
+
+# ---------- Stripe ----------
+
+resource "aws_secretsmanager_secret" "stripe" {
+  name        = "${local.name_prefix}/stripe"
+  description = "Stripe live keys for the API. JSON: { STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_ID }"
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "stripe_placeholder" {
+  secret_id = aws_secretsmanager_secret.stripe.id
+  secret_string = jsonencode({
+    STRIPE_SECRET_KEY     = "REPLACE_ME"
+    STRIPE_WEBHOOK_SECRET = "REPLACE_ME"
+    STRIPE_PRICE_ID       = "REPLACE_ME"
+  })
+
+  lifecycle {
+    # Operator updates the real value via the AWS CLI; we don't want
+    # `terraform apply` to clobber it back to placeholder on every run.
+    ignore_changes = [secret_string]
+  }
+}
+
+# ---------- Gitea service token ----------
+
+resource "aws_secretsmanager_secret" "gitea" {
+  name        = "${local.name_prefix}/gitea"
+  description = "Gitea service-account token used by the API. JSON: { BINDERSNAP_GITEA_SERVICE_TOKEN }"
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "gitea_placeholder" {
+  secret_id = aws_secretsmanager_secret.gitea.id
+  secret_string = jsonencode({
+    BINDERSNAP_GITEA_SERVICE_TOKEN = "REPLACE_ME"
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+# ---------- Outputs ----------
+
+output "session_envelope_kms_key_arn" {
+  description = "KMS CMK ARN for session token envelope encryption. Consumed by Lambda env."
+  value       = aws_kms_key.session_envelope.arn
+}
+
+output "stripe_secret_arn" {
+  description = "Stripe secret ARN. Consumed by Lambda env."
+  value       = aws_secretsmanager_secret.stripe.arn
+}
+
+output "gitea_secret_arn" {
+  description = "Gitea service-token secret ARN. Consumed by Lambda env."
+  value       = aws_secretsmanager_secret.gitea.arn
+}

--- a/infra/api-service/security-groups.tf
+++ b/infra/api-service/security-groups.tf
@@ -17,12 +17,75 @@
 # added to var.gitea_security_group_id from THIS root so the dependency
 # direction stays one-way (api-service depends on compute, not the other
 # way around).
-#
-# No alb_sg, no tasks_sg — no ALB, no ECS.
-#
-# TODO(#224):
-#   aws_security_group.lambda
-#   aws_security_group.aurora
-#   aws_security_group_rule.lambda_to_aurora
-#   aws_security_group_rule.lambda_to_gitea
-#   aws_security_group_rule.gitea_from_lambda  (on the existing Gitea SG)
+
+resource "aws_security_group" "lambda" {
+  name_prefix = "${local.name_prefix}-lambda-"
+  description = "Lambda function ENIs (egress only)"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-lambda" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "aurora" {
+  name_prefix = "${local.name_prefix}-aurora-"
+  description = "Aurora Serverless v2 cluster (Postgres from Lambda only)"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-aurora" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Lambda → Aurora (Postgres)
+resource "aws_vpc_security_group_ingress_rule" "aurora_from_lambda" {
+  security_group_id            = aws_security_group.aurora.id
+  description                  = "Postgres from Lambda"
+  referenced_security_group_id = aws_security_group.lambda.id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "lambda_to_aurora" {
+  security_group_id            = aws_security_group.lambda.id
+  description                  = "Postgres to Aurora"
+  referenced_security_group_id = aws_security_group.aurora.id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+}
+
+# Lambda → Gitea (internal HTTP)
+resource "aws_vpc_security_group_egress_rule" "lambda_to_gitea" {
+  security_group_id            = aws_security_group.lambda.id
+  description                  = "Internal HTTP to Gitea"
+  referenced_security_group_id = var.gitea_security_group_id
+  from_port                    = var.gitea_internal_port
+  to_port                      = var.gitea_internal_port
+  ip_protocol                  = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "gitea_from_lambda" {
+  security_group_id            = var.gitea_security_group_id
+  description                  = "Internal HTTP from Lambda (api-service)"
+  referenced_security_group_id = aws_security_group.lambda.id
+  from_port                    = var.gitea_internal_port
+  to_port                      = var.gitea_internal_port
+  ip_protocol                  = "tcp"
+}
+
+# Lambda → public internet on 443 (Stripe via Gitea-as-NAT; AWS APIs)
+resource "aws_vpc_security_group_egress_rule" "lambda_https_egress" {
+  security_group_id = aws_security_group.lambda.id
+  description       = "HTTPS to public internet (Stripe + AWS APIs via Gitea-as-NAT)"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}

--- a/infra/api-service/terraform.tfvars.example
+++ b/infra/api-service/terraform.tfvars.example
@@ -1,0 +1,56 @@
+# Copy to terraform.tfvars and fill in real values.
+# terraform.tfvars is gitignored — never commit it.
+#
+# Required values (no defaults — terraform will error if missing):
+
+# VPC + subnets shared with the Gitea EC2 host. Lambda and Aurora live in
+# private_subnet_ids; those subnets' default route is what nat.tf rewrites
+# to point at the Gitea ENI for outbound to Stripe.
+vpc_id             = "vpc-XXXXXXXXXXXXXXXXX"
+private_subnet_ids = ["subnet-XXXXXXXXXXXXXXXXX", "subnet-YYYYYYYYYYYYYYYYY"]
+
+# Gitea host the API talks to internally. Both come from the
+# `infra/compute/` outputs (`instance_id`, `security_group_id`).
+gitea_instance_id       = "i-XXXXXXXXXXXXXXXXX"
+gitea_security_group_id = "sg-XXXXXXXXXXXXXXXXX"
+
+# Public hostname + ACM cert in this region.
+# Cert must be issued in var.aws_region (HTTP APIs are regional — no
+# us-east-1 quirk like CloudFront has).
+api_domain_name     = "api.bindersnap.example.com"
+acm_certificate_arn = "arn:aws:acm:us-east-1:000000000000:certificate/00000000-0000-0000-0000-000000000000"
+
+# Origins the SPA is served from. CORS at the API Gateway layer
+# short-circuits preflights before invoking Lambda.
+cors_allowed_origins = [
+  "https://bindersnap.example.com",
+  "https://davidgraymi.github.io",
+]
+
+# ---------------------------------------------------------------------------
+# Optional overrides (defaults shown in comments — uncomment to change):
+# ---------------------------------------------------------------------------
+
+# aws_region          = "us-east-1"
+# project             = "bindersnap"
+# environment         = "prod"
+# image_tag           = "latest"           # CI overrides this per deploy
+# gitea_internal_port = 3000
+
+# Aurora capacity. min_capacity = 0 is true auto-pause (~$0 idle, 5-15s
+# wake-up on first request). Bump to 0.5 if a hot login path matters.
+# aurora_min_capacity   = 0
+# aurora_max_capacity   = 1
+# aurora_engine_version = "16.4"
+
+# Lambda sizing.
+# lambda_memory_mb            = 1024
+# lambda_timeout_seconds      = 29     # API Gateway HTTP API caps at 30s
+# lambda_reserved_concurrency = 10
+# lambda_log_retention_days   = 14
+
+# Route53 + NAT routing. Leave these unset on the first apply — DNS and
+# the Gitea-as-NAT route are easier to wire up after the resources exist.
+#
+# route53_zone_id        = "ZXXXXXXXXXXXXX"
+# lambda_route_table_ids = ["rtb-XXXXXXXXXXXXXXXXX"]

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -5,6 +5,17 @@ COPY services/api ./services/api
 RUN bun install --frozen-lockfile --production
 
 FROM oven/bun:1-slim
+
+# AWS Lambda Web Adapter — dormant outside Lambda (activates only when the
+# Lambda runtime sets AWS_LAMBDA_RUNTIME_API), so local `docker run` and the
+# host-side compose stack keep behaving exactly as before. In Lambda it
+# proxies API Gateway events to the Bun.serve() listener on $AWS_LWA_PORT.
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
+
+ENV PORT=8787 \
+    AWS_LWA_PORT=8787 \
+    AWS_LWA_INVOKE_MODE=BUFFERED
+
 WORKDIR /app
 RUN mkdir -p /var/lib/bindersnap && chown bun:bun /var/lib/bindersnap
 COPY --from=builder --chown=bun:bun /app .


### PR DESCRIPTION
Continues the issue #224 series. Replaces the comment-only scaffold in `infra/api-service/` with applyable resources for the Lambda + API Gateway + Aurora Serverless v2 architecture from the final design comment on the issue. **No `terraform apply` is performed by this PR** — landing the structure first so the resource design is reviewable in isolation.

## What lands

| File | What it contains |
|---|---|
| `ecr.tf` | `bindersnap-${env}-api` repo + lifecycle policy (keep last 10 tagged, expire untagged after 7d), scan-on-push. |
| `security-groups.tf` | `lambda_sg` + `aurora_sg` with the documented topology; reciprocal Lambda→Gitea ingress is added to `var.gitea_security_group_id` from this root so dependency stays one-way. |
| `secrets.tf` | Stripe + Gitea secrets with placeholder JSON and `ignore_changes = [secret_string]` so operator can fill in real values out-of-band without TF clobbering. Session-envelope KMS CMK + alias with rotation enabled. |
| `aurora.tf` | Aurora Serverless v2 Postgres 16.4, `min_capacity = 0` (auto-pause), `max = 1`, `db.serverless` instance, subnet + parameter groups (`rds.force_ssl=1`), 7-day backups, `deletion_protection = true`, `manage_master_user_password = true` (RDS owns the secret + rotation). |
| `iam.tf` | Lambda execution role with `AWSLambdaBasicExecutionRole` + `AWSLambdaVPCAccessExecutionRole` plus inline policies for scoped `secretsmanager:GetSecretValue` (3 ARNs) and `kms:Decrypt`/`GenerateDataKey` on the session-envelope CMK only. |
| `lambda.tf` | Container-image Lambda, arm64, 1024 MB, 29s timeout, reserved concurrency = 10, VPC-attached. `image_uri` defaults to a public bootstrap image and is `lifecycle.ignore_changes`-protected so `deploy-api.yml` can update it without TF rolling it back. Env passes LWA vars + `BINDERSNAP_DB_BACKEND=postgres` + secret/KMS ARNs (not values). 14-day log retention. |
| `apigw.tf` | HTTP API (cheaper than REST), CORS configured at the gateway so preflights short-circuit before invoking Lambda, `AWS_PROXY` integration on `ANY /{proxy+}`, `$default` stage with throttling, custom domain + API mapping, `lambda:InvokeFunction` permission, optional Route53 alias when `route53_zone_id` is set. |
| `nat.tf` | `aws_route` from `var.lambda_route_table_ids` to the Gitea primary ENI (via `data.aws_instance.gitea`). Empty list by default so first apply doesn't trip before the Gitea-as-NAT side lands. |
| `services/api/Dockerfile` | Adds the AWS Lambda Web Adapter binary at `/opt/extensions/lambda-adapter` and sets `PORT`/`AWS_LWA_PORT`/`AWS_LWA_INVOKE_MODE`. LWA is dormant outside Lambda — local `docker run` and host-side compose are unchanged. |

## Why these specific choices

- **`manage_master_user_password = true`** instead of a hand-rolled Secrets Manager entry — gets RDS-native rotation for free, removes one secret to maintain, removes the need for the `random` provider.
- **Placeholder JSON + `ignore_changes`** on Stripe/Gitea secrets — the operator-fills-real-values-via-CLI pattern is how secret material stays out of TF state without breaking idempotent `apply`.
- **`image_uri` lifecycle-ignored** on the Lambda — required so `aws lambda update-function-code` (run by the deploy workflow) isn't reverted by the next `terraform apply`. Same pattern as the existing `aws_instance.app` AMI ignore in `infra/compute/`.
- **`min_capacity = 0`** — keeps idle Aurora cost at ~$0/mo with a documented 5–15s cold-start tradeoff; the knob is a single variable if a hot login path ever justifies the ~$43/mo to remove it.
- **HTTP API, no ALB** — eliminates the ~$16/mo ALB floor cost; per the final design comment on the issue.

## Out of scope (intentional — separate PRs)

- The two complementary `infra/compute/` changes for Gitea-as-NAT (disable `source_dest_check` on the Gitea ENI, IP forwarding + iptables MASQUERADE in user-data). Documented inline in `nat.tf` comments.
- `.github/workflows/deploy-api.yml` — depends on the ECR repo and Lambda function existing, so it follows after this lands.
- Real `terraform.tfvars` values + slotting into `infra/apply-all.sh` — needs operator decisions (VPC, subnets, `gitea_instance_id`, `acm_certificate_arn`).
- Production migration + cutover — manual runbook step per the issue.

## Validation

- `terraform fmt` — clean (whitespace-only normalization, included).
- `terraform validate` — `Success! The configuration is valid.`
- No `terraform plan`/`apply` run — this PR intentionally lands structure only.

## Workflow evidence

- Issue read method: `mcp__github__issue_read` (`get` + `get_comments`) on #224.
- Branch creation method: local `git checkout -b` off `origin/development/api-going-serverless`.
- Commit SHA: `ce5b146`.
- PR creation method: `mcp__github__create_pull_request`.
- Fallback used: none.

Closes part of #224 (resource scaffold for items 1, partial 7 of the revised acceptance criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)