### PR TITLE
fix(landing): fix footer copyright — © symbol and proper entity (#265)

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -689,10 +689,9 @@
           </p>
           <div class="footer-rule"></div>
           <div class="footer-bottom">
-            <span class="footer-copy">2026 BINDERSNAP</span>
+            <span class="footer-copy">&copy; 2026 Solid Gray LLC</span>
             <span class="footer-love"
-              >Made for teams that answer to auditors
-              <span class="heart">&hearts;</span></span
+              >Made for teams that answer to auditors</span
             >
           </div>
         </div>


### PR DESCRIPTION
## Summary

Closes #265

The footer showed `2026 BINDERSNAP` — no copyright symbol, screaming caps, no legal entity. Regulated buyers scan the footer; this looked unfinished.

- Changed to `© 2026 Solid Gray LLC`
- Removed the decorative `♥` heart glyph (doesn't fit the audit/compliance positioning)

## Workflow evidence
- Issue read: `mcp__github__issue_read` #265
- Branch: local `git checkout -b fix/265-footer-copyright main`
- PR: `mcp__github__create_pull_request`