### PR TITLE
fix(landing): remove nav-badge from nav chrome

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -67,10 +67,6 @@
             </div>
             <span class="logo-name">Bindersnap</span>
           </a>
-          <div class="nav-badge">
-            <div class="nav-badge-dot"></div>
-            <span id="nav-count">247 teams signed up</span>
-          </div>
           <div class="nav-right">
             <button
               class="bs-theme-toggle theme-toggle"

--- a/packages/ui-tokens/css/bindersnap-landing.css
+++ b/packages/ui-tokens/css/bindersnap-landing.css
@@ -150,7 +150,6 @@ body::after {
   gap: 0;
 }
 
-
 .nav-cta-link {
   background: var(--bs-text-primary);
   color: var(--bs-page-bg) !important;

--- a/packages/ui-tokens/css/bindersnap-landing.css
+++ b/packages/ui-tokens/css/bindersnap-landing.css
@@ -150,30 +150,6 @@ body::after {
   gap: 0;
 }
 
-.nav-badge {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-family: var(--brand-font-mono);
-  font-size: 11px;
-  color: var(--bs-text-secondary);
-  background: var(--bs-surface-1);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-full);
-  padding: 5px 12px;
-  transition: var(--bs-mode-transition);
-}
-
-.nav-badge-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--brand-green);
-  animation: breathe 2.5s ease-in-out infinite;
-}
 
 .nav-cta-link {
   background: var(--bs-text-primary);
@@ -1647,13 +1623,6 @@ footer {
 }
 
 @media (max-width: 900px) {
-  .nav-badge {
-    position: static;
-    transform: none;
-    order: 3;
-    margin-top: var(--brand-space-2);
-  }
-
   .nav-inner {
     flex-wrap: wrap;
     justify-content: space-between;


### PR DESCRIPTION
## Summary

- Removes `.nav-badge` div ("247 teams signed up") from `apps/app/index.html`
- Deletes `.nav-badge` and `.nav-badge-dot` CSS rules from `bindersnap-landing.css`
- Removes the `@media (max-width: 900px)` responsive override for `.nav-badge`

Social proof stays in the hero `waitlist-row` where it has context. Nav now carries only logo + theme toggle + Sign In / Sign Up.

Closes #263.

## Workflow evidence

- Issue read: `issue_read` (GitHub MCP)
- Branch created: `create_branch` (GitHub MCP) → `fix/remove-nav-badge-263` from `main` @ `1ca84ff`
- Commit: `168c15b`
- PR created: `create_pull_request` (GitHub MCP)

## Test plan

- [ ] Nav renders with logo on left and Sign In / Sign Up cluster on right — no badge in between
- [ ] Hero waitlist-row still shows social proof count
- [ ] Dark mode toggle still works
- [ ] Responsive layout looks correct at ≤900px (no layout artifacts from removed badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)