### PR TITLE
fix(deploy): pass -y so the CI pyinfra apply doesn't block on confirmation

### DIFF
--- a/.github/workflows/deploy-pyinfra.yml
+++ b/.github/workflows/deploy-pyinfra.yml
@@ -139,6 +139,11 @@ jobs:
           if [ "${DRY_RUN}" = "true" ]; then
             args+=(--dry)
             echo "Running pyinfra in dry-run mode (no changes will be applied)"
+          else
+            # CI has no TTY: auto-approve so pyinfra doesn't block on its
+            # "Press enter to execute..." confirmation prompt (EOFError). Kept
+            # out of ssm-connect.sh so local operator runs still confirm.
+            args+=(-y)
           fi
 
           deploy/bin/ssm-connect.sh "${args[@]}"


### PR DESCRIPTION
Follow-up to #312. With the SSM tunnel fix in place, the first real deploy got much further — it connected, loaded `deploy.py`, and printed the change summary — then failed:

```
    Detected changes displayed above, skip this step with -y
    Press enter to execute...
--> An internal exception occurred:
    v = input()
EOFError: EOF when reading a line
```

## Cause
A non-`--dry` pyinfra run shows the change plan and waits for interactive confirmation. GitHub Actions has no TTY/stdin, so `input()` hits EOF.

## Fix
Pass `-y` (auto-approve) on the apply path in `deploy-pyinfra.yml`. Dry runs don't prompt, so they're left as-is. Kept in the workflow rather than in `deploy/bin/ssm-connect.sh`, so local operator runs still get the interactive confirmation.

## After merge
Re-run `deploy-pyinfra.yml` — I'd start with `workflow_dispatch dry_run=true` to confirm a clean connect + plan, then a real run to apply. The plan from the failed run shows the expected first-run work (install Docker, mount EBS, render `.env.prod`, GHCR login, **first-run Gitea token bootstrap**, compose up), so watch it and keep `docs/ops/break-glass.md` handy.

Note: the API `:latest`/version-pinning gap (#313) still applies to the first successful deploy.

## Testing
- `prettier --check` on the workflow — clean
- Change is CI-only (no unit-testable surface); the fix is verified by the next deploy run reaching execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)