### PR TITLE
fix(landing): remove emojis and reduce italic overuse for audit positioning (#262)

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -98,7 +98,13 @@
         <section class="hero">
           <div class="hero-inner">
             <div class="chaos-pill">
-              <span class="chaos-pill-emoji">😩</span>
+              <span
+                class="landing-lucide-icon chaos-pill-icon"
+                data-lucide-icon="file-x-2"
+                data-lucide-size="14"
+                data-lucide-stroke-width="1.75"
+                aria-hidden="true"
+              ></span>
               <span class="chaos-file"
                 >contract_FINAL_v2_JanEdits_APPROVED(1).docx</span
               >
@@ -161,8 +167,8 @@
                     aria-hidden="true"
                   ></span>
                 </div>
-                <h3>You're on the list! 🎉</h3>
-                <p>We'll be in touch the moment Bindersnap launches.</p>
+                <h3>You're on the waitlist.</h3>
+                <p>We'll email when access opens for your team.</p>
               </div>
             </div>
 
@@ -308,7 +314,7 @@
               <div class="eyebrow-tag">The Solution</div>
             </div>
             <h2 class="features-title reveal">
-              One tool that <em>actually</em> handles the whole process
+              One tool that handles the whole process
             </h2>
             <p class="features-subtitle reveal">
               Familiar to write in. Built for teams. Airtight on accountability.
@@ -379,7 +385,7 @@
         <section class="section-compare">
           <div class="compare-inner">
             <div class="compare-header reveal">
-              <h2>Before Bindersnap.<br /><em>After</em> Bindersnap.</h2>
+              <h2>Before Bindersnap.<br />After Bindersnap.</h2>
               <p>The same workflow &mdash; completely transformed.</p>
             </div>
             <div class="compare-grid">
@@ -511,7 +517,7 @@
           <div class="section-compliance">
             <div class="comp-left reveal">
               <div class="overline">Enterprise-Ready</div>
-              <h2>Built for teams that<br />answer to <em>auditors.</em></h2>
+              <h2>Built for teams that<br />answer to auditors.</h2>
               <p>
                 Bindersnap isn't just convenient &mdash; it's built to the
                 security standards that regulated industries demand. Whether
@@ -656,8 +662,8 @@
                     aria-hidden="true"
                   ></span>
                 </div>
-                <h3>You're on the list! 🎉</h3>
-                <p>We'll be in touch the moment we launch.</p>
+                <h3>You're on the waitlist.</h3>
+                <p>We'll email when access opens for your team.</p>
               </div>
             </div>
           </div>

--- a/packages/ui-tokens/css/bindersnap-landing.css
+++ b/packages/ui-tokens/css/bindersnap-landing.css
@@ -269,8 +269,8 @@ body::after {
 .chaos-pill-text {
   color: var(--bs-text-muted);
 }
-.chaos-pill-emoji {
-  font-size: 15px;
+.chaos-pill-icon {
+  color: var(--bs-text-muted);
 }
 
 /* Hero headline */


### PR DESCRIPTION
## Summary

Closes #262

The product targets compliance/regulated buyers. Emojis and `🎉` success states cut against that positioning — they belong on a Notion-for-creators landing, not a SOC 2 pitch.

**Changes:**
- `index.html:101` — replaced `😩` emoji in chaos-pill with a Lucide `file-x-2` icon (same icon language used throughout)
- `index.html:164, 659` — both success states: `"You're on the list! 🎉"` → `"You're on the waitlist."` with copy `"We'll email when access opens for your team."`
- Removed `<em>` italic treatment from features h2, before/after h2, and compliance h2 — kept only in chaos-strip ("document governance") and final CTA ("Finally."), which are the two strongest emotional beats
- CSS: renamed `.chaos-pill-emoji` → `.chaos-pill-icon` for the Lucide icon

## Workflow evidence
- Issue read: `mcp__github__issue_read` #262
- Branch: local `git checkout -b fix/262-tone-mismatch main`
- PR: `mcp__github__create_pull_request`