### PR TITLE
fix(landing): remove theme toggle from marketing nav (#264)

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -68,25 +68,6 @@
             <span class="logo-name">Bindersnap</span>
           </a>
           <div class="nav-right">
-            <button
-              class="bs-theme-toggle theme-toggle"
-              onclick="toggleTheme()"
-              aria-label="Toggle dark mode"
-              title="Toggle dark / light mode"
-            >
-              <span
-                class="landing-lucide-icon icon-moon"
-                data-lucide-icon="moon"
-                data-lucide-size="16"
-                aria-hidden="true"
-              ></span>
-              <span
-                class="landing-lucide-icon icon-sun"
-                data-lucide-icon="sun-medium"
-                data-lucide-size="16"
-                aria-hidden="true"
-              ></span>
-            </button>
             <a href="/login" class="nav-login-link">Sign In</a>
             <a href="/signup" class="nav-cta-link">Sign Up</a>
           </div>


### PR DESCRIPTION
## Summary

Closes #264

The light/dark toggle button in the marketing nav occupies prime conversion real estate with a power-user concern. A visitor's first decision is "do I trust this enough to give my email" — not "which colour scheme do I want."

- Removed the `.theme-toggle` button from the nav in `index.html:71–89`
- `prefers-color-scheme` is already honoured automatically at page load (the inline script at `index.html:40–49` runs before paint)
- The toggle remains in the in-app `AppShell` profile menu for authenticated users

## Workflow evidence
- Issue read: `mcp__github__issue_read` #264
- Branch: local `git checkout -b fix/264-remove-nav-theme-toggle main`
- PR: `mcp__github__create_pull_request`