### PR TITLE
fix(landing): coral Sign Up CTA; quiet Sign In link in nav (#272)

### DIFF
--- a/packages/ui-tokens/css/bindersnap-landing.css
+++ b/packages/ui-tokens/css/bindersnap-landing.css
@@ -151,8 +151,8 @@ body::after {
 }
 
 .nav-cta-link {
-  background: var(--bs-text-primary);
-  color: var(--bs-page-bg) !important;
+  background: var(--brand-coral);
+  color: #fff !important;
   font-size: 13px;
   font-weight: var(--brand-weight-medium);
   padding: 9px 22px;
@@ -160,13 +160,13 @@ body::after {
   text-decoration: none;
   letter-spacing: 0.01em;
   transition:
-    opacity var(--brand-transition-base),
+    background var(--brand-transition-base),
     transform var(--brand-transition-fast);
 }
 
 .nav-cta-link:hover,
 .nav-cta-link:focus-visible {
-  opacity: 0.85;
+  background: var(--brand-coral-dark);
   transform: translateY(-1px);
 }
 


### PR DESCRIPTION
## Summary

Closes #272

`.nav-cta-link` was using `--bs-text-primary` (dark ink) as its background. This violated the CLAUDE.md rule: "Coral is used for exactly ONE primary action per section." The Sign Up button looked like a generic dark button with no visual hierarchy distinction from Sign In.

- Changed `.nav-cta-link` background to `var(--brand-coral)` with hover state `var(--brand-coral-dark)`
- Sign In remains a quiet mono-font secondary link — the hierarchy is now clear

## Workflow evidence
- Issue read: `mcp__github__issue_read` #272
- Branch: local `git checkout -b fix/272-nav-cta-hierarchy main`
- PR: `mcp__github__create_pull_request`