### PR TITLE
fix(deploy): force GHCR re-login every deploy run

### DIFF
--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -437,7 +437,10 @@ server.shell(
 # ---------- 9. Registry login + Gitea bootstrap ----------
 
 # GHCR credentials are supplied by the control plane (CI secret / local env var).
-# Native docker.login is idempotent: a no-op when the auth entry is already present.
+# force=True: docker.login's idempotency check only looks for an existing auth
+# entry for the server, but CI's GITHUB_TOKEN is minted per run and expires when
+# the run ends — a skipped login leaves an expired token and the image pull
+# fails with "denied".
 _ghcr_token = os.environ.get("GHCR_TOKEN", "")
 _ghcr_user = os.environ.get("GHCR_USER", "davidgraymi")
 if _ghcr_token:
@@ -446,6 +449,7 @@ if _ghcr_token:
         server="ghcr.io",
         username=_ghcr_user,
         password=_ghcr_token,
+        force=True,
     )
 
 # First run only: the bootstrap reads the placeholder token from the env file


### PR DESCRIPTION
## Problem

The latest `Deploy Production (pyinfra)` run ([30754080819](https://github.com/davidgraymi/bindersnap-editor-demo/actions/runs/30754080819)) failed pulling the pinned API image:

```
api Error Head "https://ghcr.io/v2/davidgraymi/bindersnap-api/manifests/df13822...": denied: denied
```

The image itself was fine — the build job had just pushed that exact SHA tag. The tell in the log is:

```
--> Starting operation: Log in to GHCR
    [i-03f...] No changes
```

pyinfra's `docker.login` idempotency check only verifies that an auth entry for `ghcr.io` exists in `~/.docker/config.json` on the host — it never validates the credential. CI's `GITHUB_TOKEN` is minted per workflow run and expires when that run ends, so after the first successful deploy, every subsequent deploy skipped the login and pulled with a dead token.

## Fix

Pass `force=True` to `docker.login` (the documented escape hatch "e.g. after rotating credentials") so every deploy re-authenticates with the fresh token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)