### PR TITLE
infra(#224): Gitea-as-NAT in compute root

### DIFF
--- a/infra/compute/main.tf
+++ b/infra/compute/main.tf
@@ -110,6 +110,17 @@ variable "config_bucket_name" {
   default     = "bindersnap-config"
 }
 
+variable "lambda_subnet_cidrs" {
+  description = "CIDR blocks of the private subnets used by the api-service Lambda. The Gitea instance acts as a NAT for these subnets: source/dest check is disabled on its ENI, the kernel forwards IPv4 packets, and an iptables MASQUERADE rule rewrites packets sourced from these CIDRs. Leave empty until the api-service root is being applied — the host runs normally with an empty list."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for c in var.lambda_subnet_cidrs : can(cidrnetmask(c))])
+    error_message = "lambda_subnet_cidrs must contain valid IPv4 CIDR blocks."
+  }
+}
+
 # ---------- Data sources ----------
 
 # Auto-discover latest AL2023 ARM64 AMI if not pinned
@@ -216,6 +227,19 @@ resource "aws_vpc_security_group_egress_rule" "all" {
   ip_protocol       = "-1"
 }
 
+# Gitea-as-NAT: accept inbound from Lambda subnet CIDRs on any port so packets
+# routed through this ENI on their way to the public internet are not dropped
+# by the SG. Egress is unrestricted (rule above) so the MASQUERADE'd outbound
+# leg leaves freely.
+resource "aws_vpc_security_group_ingress_rule" "lambda_nat" {
+  count = length(var.lambda_subnet_cidrs)
+
+  security_group_id = aws_security_group.app.id
+  description       = "Gitea-as-NAT: forwarded traffic from Lambda subnet ${var.lambda_subnet_cidrs[count.index]}"
+  cidr_ipv4         = var.lambda_subnet_cidrs[count.index]
+  ip_protocol       = "-1"
+}
+
 # ---------- IAM Instance Profile ----------
 
 data "aws_iam_policy_document" "ec2_assume" {
@@ -289,9 +313,15 @@ resource "aws_instance" "app" {
   iam_instance_profile   = aws_iam_instance_profile.instance.name
   key_name               = var.key_pair_name
 
+  # Required for Gitea-as-NAT: the kernel forwards packets sourced from
+  # var.lambda_subnet_cidrs out via this ENI, so AWS must not drop frames
+  # whose source/destination IP does not match the ENI's address.
+  source_dest_check = length(var.lambda_subnet_cidrs) == 0
+
   user_data_base64 = base64gzip(templatefile("${path.module}/user-data.sh.tftpl", {
-    ssm_parameter_path = var.ssm_parameter_path
-    config_bucket_name = var.config_bucket_name
+    ssm_parameter_path  = var.ssm_parameter_path
+    config_bucket_name  = var.config_bucket_name
+    lambda_subnet_cidrs = var.lambda_subnet_cidrs
   }))
   user_data_replace_on_change = false
 
@@ -359,4 +389,9 @@ output "data_volume_id" {
 output "eip_allocation_id" {
   description = "Elastic IP allocation ID (for Route53 A records)"
   value       = aws_eip.app.id
+}
+
+output "primary_network_interface_id" {
+  description = "Primary ENI of the Gitea instance. Consumed by infra/api-service to route 0.0.0.0/0 from Lambda subnets at this ENI (Gitea-as-NAT)."
+  value       = aws_instance.app.primary_network_interface_id
 }

--- a/infra/compute/terraform.tfvars.example
+++ b/infra/compute/terraform.tfvars.example
@@ -9,3 +9,8 @@ data_volume_size_gb = 20
 # vpc_id            = null          # null = default VPC
 # subnet_id         = null          # null = first default subnet
 # allowed_ssh_cidrs = ["1.2.3.4/32"]
+
+# Gitea-as-NAT for the api-service Lambda. Set once the api-service root
+# has provisioned its private subnets; otherwise leave empty. Must list the
+# CIDRs of every subnet passed to api-service's private_subnet_ids.
+# lambda_subnet_cidrs = ["10.0.16.0/20", "10.0.32.0/20"]

--- a/infra/compute/user-data.sh.tftpl
+++ b/infra/compute/user-data.sh.tftpl
@@ -13,8 +13,45 @@ install -d -m 0755 "$${APP_DIR}"
 
 # ---------- Install Docker + Compose plugin (AL2023) ----------
 
-dnf install -y awscli docker xfsprogs
+dnf install -y awscli docker xfsprogs iptables-services
 systemctl enable --now docker
+
+# ---------- Gitea-as-NAT for the api-service Lambda ----------
+# When var.lambda_subnet_cidrs is non-empty in Terraform, this host doubles as
+# the NAT for the Lambda's outbound traffic. Three pieces are needed:
+#   1. source_dest_check disabled on the ENI (set in Terraform)
+#   2. A default route in the Lambda subnets pointing at this ENI (set in
+#      infra/api-service/nat.tf)
+#   3. The two things below: IP forwarding in the kernel + a MASQUERADE rule
+#      that rewrites packets sourced from the Lambda CIDRs.
+#
+# The rules are persisted via iptables-services so they survive reboots. We
+# also write a sysctl drop-in so net.ipv4.ip_forward survives the next boot.
+
+%{ if length(lambda_subnet_cidrs) > 0 ~}
+install -m 0644 /dev/stdin /etc/sysctl.d/99-bindersnap-nat.conf <<'SYSCTL'
+net.ipv4.ip_forward = 1
+SYSCTL
+sysctl --system
+
+# Discover the primary outbound interface (the one carrying the default route).
+NAT_IFACE="$(ip -o -4 route show default | awk '{print $5; exit}')"
+if [ -z "$${NAT_IFACE}" ]; then
+  echo "WARNING: could not detect default-route interface; skipping NAT rules" >&2
+else
+%{ for cidr in lambda_subnet_cidrs ~}
+  iptables -t nat -C POSTROUTING -s ${cidr} -o "$${NAT_IFACE}" -j MASQUERADE 2>/dev/null \
+    || iptables -t nat -A POSTROUTING -s ${cidr} -o "$${NAT_IFACE}" -j MASQUERADE
+  iptables -C FORWARD -s ${cidr} -j ACCEPT 2>/dev/null \
+    || iptables -A FORWARD -s ${cidr} -j ACCEPT
+  iptables -C FORWARD -d ${cidr} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
+    || iptables -A FORWARD -d ${cidr} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+%{ endfor ~}
+  install -d -m 0755 /etc/sysconfig
+  iptables-save > /etc/sysconfig/iptables
+  systemctl enable iptables
+fi
+%{ endif ~}
 
 COMPOSE_ARCH="$(uname -m)"
 COMPOSE_VERSION="v2.37.3"


### PR DESCRIPTION
Refs #224. Final follow-up flagged in the last comment on the issue: the Lambda → Stripe egress path needs the Gitea EC2 host to act as a NAT, which requires three concrete changes inside the `compute/` Terraform root.

## Changes

1. **`source_dest_check = false`** on `aws_instance.app` whenever `var.lambda_subnet_cidrs` is non-empty. Without this, AWS drops frames whose source IP doesn't match the ENI's own address — i.e., every packet the kernel is supposed to forward on behalf of Lambda.
2. **IP forwarding + iptables MASQUERADE** in `user-data.sh.tftpl`, generated per Lambda subnet CIDR. `net.ipv4.ip_forward=1` is persisted via a sysctl drop-in; the iptables rules are persisted via `iptables-save → /etc/sysconfig/iptables` and `systemctl enable iptables`.
3. **SG ingress** on `aws_security_group.app` from each Lambda subnet CIDR so the forwarded packets arrive at the ENI.

Output `primary_network_interface_id` is exported so the api-service root no longer has to relookup the Gitea instance via `data.aws_instance` if we want to tighten that later — for now `infra/api-service/nat.tf` still uses `data.aws_instance(var.gitea_instance_id).network_interface_id`, which returns the same ENI.

## Apply order

`var.lambda_subnet_cidrs` defaults to `[]`, so this PR is a no-op for any existing apply. Cutover order once both PRs are merged:

1. Apply `api-service` root → it provisions the Lambda subnets and exports their CIDRs.
2. Re-apply `compute` with `lambda_subnet_cidrs = [...]` populated → ENI flips, NAT rules land via user-data.
3. Pass the resulting subnet route table IDs back into `api-service`'s `lambda_route_table_ids` → default route activates, Lambda can reach `api.stripe.com`.

## Workflow evidence

- **Issue read method:** `mcp__github__issue_read` (get + get_comments on #224)
- **Branch creation method:** local `git checkout -b` off `development/api-going-serverless`
- **Commit SHA:** `5c644ca`
- **PR creation method:** `mcp__github__create_pull_request`
- **Validation:** `terraform validate` clean; `terraform console` confirms the templatefile renders both branches (empty → 1 MASQUERADE token from the comment only; populated → 1 comment + 4 rule occurrences across 2 CIDRs).