### PR TITLE
fix(deploy): split ssm:StartSession so the SSH document isn't tag-gated

### DIFF
--- a/infra/ci/oidc.tf
+++ b/infra/ci/oidc.tf
@@ -276,10 +276,14 @@ data "aws_iam_policy_document" "deploy" {
     }
   }
 
+  # StartSession authorizes the target instance and the session document
+  # separately, so they must be split across two statements: the instance is
+  # tag-scoped, but the AWS-managed document carries no tags — folding both under
+  # the tag condition makes the condition fail for the document and denies the
+  # whole StartSession call (the tunnel then fails with "No existing session").
   statement {
-    # Open the SSH-over-SSM tunnel via the AWS-StartSSHSession document against
-    # the tagged host. AWS-managed documents carry no account ID in their ARN.
-    sid    = "StartSshTunnelSession"
+    # Open the SSH-over-SSM tunnel against the tagged host.
+    sid    = "StartSshTunnelSessionOnInstance"
     effect = "Allow"
 
     actions = [
@@ -287,7 +291,6 @@ data "aws_iam_policy_document" "deploy" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}::document/${var.ssh_session_document_name}",
       "arn:${data.aws_partition.current.partition}:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
     ]
 
@@ -296,6 +299,22 @@ data "aws_iam_policy_document" "deploy" {
       variable = "aws:ResourceTag/${var.instance_tag_key}"
       values   = [var.instance_tag_value]
     }
+  }
+
+  statement {
+    # Allow the AWS-StartSSHSession document itself. AWS-managed documents carry
+    # no account ID in their ARN and no tags, so this statement is unconditioned;
+    # the instance scoping above is what constrains which host can be reached.
+    sid    = "StartSshTunnelSessionDocument"
+    effect = "Allow"
+
+    actions = [
+      "ssm:StartSession",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}::document/${var.ssh_session_document_name}",
+    ]
   }
 
   statement {


### PR DESCRIPTION
Follow-up to #311 / #305. The first live pyinfra deploy on `main` failed.

## Symptom
`deploy-pyinfra.yml` reached the connect step and died:
```
Target instance: i-03f112fa214331f4f
Pushed ephemeral key for ec2-user@i-03f112fa214331f4f
--> Connecting to hosts...
    [i-03f112fa214331f4f] SSH error (No existing session)
--> pyinfra error: No hosts remaining!
```
The deploy failed **before any host operation ran**, so production was untouched.

## Root cause
`ssm:StartSession` authorizes the **target instance** and the **session document** as separate resources. My `StartSshTunnelSession` statement listed both the instance ARN and the `AWS-StartSSHSession` document ARN under one `aws:ResourceTag/Project=bindersnap` condition. AWS-managed documents carry no tags, so the condition evaluates false for the document resource and the whole StartSession call is denied.

The ephemeral-key push (`ec2-instance-connect:SendSSHPublicKey`) succeeded in the same run because it only targets the tagged instance — which is what isolated the cause to the document being caught by the tag condition.

## Fix
Split into two statements (AWS's documented pattern):
- `StartSshTunnelSessionOnInstance` — `ssm:StartSession` on the instance ARN, still `Project` tag-scoped.
- `StartSshTunnelSessionDocument` — `ssm:StartSession` on the `AWS-StartSSHSession` document ARN, unconditioned (no tags exist to match). Instance scoping above still constrains which host is reachable.

## After merge — required order
1. `terraform apply` in `infra/ci` (updates the policy in place; expect 0 add / 1 change / 0 destroy)
2. Re-run `deploy-pyinfra.yml` (push, or `workflow_dispatch` — try `dry_run=true` first to confirm the tunnel connects, then a real run)

Note this run will still deploy the API at `:latest` and won't rebuild it — the separate image-build/pin gap from #311 is still open.

## Testing
- `terraform fmt` + `terraform validate` (infra/ci) — clean
- `bun run test:ops` — 280 pass / 3 skip / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)