### PR TITLE
feat(deploy): pyinfra scaffold with SSH-over-SSM connection (Phase 1)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,9 @@ on:
       - "CHANGELOG.md"
       - "package.json"
       - "bun.lock"
+      # Infra/deploy-only changes never affect the static SPA — don't republish.
+      - "deploy/**"
+      - "infra/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -10,6 +10,10 @@ on:
       - "CHANGELOG.md"
       - "package.json"
       - "bun.lock"
+      # Infra/deploy-only changes are validated on the PR itself (pull_request
+      # has no path filter); skip the redundant re-run on the main push.
+      - "deploy/**"
+      - "infra/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       - "CHANGELOG.md"
       - "package.json"
       - "bun.lock"
+      # Infra/deploy-only changes don't ship app code — don't cut a release.
+      - "deploy/**"
+      - "infra/**"
 
 concurrency:
   group: release

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,8 @@
+# Never commit SSH key material, local virtualenvs or bytecode caches.
+.venv/
+__pycache__/
+*.pyc
+*.pem
+id_ed25519*
+id_rsa*
+*.pub

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,12 +26,12 @@ inbound port 22** and we store **no long-lived keys**. Every run:
 
 ## Layout
 
-| File                  | Purpose                                                        |
-| --------------------- | ------------------------------------------------------------- |
-| `inventory.py`        | Single prod host + SSH-over-SSM connection data               |
-| `deploy.py`           | The deployment itself (operations run against the host)       |
-| `bin/ssm-connect.sh`  | Resolve instance, push ephemeral key, invoke pyinfra          |
-| `requirements.txt`    | Python toolchain (pyinfra, paramiko)                          |
+| File                 | Purpose                                                 |
+| -------------------- | ------------------------------------------------------- |
+| `inventory.py`       | Single prod host + SSH-over-SSM connection data         |
+| `deploy.py`          | The deployment itself (operations run against the host) |
+| `bin/ssm-connect.sh` | Resolve instance, push ephemeral key, invoke pyinfra    |
+| `requirements.txt`   | Python toolchain (pyinfra, paramiko)                    |
 
 ## Prerequisites
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,74 @@
+# `deploy/` — pyinfra push deployment
+
+This directory is the single source of truth for how the Bindersnap production
+host is configured and how the application is deployed. It replaces the old
+flow (manual SSH, `infra/compute/user-data.sh.tftpl` bootstrap, and the S3
+config bucket). See epic
+[#302](https://github.com/davidgraymi/bindersnap-editor-demo/issues/302).
+
+> **Status:** Phase 1 (scaffold + connectivity). Host configuration operations
+> arrive in Phase 2 ([#304](https://github.com/davidgraymi/bindersnap-editor-demo/issues/304)).
+
+## How it connects
+
+pyinfra drives the host from the outside over SSH — but the host keeps **no
+inbound port 22** and we store **no long-lived keys**. Every run:
+
+1. resolves the running instance by tag (`Project=bindersnap`);
+2. generates a throwaway ed25519 keypair and a matching SSH config;
+3. pushes the public key to the host with **EC2 Instance Connect** (valid ~60s);
+4. opens SSH **tunnelled through AWS SSM** via a `ProxyCommand` in that config
+   (`aws ssm start-session` with the `AWS-StartSSHSession` document), which
+   pyinfra parses and dials lazily at connect time.
+
+`deploy/bin/ssm-connect.sh` orchestrates 1–3 and then runs pyinfra;
+`deploy/inventory.py` references the generated config so pyinfra dials it.
+
+## Layout
+
+| File                  | Purpose                                                        |
+| --------------------- | ------------------------------------------------------------- |
+| `inventory.py`        | Single prod host + SSH-over-SSM connection data               |
+| `deploy.py`           | The deployment itself (operations run against the host)       |
+| `bin/ssm-connect.sh`  | Resolve instance, push ephemeral key, invoke pyinfra          |
+| `requirements.txt`    | Python toolchain (pyinfra, paramiko)                          |
+
+## Prerequisites
+
+- AWS CLI v2 and the `session-manager-plugin` on `PATH`
+- Python 3 + the deps in `requirements.txt`
+- AWS credentials (locally a profile; in CI the OIDC deploy role) able to:
+  - `ec2:DescribeInstances`
+  - `ec2-instance-connect:SendSSHPublicKey`
+  - `ssm:StartSession` on the `AWS-StartSSHSession` document and the instance
+
+> The OIDC deploy role does **not** yet grant `StartSession` /
+> `SendSSHPublicKey` — those IAM additions land with the CI workflow in Phase 3
+> ([#305](https://github.com/davidgraymi/bindersnap-editor-demo/issues/305)).
+> Until then, run locally with a profile that has them.
+
+## Usage
+
+```bash
+# one-time
+python3 -m venv deploy/.venv
+deploy/.venv/bin/pip install -r deploy/requirements.txt
+source deploy/.venv/bin/activate
+
+# connectivity check (Phase 1)
+deploy/bin/ssm-connect.sh
+
+# dry run (no changes applied)
+deploy/bin/ssm-connect.sh --dry
+```
+
+Override defaults with env vars: `AWS_REGION`, `BINDERSNAP_INSTANCE_ID`
+(skip tag lookup), `BINDERSNAP_SSH_USER`, `BINDERSNAP_INSTANCE_TAG_KEY`,
+`BINDERSNAP_INSTANCE_TAG_VALUE`.
+
+## Security notes
+
+- No SSH key material is ever written to the repo (`.gitignore` enforces this).
+- Secrets continue to live in AWS Parameter Store; pyinfra reads them on the
+  host at deploy time and writes `/opt/bindersnap/.env.prod` with `0600` perms
+  (Phase 2). They are never printed or committed.

--- a/deploy/bin/ssm-connect.sh
+++ b/deploy/bin/ssm-connect.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Connect to the Bindersnap production host and run pyinfra over an
+# SSM-tunnelled SSH transport (epic #302). No inbound port 22, no long-lived
+# SSH keys: we resolve the instance by tag, push an ephemeral key via EC2
+# Instance Connect, then let paramiko tunnel SSH through Session Manager.
+#
+# Usage:
+#   deploy/bin/ssm-connect.sh                 # apply deploy/deploy.py
+#   deploy/bin/ssm-connect.sh --dry           # pyinfra dry run
+#   deploy/bin/ssm-connect.sh fact server.Os  # any pyinfra args pass through
+#
+# Prerequisites (local or CI):
+#   - aws CLI v2 + session-manager-plugin on PATH
+#   - pyinfra installed (deploy/requirements.txt)
+#   - AWS credentials with: ec2:DescribeInstances,
+#     ec2-instance-connect:SendSSHPublicKey, ssm:StartSession on the
+#     AWS-StartSSHSession document and the target instance.
+set -euo pipefail
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+SSH_USER="${BINDERSNAP_SSH_USER:-ec2-user}"
+INSTANCE_TAG_KEY="${BINDERSNAP_INSTANCE_TAG_KEY:-Project}"
+INSTANCE_TAG_VALUE="${BINDERSNAP_INSTANCE_TAG_VALUE:-bindersnap}"
+
+deploy_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="$(cd "${deploy_dir}/.." && pwd)"
+
+# 1. Resolve the running instance id (explicit override wins).
+instance_id="${BINDERSNAP_INSTANCE_ID:-}"
+if [ -z "${instance_id}" ]; then
+  instance_id="$(aws ec2 describe-instances \
+    --region "${AWS_REGION}" \
+    --filters "Name=tag:${INSTANCE_TAG_KEY},Values=${INSTANCE_TAG_VALUE}" \
+              "Name=instance-state-name,Values=running" \
+    --query 'Reservations[].Instances[].InstanceId | [0]' \
+    --output text)"
+fi
+if [ -z "${instance_id}" ] || [ "${instance_id}" = "None" ]; then
+  echo "ERROR: no running instance for ${INSTANCE_TAG_KEY}=${INSTANCE_TAG_VALUE} in ${AWS_REGION}" >&2
+  exit 1
+fi
+echo "Target instance: ${instance_id}"
+
+# 2. Ephemeral keypair + SSH config, removed on exit.
+keydir="$(mktemp -d)"
+trap 'rm -rf "${keydir}"' EXIT
+ssh-keygen -t ed25519 -N "" -f "${keydir}/id" -q -C "bindersnap-deploy"
+
+# SSH config whose ProxyCommand tunnels the transport through Session Manager.
+# %h/%p expand to the instance id and port pyinfra connects to.
+cat >"${keydir}/ssh_config" <<SSH_CONFIG
+Host *
+    User ${SSH_USER}
+    IdentityFile ${keydir}/id
+    StrictHostKeyChecking accept-new
+    UserKnownHostsFile /dev/null
+    ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p --region ${AWS_REGION}"
+SSH_CONFIG
+
+# 3. Push the public key (~60s validity) via EC2 Instance Connect.
+az="$(aws ec2 describe-instances \
+  --region "${AWS_REGION}" \
+  --instance-ids "${instance_id}" \
+  --query 'Reservations[0].Instances[0].Placement.AvailabilityZone' \
+  --output text)"
+aws ec2-instance-connect send-ssh-public-key \
+  --region "${AWS_REGION}" \
+  --instance-id "${instance_id}" \
+  --availability-zone "${az}" \
+  --instance-os-user "${SSH_USER}" \
+  --ssh-public-key "file://${keydir}/id.pub" >/dev/null
+echo "Pushed ephemeral key for ${SSH_USER}@${instance_id}"
+
+# 4. Run pyinfra. inventory.py reads the exported variables below.
+export BINDERSNAP_INSTANCE_ID="${instance_id}"
+export BINDERSNAP_SSH_KEY="${keydir}/id"
+export BINDERSNAP_SSH_CONFIG="${keydir}/ssh_config"
+export BINDERSNAP_SSH_USER="${SSH_USER}"
+export AWS_REGION
+
+cd "${repo_root}"
+exec pyinfra deploy/inventory.py deploy/deploy.py "$@"

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -1,0 +1,17 @@
+"""Bindersnap production deployment (epic #302).
+
+Phase 1 (#303): connectivity check only — proves pyinfra can reach the host
+through the SSM tunnel. The real host configuration (Docker, EBS mount, config
+upload, secret refresh, compose up) lands in Phase 2 (#304).
+"""
+
+from pyinfra.operations import server
+
+server.shell(
+    name="Connectivity check",
+    commands=[
+        "whoami",
+        "hostname",
+        "uname -a",
+    ],
+)

--- a/deploy/inventory.py
+++ b/deploy/inventory.py
@@ -1,0 +1,48 @@
+"""pyinfra inventory for the Bindersnap production host (epic #302).
+
+Connection model: SSH tunnelled over AWS SSM, so the host needs no inbound
+port 22 and we keep no long-lived SSH keys.
+
+  1. ``deploy/bin/ssm-connect.sh`` resolves the running instance by tag,
+     generates an ephemeral keypair, and pushes the public half to the host
+     via EC2 Instance Connect (valid ~60s).
+  2. It writes a throwaway SSH config whose ``ProxyCommand`` tunnels the
+     transport through ``aws ssm start-session`` (the AWS-StartSSHSession
+     document), then exports the variables this file reads and invokes pyinfra.
+  3. pyinfra parses that config and opens the proxied connection lazily,
+     authenticating with the ephemeral key.
+
+Run deploys through the wrapper rather than invoking pyinfra directly, or
+export ``BINDERSNAP_INSTANCE_ID``, ``BINDERSNAP_SSH_KEY`` and
+``BINDERSNAP_SSH_CONFIG`` yourself first.
+"""
+
+import os
+
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+SSH_USER = os.environ.get("BINDERSNAP_SSH_USER", "ec2-user")
+
+_instance_id = os.environ.get("BINDERSNAP_INSTANCE_ID")
+_ssh_key = os.environ.get("BINDERSNAP_SSH_KEY")
+_ssh_config = os.environ.get("BINDERSNAP_SSH_CONFIG")
+
+if not _instance_id or not _ssh_key or not _ssh_config:
+    raise RuntimeError(
+        "BINDERSNAP_INSTANCE_ID, BINDERSNAP_SSH_KEY and BINDERSNAP_SSH_CONFIG "
+        "must be set before running pyinfra. Use deploy/bin/ssm-connect.sh, "
+        "which resolves the instance, pushes an ephemeral key and writes the "
+        "SSM-tunnel SSH config, then invokes pyinfra for you."
+    )
+
+# The ProxyCommand that tunnels SSH over SSM lives in the generated config
+# file; pyinfra parses it and builds the proxy lazily at connect time.
+host_data = {
+    "ssh_user": SSH_USER,
+    "ssh_key": _ssh_key,
+    "ssh_config_file": _ssh_config,
+    # The instance is rebuilt from an AMI, so its host key is not stable;
+    # accept-new avoids an interactive prompt on first contact.
+    "ssh_strict_host_key_checking": "accept-new",
+}
+
+hosts = [(_instance_id, host_data)]

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,0 +1,9 @@
+# Python toolchain for the pyinfra push-deployment pipeline (epic #302).
+#
+# Install into a local venv:
+#   python3 -m venv deploy/.venv && deploy/.venv/bin/pip install -r deploy/requirements.txt
+#
+# pyinfra ships with paramiko, but we depend on it directly in inventory.py
+# (paramiko.ProxyCommand) so it is pinned explicitly here.
+pyinfra~=3.1
+paramiko~=3.4


### PR DESCRIPTION
## Phase 1 of the pyinfra deployment migration

Closes #303. Part of epic #302.

Stands up `deploy/` as the home for the pyinfra push-deployment pipeline. **No host configuration yet** — this phase only establishes the directory layout and the connection mechanism so later phases have something to build on. Also hardens CI so infra/deploy-only changes can't deploy anything.

### What's here

| File | Purpose |
| --- | --- |
| `deploy/inventory.py` | Single prod host + SSH-over-SSM connection data |
| `deploy/deploy.py` | Connectivity check (real operations land in Phase 2 / #304) |
| `deploy/bin/ssm-connect.sh` | Resolve instance, push ephemeral key, write SSM-tunnel SSH config, invoke pyinfra |
| `deploy/requirements.txt` | `pyinfra~=3.1`, `paramiko~=3.4` |
| `deploy/README.md` | Architecture, prerequisites, usage, security notes |
| `deploy/.gitignore` | Block key material / venv / bytecode |

### Connection model

Keeps today's hardened posture — **no inbound port 22, no long-lived SSH keys**:

1. resolve the running instance by tag (`Project=bindersnap`);
2. generate a throwaway ed25519 keypair + matching SSH config;
3. push the public key via **EC2 Instance Connect** (~60s validity);
4. open SSH **tunnelled through AWS SSM** via a `ProxyCommand` (`aws ssm start-session` + `AWS-StartSSHSession`), which pyinfra parses and dials lazily at connect time.

### CI hardening (does merging deploy anything?)

To make incremental merges of this migration safe, `deploy/**` and `infra/**` are added to the `paths-ignore` of:
- `pages.yml` — so infra changes don't republish the SPA
- `release.yml` — so infra changes don't cut a version bump / build+tag an API image
- `pr-verify.yml` (push trigger) — the PR already runs tests via the unfiltered `pull_request` trigger

The **host-deploy** workflows (`deploy.yml`, `deploy-api.yml`, `deploy-config.yml`) are already scoped to `services/api`, `packages/api-schema` and `config/**`, so they **never** match `deploy/**`/`infra/**` — merging this migration does not interact with the running webservice (EC2/Gitea/API/Lambda).

> ⚠️ **Merging _this_ PR:** because it edits the workflow files themselves, GitHub will still run `pages.yml`/`release.yml` on this one merge (not all changed files are ignored). To merge with **zero** pipeline activity, append `[skip ci]` to the squash-commit message. The hardening then protects every subsequent infra-only merge.

### Verification

- `python -m py_compile` on both modules ✓
- `bash -n` on the wrapper ✓
- Installed `pyinfra~=3.1` (→ 3.9.2) in a throwaway venv; confirmed `ssh_config_file` / `ssh_strict_host_key_checking` are valid connector data keys and that `inventory.py` loads to the expected host data (and raises a clear error outside the wrapper) ✓
- Re-parsed all three edited workflows with PyYAML; `paths-ignore` lists are correct ✓

A live end-to-end connection requires the deploy IAM role to grant `ssm:StartSession` + `ec2-instance-connect:SendSSHPublicKey`, which it does **not** yet — those land with the CI workflow in **Phase 3 (#305)**. Until then this runs locally with a profile that has them. Called out in the README.

### Workflow evidence
- Issue read: epic #302 / sub-issues via `issue_write` + `sub_issue_write` (MCP)
- Branch + commits: local `git` (working-tree ownership per AGENTS.md) — `449e89f`, `f50cbb3`
- PR: `create_pull_request` / `update_pull_request` (MCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)