### PR TITLE
fix(home): change "past due" to "need your review" (#273)

### DIFF
--- a/apps/app/components/HomePage.tsx
+++ b/apps/app/components/HomePage.tsx
@@ -398,7 +398,7 @@ export function HomePage({
           {awaitingReview > 0 ? (
             <div className="dash-stat-sub dash-stat-sub--warning">
               <Clock3 size={11} strokeWidth={1.8} aria-hidden="true" />
-              {awaitingReview} past due
+              {awaitingReview} need your review
             </div>
           ) : (
             <div className="dash-stat-sub">All clear</div>


### PR DESCRIPTION
## Summary

Closes #273

The `awaitingReview` count has no due-date logic — it counts PRs currently in review by someone other than the current user. Labelling them "past due" is inaccurate and would be embarrassing in a demo.

- Changed copy from `{awaitingReview} past due` → `{awaitingReview} need your review` in `HomePage.tsx:401`

## Workflow evidence
- Issue read: `mcp__github__issue_read` #273
- Branch: local `git checkout -b fix/273-past-due-copy main`
- PR: `mcp__github__create_pull_request`