### PR TITLE
fix(landing): bind signup buttons via addEventListener, drop inline onclick (#268)

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -136,7 +136,7 @@
                   placeholder="your@company.com"
                   autocomplete="email"
                 />
-                <button type="button" onclick="signup('hero')">
+                <button type="button" id="hero-signup-btn">
                   Sign Up Free &rarr;
                 </button>
               </div>
@@ -638,7 +638,7 @@
                   placeholder="your@company.com"
                   autocomplete="email"
                 />
-                <button type="button" onclick="signup('cta')">
+                <button type="button" id="cta-signup-btn">
                   Sign Up Free
                 </button>
               </div>

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -638,9 +638,7 @@
                   placeholder="your@company.com"
                   autocomplete="email"
                 />
-                <button type="button" id="cta-signup-btn">
-                  Sign Up Free
-                </button>
+                <button type="button" id="cta-signup-btn">Sign Up Free</button>
               </div>
               <p class="cta-hint">
                 Free to join &middot; No credit card &middot; Start in minutes

--- a/apps/app/landing-inline.ts
+++ b/apps/app/landing-inline.ts
@@ -46,6 +46,13 @@ window.signup = (source: SignupSource) => {
   routeLandingSignup(document, source);
 };
 
+document.getElementById("hero-signup-btn")?.addEventListener("click", () => {
+  routeLandingSignup(document, "hero");
+});
+document.getElementById("cta-signup-btn")?.addEventListener("click", () => {
+  routeLandingSignup(document, "cta");
+});
+
 bindSignupEnterKeys(document, (source) => {
   window.signup?.(source);
 });


### PR DESCRIPTION
## Summary

Closes #268

Inline `onclick="signup('hero')"` and `onclick="signup('cta')"` in `index.html` mix paradigms — a React SPA shipping inline HTML handlers makes the static landing a maintenance landmine when analytics or CSP need to participate.

**Changes:**
- `index.html:139` — removed `onclick="signup('hero')"`, added `id="hero-signup-btn"`
- `index.html:641` — removed `onclick="signup('cta')"`, added `id="cta-signup-btn"`
- `landing-inline.ts` — added `addEventListener("click")` bindings for both buttons, consistent with the existing enter-key binding pattern (`landing.ts:84–95`)

The `window.signup` global is retained for backwards compatibility with any external callers, but the HTML no longer uses it directly.

## Workflow evidence
- Issue read: `mcp__github__issue_read` #268
- Branch: local `git checkout -b fix/268-remove-inline-onclick main`
- PR: `mcp__github__create_pull_request`