### PR TITLE
fix(home): token class for skeleton heights; trim mockup bar text (#269)

### DIFF
--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -1695,6 +1695,15 @@ input {
   width: 85%;
 }
 
+.dash-stat-skeleton {
+  height: var(--brand-space-8);
+  margin-top: var(--brand-space-1);
+  background: var(--bs-surface-3);
+  border-radius: var(--brand-radius-sm);
+  width: 40%;
+  animation: vault-skeleton-pulse 2s ease-in-out infinite;
+}
+
 /* ── Login logo lockup ─────────────────────────────────────── */
 
 .app-login-logo {

--- a/apps/app/components/HomePage.tsx
+++ b/apps/app/components/HomePage.tsx
@@ -389,8 +389,7 @@ export function HomePage({
           <div className="dash-stat-label">Awaiting Review</div>
           {isLoadingDocuments ? (
             <div
-              className="vault-skeleton-line vault-skeleton-line--short"
-              style={{ height: "2rem", marginTop: 4 }}
+              className="dash-stat-skeleton"
             />
           ) : (
             <div className="dash-stat-value">{awaitingReview}</div>
@@ -409,8 +408,7 @@ export function HomePage({
           <div className="dash-stat-label">Approved This Month</div>
           {isLoadingDocuments ? (
             <div
-              className="vault-skeleton-line vault-skeleton-line--short"
-              style={{ height: "2rem", marginTop: 4 }}
+              className="dash-stat-skeleton"
             />
           ) : (
             <div className="dash-stat-value">{approvedThisMonth}</div>
@@ -425,8 +423,7 @@ export function HomePage({
           <div className="dash-stat-label">Open Change Requests</div>
           {isLoadingDocuments ? (
             <div
-              className="vault-skeleton-line vault-skeleton-line--short"
-              style={{ height: "2rem", marginTop: 4 }}
+              className="dash-stat-skeleton"
             />
           ) : (
             <div className="dash-stat-value">{openChangeRequests}</div>
@@ -440,8 +437,7 @@ export function HomePage({
           <div className="dash-stat-label">Active Contributors</div>
           {isLoadingDocuments ? (
             <div
-              className="vault-skeleton-line vault-skeleton-line--short"
-              style={{ height: "2rem", marginTop: 4 }}
+              className="dash-stat-skeleton"
             />
           ) : (
             <div className="dash-stat-value">{activeContributors}</div>

--- a/apps/app/components/HomePage.tsx
+++ b/apps/app/components/HomePage.tsx
@@ -388,9 +388,7 @@ export function HomePage({
         <div className="dash-stat-card">
           <div className="dash-stat-label">Awaiting Review</div>
           {isLoadingDocuments ? (
-            <div
-              className="dash-stat-skeleton"
-            />
+            <div className="dash-stat-skeleton" />
           ) : (
             <div className="dash-stat-value">{awaitingReview}</div>
           )}
@@ -407,9 +405,7 @@ export function HomePage({
         <div className="dash-stat-card">
           <div className="dash-stat-label">Approved This Month</div>
           {isLoadingDocuments ? (
-            <div
-              className="dash-stat-skeleton"
-            />
+            <div className="dash-stat-skeleton" />
           ) : (
             <div className="dash-stat-value">{approvedThisMonth}</div>
           )}
@@ -422,9 +418,7 @@ export function HomePage({
         <div className="dash-stat-card">
           <div className="dash-stat-label">Open Change Requests</div>
           {isLoadingDocuments ? (
-            <div
-              className="dash-stat-skeleton"
-            />
+            <div className="dash-stat-skeleton" />
           ) : (
             <div className="dash-stat-value">{openChangeRequests}</div>
           )}
@@ -436,9 +430,7 @@ export function HomePage({
         <div className="dash-stat-card">
           <div className="dash-stat-label">Active Contributors</div>
           {isLoadingDocuments ? (
-            <div
-              className="dash-stat-skeleton"
-            />
+            <div className="dash-stat-skeleton" />
           ) : (
             <div className="dash-stat-value">{activeContributors}</div>
           )}

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -172,7 +172,7 @@
                   <span></span><span></span><span></span>
                 </div>
                 <div class="mockup-bar">
-                  bindersnap.com &mdash; Q4 Vendor Agreement &middot; In Review
+                  Q4 Vendor Agreement &middot; In Review
                 </div>
               </div>
               <div class="mockup-editor">


### PR DESCRIPTION
## Summary

Closes #269

Two fixes:

**Skeleton inline styles** — `HomePage.tsx:391–444` used `style={{ height: '2rem', marginTop: 4 }}` on four stat-card skeleton lines, violating the design-token rule in CLAUDE.md. Replaced with a new `.dash-stat-skeleton` CSS class in `app.css` that uses `--brand-space-8`, `--brand-space-1`, `--brand-radius-sm`, and `--bs-surface-3` tokens.

**Hero mockup bar** — `index.html:175` read `bindersnap.com — Q4 Vendor Agreement · In Review`. The URL prefix is implied and clutters the mock UI. Trimmed to `Q4 Vendor Agreement · In Review`.

## Workflow evidence
- Issue read: `mcp__github__issue_read` #269
- Branch: local `git checkout -b fix/269-skeleton-token-and-hero-text main`
- PR: `mcp__github__create_pull_request`