### PR TITLE
fix(app-shell): hide disabled Profile and Settings menu items (#267)

### DIFF
--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -7,9 +7,7 @@ import {
   Moon,
   Plus,
   Search,
-  Settings,
   Shield,
-  User,
 } from "lucide-react";
 import type { SessionUser } from "../api";
 import type { AppRoute } from "../routes";
@@ -82,12 +80,8 @@ function getInitials(name: string): string {
 
 function renderProfileMenuIcon(icon: string) {
   switch (icon) {
-    case "profile":
-      return <User size={16} strokeWidth={1.5} aria-hidden="true" />;
     case "documents":
       return <FileText size={16} strokeWidth={1.5} aria-hidden="true" />;
-    case "settings":
-      return <Settings size={16} strokeWidth={1.5} aria-hidden="true" />;
     case "appearance":
       return <Moon size={16} strokeWidth={1.5} aria-hidden="true" />;
     case "admin":
@@ -268,18 +262,6 @@ export function AppShell({
                   >
                     <button
                       type="button"
-                      className="app-profile-menu-item app-profile-menu-item--disabled"
-                      role="menuitem"
-                      aria-disabled="true"
-                      disabled
-                    >
-                      <span className="app-profile-menu-icon">
-                        {renderProfileMenuIcon("profile")}
-                      </span>
-                      <span className="app-profile-menu-label">Profile</span>
-                    </button>
-                    <button
-                      type="button"
                       className={`app-profile-menu-item${isDocuments ? " app-profile-menu-item--active" : ""}`}
                       role="menuitem"
                       onClick={() => {
@@ -291,18 +273,6 @@ export function AppShell({
                         {renderProfileMenuIcon("documents")}
                       </span>
                       <span className="app-profile-menu-label">Documents</span>
-                    </button>
-                    <button
-                      type="button"
-                      className="app-profile-menu-item app-profile-menu-item--disabled"
-                      role="menuitem"
-                      aria-disabled="true"
-                      disabled
-                    >
-                      <span className="app-profile-menu-icon">
-                        {renderProfileMenuIcon("settings")}
-                      </span>
-                      <span className="app-profile-menu-label">Settings</span>
                     </button>
                     <button
                       type="button"


### PR DESCRIPTION
## Summary

Closes #267

Disabled menu items in the top-level profile dropdown read as "this product is unfinished." Hiding them until the features ship is cleaner than surfacing a broken interaction.

- Removed the disabled `Profile` button from `AppShell.tsx:269–280`
- Removed the disabled `Settings` button from `AppShell.tsx:295–306`
- Cleaned up now-unused `User` and `Settings` Lucide imports and their `renderProfileMenuIcon` cases

## Workflow evidence
- Issue read: `mcp__github__issue_read` #267
- Branch: local `git checkout -b fix/267-hide-disabled-menu-items main`
- PR: `mcp__github__create_pull_request`