### PR TITLE
fix(release): include CHANGELOG.md in release commit

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -14,10 +14,7 @@
   "issueUrlFormat": "https://github.com/davidgraymi/bindersnap-editor-demo/issues/{{id}}",
   "userUrlFormat": "https://github.com/{{user}}",
   "releaseCommitMessageFormat": "chore: release v{{currentTag}} [skip ci]",
-  "skip": {
-    "changelog": true
-  },
   "scripts": {
-    "postbump": "bun run changelog"
+    "postchangelog": "bun run changelog"
   }
 }


### PR DESCRIPTION
## Summary

- `standard-version` only commits files it explicitly tracks; with `skip.changelog: true` set, `CHANGELOG.md` was never in that list
- The `postbump` hook staged the file via `git add`, but `standard-version` commits specific files explicitly, so the staged file was silently dropped
- Removes `skip.changelog` so `standard-version` adds `CHANGELOG.md` to its commit file list
- Moves the `auto-changelog` call from `postbump` → `postchangelog`, which runs after standard-version generates its changelog but before the commit — so auto-changelog overwrites the content and re-stages it cleanly

## Test plan

- [ ] Trigger the release pipeline and confirm the release commit includes `CHANGELOG.md` alongside `package.json` and `package-lock.json`
- [ ] Verify `CHANGELOG.md` content is generated by `auto-changelog` (not the conventional-commits format from standard-version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)