### PR TITLE
fix(landing): unify form hint copy and class across hero and CTA (#271)

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -642,7 +642,14 @@
                   Sign Up Free
                 </button>
               </div>
-              <p class="cta-hint">
+              <p class="form-hint">
+                <span
+                  class="landing-lucide-icon"
+                  data-lucide-icon="clock-3"
+                  data-lucide-size="12"
+                  data-lucide-stroke-width="1.75"
+                  aria-hidden="true"
+                ></span>
                 Free to join &middot; No credit card &middot; Start in minutes
               </p>
               <div class="cta-success" id="cta-success">

--- a/packages/ui-tokens/css/bindersnap-landing.css
+++ b/packages/ui-tokens/css/bindersnap-landing.css
@@ -1473,11 +1473,6 @@ body::after {
   background: var(--brand-coral-dark);
 }
 
-.cta-hint {
-  font-size: 12px;
-  color: var(--bs-text-faint);
-}
-
 .cta-success {
   display: none;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Closes #271

`index.html:147–156` (hero) and `index.html:649–651` (CTA) had the same hint copy but two diverging implementations: `.form-hint` with a Lucide `clock-3` icon vs. `.cta-hint` with no icon and a separate CSS rule.

**Changes:**
- `index.html:649` — changed `class="cta-hint"` → `class="form-hint"`, added the same `clock-3` icon span used by the hero hint
- `bindersnap-landing.css` — removed `.cta-hint` rule (now covered by the shared `.form-hint`)

Both hints are now identical in markup and style. Any future copy change only needs to happen once.

## Workflow evidence
- Issue read: `mcp__github__issue_read` #271
- Branch: local `git checkout -b fix/271-form-hint-dedup main`
- PR: `mcp__github__create_pull_request`