### PR TITLE
chore(docs): audit and tighten CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,10 +144,8 @@ a `human-needed` issue instead.
 
 `services/api` handles login and signup. It mints a per-user Gitea token at
 login time, stores it in its SQLite session store, and sets an `HttpOnly`
-`bindersnap_session` cookie on the browser. The Gitea token is also returned in
-the login/me response body so the SPA can cache it in `sessionStorage` for
-`gitea-client` calls, but the primary auth path is always the session cookie.
-No bearer tokens in cookies. No Gitea credentials in `localStorage`.
+`bindersnap_session` cookie on the browser. The primary auth path is always the session cookie.
+No bearer tokens in cookies. No Gitea credentials in `sessionStorage` or `localStorage`.
 
 ### All data lives in Gitea. No secondary database.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-**Read `AGENTS.md` before making any changes.** It contains design system rules, GitHub workflow policy, and product context.
+**Read `AGENTS.md` before making any changes.** It is the single source of truth for architecture decisions, design system rules, GitHub workflow policy, and product context.
 
 ---
 
@@ -11,96 +9,59 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 All commands use **Bun** as the runtime and package manager.
 
 ```bash
-# Development (run both together for local dev)
-bun run dev:app       # Start SPA (hot reload, port 5173)
-bun run dev:api       # Start API service (hot reload, port 8787)
+# Development (run both together)
+bun run dev:app       # SPA (hot reload, port 5173)
+bun run dev:api       # API service (hot reload, port 8787)
 
 # Build
 bun run build         # Build SPA to dist/
 
 # Tests
-bun run test          # Run all unit tests (test:app + test:ops)
-bun run test:app      # Test apps/app, packages/editor, packages/utils
-bun run test:ops      # Test services/api, scripts, infra/backups
-bun run test:integration  # Playwright tests (requires: bun run up)
-
-# Run a single test file
-bun test path/to/file.test.ts
+bun run test          # All unit tests (test:app + test:ops)
+bun run test:app      # apps/app, packages/editor, packages/utils
+bun run test:ops      # services/api, scripts, infra/backups
+bun run test:integration  # Playwright (requires: bun run up)
+bun test path/to/file.test.ts  # Single file
 
 # Code formatting
-bun run format        # Format all source files with Prettier
-bun run format:check  # Check formatting without writing
+bun run format        # Format all source files
+bun run format:check  # Check without writing
 
-# Local dev stack (Docker Compose: Gitea + Hocuspocus + app)
-bun run up            # Start full local stack
-bun run down          # Tear down local stack
+# Local dev stack (Gitea + Hocuspocus + app)
+bun run up            # Start
+bun run down          # Tear down
 ```
 
-Test files live alongside source as `*.test.ts`. There is no separate linter script — TypeScript strict mode enforces type correctness.
+Test files live alongside source as `*.test.ts`. TypeScript strict mode is the linter.
 
 ---
 
 ## Architecture
 
-This is a **Bun monorepo** with one unified SPA, shared packages, and backend services.
+Bun monorepo — one SPA, shared packages, backend services.
 
-### One Application
+| Directory | Purpose |
+|-----------|---------|
+| `apps/app/` | Unified SPA → GitHub Pages |
+| `packages/ui-tokens/` | CSS design tokens (single source of truth) |
+| `packages/utils/` | Shared utilities |
+| `services/api/` | Auth + data BFF (port 8787) |
+| `services/hocuspocus/` | Yjs WebSocket collaboration server |
 
-`apps/app/` is the single deployable frontend — published to GitHub Pages. It pre-renders a static landing shell into `index.html`; React swaps to the workspace shell when a valid session is present.
-
-### Packages (shared)
-
-- `packages/ui-tokens/` — CSS design tokens (single source of truth for all visual values).
-- `packages/utils/` — Shared utilities (DOMPurify sanitizer, etc.).
-
-### Services
-
-- `services/api/` — Lightweight BFF (Bun). Owns auth (login/signup/logout/me), session cookies, and Gitea token custody. App data calls go through `/api/app/*` routes.
-- `services/hocuspocus/` — Yjs WebSocket server for real-time collaboration.
-- `server.ts` — Bun dev/prod server that serves the SPA.
-
-### Path aliases (tsconfig)
-
-`@editor/*`, `@gitea/*`, `@ui/*`, `@utils/*` map to their respective packages.
+**Path aliases:** `@editor/*`, `@gitea/*`, `@ui/*`, `@utils/*`
 
 ---
 
 ## Non-Negotiable Architecture Decisions
 
-These are settled. Do not reopen them. If a task seems to require violating one, open a `human-needed` issue instead.
+Settled. Do not reopen. If a task requires violating one, open a `human-needed` issue.
 
-1. **BFF owns auth; Gitea tokens stay server-side.** `services/api` handles login/signup and stores per-session Gitea tokens in its SQLite session store. The browser only receives an `HttpOnly` session cookie — never a raw Gitea token. No bearer tokens in `sessionStorage` or `localStorage`.
+1. **BFF owns auth; Gitea tokens stay server-side.** The browser receives only an `HttpOnly` session cookie. No bearer tokens in `sessionStorage` or `localStorage`.
 
-2. **Gitea is the only datastore.** Documents, approvals, and audit trail are Gitea repos/commits/PRs/reviews. No Postgres, no cache, no shadow state beyond the API's session store.
+2. **Gitea is the only datastore.** No Postgres, no cache, no shadow state beyond the BFF's SQLite session store.
 
-3. **File uploads are browser-direct.** `FileReader → base64 → Gitea contents API`. No server receives the file. See `docs/adr/0001-external-file-workflow.md` — that ADR is law for the file vault workflow.
+3. **File uploads flow browser → BFF → Gitea.** The BFF reads the file as base64 and commits to the Gitea contents API. See `docs/adr/0001-external-file-workflow-contract.md` — that ADR is law.
 
-4. **Two independent workflows.** File vault (external uploads, issues #101–#105) and inline editor (issues #71–#72) are separate. Do not conflate them.
+4. **Two independent workflows.** File vault (external uploads) and inline editor are separate. Do not conflate them.
 
-5. **When editor UI changes, flag it.** If you change `packages/editor/` visuals, note it in your PR — the landing demo embed is a static snapshot requiring a manual `bun run sync-demo` update.
-
----
-
-## Design System
-
-All visual values come from `packages/ui-tokens/css/bindersnap-tokens.css`. **Never hardcode hex values or pixel sizes.** Use `--color-*`, `--font-*`, `--space-*`, `--radius-*`, `--shadow-*` variables.
-
-Key rules:
-
-- Background is always `var(--color-paper)` (`#FAFAF7`), never `#fff`
-- Coral (`--color-coral`) is used for exactly **one** primary action per section
-- Typography: Lora (headlines only), Geist (body/UI), Geist Mono (eyebrows/labels/code)
-- Spacing is a base-8 system (`--space-1` through `--space-24`)
-
----
-
-## GitHub Workflow Policy
-
-Use **GitHub MCP tools first** for all GitHub API actions. `gh` CLI is fallback-only (document the MCP tool that failed and why).
-
-- Read: `issue_read`, `pull_request_read`, `list_issues`, `list_pull_requests`
-- Write: `create_branch`, `create_or_update_file`, `create_pull_request`, `update_pull_request`, `add_issue_comment`, `pull_request_review_write`
-
-Every PR must include workflow evidence (issue read method, branch creation method, commit SHA, PR creation method, any fallbacks used).
-
-Local `git` for working tree operations. MCP for GitHub API operations.
+5. **Editor UI changes need a flag.** If you change `packages/editor/` visuals, note it in your PR — the landing demo embed requires a manual `bun run sync-demo`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,13 +40,13 @@ Test files live alongside source as `*.test.ts`. TypeScript strict mode is the l
 
 Bun monorepo — one SPA, shared packages, backend services.
 
-| Directory | Purpose |
-|-----------|---------|
-| `apps/app/` | Unified SPA → GitHub Pages |
-| `packages/ui-tokens/` | CSS design tokens (single source of truth) |
-| `packages/utils/` | Shared utilities |
-| `services/api/` | Auth + data BFF (port 8787) |
-| `services/hocuspocus/` | Yjs WebSocket collaboration server |
+| Directory              | Purpose                                    |
+| ---------------------- | ------------------------------------------ |
+| `apps/app/`            | Unified SPA → GitHub Pages                 |
+| `packages/ui-tokens/`  | CSS design tokens (single source of truth) |
+| `packages/utils/`      | Shared utilities                           |
+| `services/api/`        | Auth + data BFF (port 8787)                |
+| `services/hocuspocus/` | Yjs WebSocket collaboration server         |
 
 **Path aliases:** `@editor/*`, `@gitea/*`, `@ui/*`, `@utils/*`
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: removed duplicate GitHub workflow policy and design system sections (AGENTS.md is the single source of truth); tightened prose from ~107 to ~65 lines; converted architecture section to a quick-reference table
- **CLAUDE.md ADR #3**: fixed contradiction — the rule previously said uploads are "browser-direct" with no server involved, but AGENTS.md and the actual implementation describe a `browser → BFF → Gitea` flow; aligned to match reality
- **AGENTS.md**: removed sessionStorage contradiction on line 109 — after #247 removed `gitea-client` from the frontend, there is no client-side token caching; the line now correctly states "No Gitea credentials in `sessionStorage` or `localStorage`"

## What was NOT changed

- `settings.local.json` (not git-tracked — cleaned up locally)
- Memory files (stale `project_document_upload_complete.md` deleted locally — not in repo)
- All AGENTS.md design system, product context, and component pattern content — left intact

## Workflow evidence

- Branch created: local `git checkout -b`
- Commit SHA: 36fb74e
- PR created: `gh pr create` (GitHub MCP unavailable this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)