### PR TITLE
docs: record the single-EC2 + pyinfra push-deploy model (#308)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,15 @@ bindersnap-editor-demo/
 │       ├── routes.ts               ← Client-side route definitions
 │       └── components/             ← App shell, landing page, document UI
 │
-├── infra/                          ← Infrastructure as code
-│   ├── compute/                    ← EC2 Terraform for API host
+├── deploy/                         ← CONFIGURATION AS CODE (pyinfra push deploy)
+│   ├── deploy.py                   ← The production deployment itself
+│   ├── inventory.py                ← Single prod host + SSH-over-SSM connection
+│   ├── files/                      ← Runtime config uploaded to the host
+│   ├── bin/ssm-connect.sh          ← Ephemeral key + SSM tunnel, then pyinfra
+│   └── README.md                   ← Read before touching production config
+│
+├── infra/                          ← INFRASTRUCTURE AS CODE (Terraform only)
+│   ├── compute/                    ← EC2 Terraform for the app host
 │   ├── backups/                    ← DLM snapshot policy
 │   ├── ci/                         ← GitHub Actions OIDC role
 │   ├── secrets/                    ← AWS Secrets Manager
@@ -122,15 +129,54 @@ See `tests/README.md` for full usage.
 
 ### Deployment
 
+Everything except the SPA runs as Docker Compose services on **one EC2 host**,
+deployed by **pushing with pyinfra** from GitHub Actions. There is no serverless
+stack: Lambda, Aurora, API Gateway and the Gitea-as-NAT plumbing were removed
+(epic #302). See `docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md`.
+
 | Component  | Host           | How deployed                                                          |
 | ---------- | -------------- | --------------------------------------------------------------------- |
 | SPA        | GitHub Pages   | `pages.yml` on push to `main`                                         |
 | API        | EC2 via Docker | `deploy-pyinfra.yml` (pyinfra over SSH-through-SSM) on push to `main` |
-| Gitea      | Same EC2 host  | `docker-compose.prod.yml`                                             |
-| Hocuspocus | Same EC2 host  | `docker-compose.prod.yml`                                             |
+| Gitea      | Same EC2 host  | `docker-compose.prod.yml`, same pyinfra run                           |
+| Hocuspocus | Same EC2 host  | `docker-compose.prod.yml`, same pyinfra run                           |
+| Caddy      | Same EC2 host  | `docker-compose.prod.yml`, same pyinfra run                           |
 
 The SPA is built with `BUN_PUBLIC_API_BASE_URL=https://api.bindersnap.com`
 baked in at compile time. Locally, this is `http://localhost:8787`.
+
+**How a production deploy runs.** On every push to `main`,
+`deploy-pyinfra.yml` runs the unit suites, builds and pushes
+`ghcr.io/davidgraymi/bindersnap-api:<sha>`, assumes the OIDC deploy role, then
+runs `deploy/bin/ssm-connect.sh`. That script resolves the instance by tag,
+pushes a ~60-second ephemeral key with EC2 Instance Connect, tunnels SSH through
+`aws ssm start-session`, and runs `pyinfra deploy/inventory.py deploy/deploy.py`.
+**There is no inbound port 22 and no long-lived key material anywhere in this
+path.** `deploy.py` is idempotent: it installs Docker, mounts the EBS volume,
+uploads `deploy/files/`, renders `/opt/bindersnap/.env.prod` from SSM Parameter
+Store, and force-recreates the stack only when config or secrets actually
+changed.
+
+Rollback is `git revert` on `main` (the deploy re-applies the prior stack), or a
+`workflow_dispatch` run with an explicit `api_tag`. Each deploy pins `API_TAG`
+to the deployed commit's SHA — never mutable `:latest`.
+
+**Terraform provisions; pyinfra configures.** These do not overlap:
+
+- Anything about the _host's contents_ — packages, config files, secrets,
+  containers, the CloudWatch agent — belongs in `deploy/`. Adding a config file
+  is a commit to `deploy/files/`, not an infrastructure change.
+- Anything about _AWS resources_ — instance, volumes, IAM, networking, backups,
+  monitoring, Parameter Store — belongs in `infra/`.
+- `infra/compute/user-data.sh` does exactly one thing: confirm the SSM agent is
+  running. Do not add bootstrap logic to it, and do not reintroduce a config
+  bucket. If you find yourself editing Terraform to change how the app is
+  configured, you are in the wrong directory.
+
+Read `deploy/README.md` before changing anything under `deploy/`, and
+`docs/ops/deploy.md` for the pipeline, required GitHub variables, and rollback.
+`docs/ops/break-glass.md` covers recovering the host over SSM when CI is
+unavailable.
 
 ---
 
@@ -174,6 +220,18 @@ before any API call.
 
 See `docs/adr/0001-external-file-workflow-contract.md` for the full
 upload/review/publish contract. **That ADR is law for the file vault workflow.**
+
+### Production is one EC2 host, deployed by pushing with pyinfra.
+
+No serverless. The backend is a Docker Compose stack on a single EC2 instance,
+and `deploy/` is the only thing that configures it. Do not add a Lambda, an
+Aurora cluster, an API Gateway, a config bucket, or a bootstrap script to
+Terraform user-data. Do not add a pull agent to the host. Deployment logic goes
+in `deploy/deploy.py`, in Python, in version control.
+
+See `docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md`. Note that
+`docs/adr/0002-mvp-backend-aws-s3-dynamodb-cognito.md` describes an
+AWS-native backend that was **reversed** — it is history, not guidance.
 
 ### The MVP is a document repository, not an editor.
 
@@ -489,9 +547,9 @@ This repository uses either `gh` CLI or an MCP tool.
 
 ## Production Security Rules
 
-These apply to any changes touching `docker-compose.prod.yml`, `Caddyfile.prod`, or EC2 deployment:
+These apply to any changes touching `deploy/`, `deploy/files/docker-compose.prod.yml`, `deploy/files/Caddyfile.prod`, or EC2 deployment:
 
-1. **Never hardcode credentials.** All secrets (`GITEA_ADMIN_PASS`, `GITEA_SECRET_KEY`, `BINDERSNAP_GITEA_SERVICE_TOKEN`, etc.) must come from environment variables, loaded from `.env.prod` on the server. `.env.prod` is in `.gitignore` and must never be committed.
+1. **Never hardcode credentials.** All secrets (`GITEA_ADMIN_PASS`, `GITEA_SECRET_KEY`, `BINDERSNAP_GITEA_SERVICE_TOKEN`, etc.) must come from environment variables in `/opt/bindersnap/.env.prod`, which `deploy.py` renders on every run from `/bindersnap/prod/*` in SSM Parameter Store. The SSM read happens on the control plane and the file is uploaded `0600` — secrets are never written to a control-plane disk file, printed, or committed. Never commit an `.env.prod`; it is in `.gitignore`.
 2. **Registration is disabled in prod.** `GITEA__service__DISABLE_REGISTRATION=true` is non-negotiable for production. Dev compose may differ.
 3. **`INSTALL_LOCK=true` in prod.** Prevents Gitea setup wizard from re-running after first boot.
 4. **Rotate credentials on first deploy.** Generate with `openssl rand -base64 20` for passwords and `openssl rand -base64 32` for secret keys.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,21 +34,41 @@ bun run down          # Tear down
 
 Test files live alongside source as `*.test.ts`. TypeScript strict mode is the linter.
 
+Production deploys run themselves — `deploy-pyinfra.yml` on every push to `main`.
+To drive one by hand (Python, not Bun):
+
+```bash
+python3 -m venv deploy/.venv
+deploy/.venv/bin/pip install -r deploy/requirements.txt
+source deploy/.venv/bin/activate
+
+deploy/bin/ssm-connect.sh --dry   # report changes without applying
+deploy/bin/ssm-connect.sh         # apply
+```
+
 ---
 
 ## Architecture
 
 Bun monorepo — one SPA, shared packages, backend services.
 
-| Directory              | Purpose                                    |
-| ---------------------- | ------------------------------------------ |
-| `apps/app/`            | Unified SPA → GitHub Pages                 |
-| `packages/ui-tokens/`  | CSS design tokens (single source of truth) |
-| `packages/utils/`      | Shared utilities                           |
-| `services/api/`        | Auth + data BFF (port 8787)                |
-| `services/hocuspocus/` | Yjs WebSocket collaboration server         |
+| Directory              | Purpose                                     |
+| ---------------------- | ------------------------------------------- |
+| `apps/app/`            | Unified SPA → GitHub Pages                  |
+| `packages/ui-tokens/`  | CSS design tokens (single source of truth)  |
+| `packages/utils/`      | Shared utilities                            |
+| `services/api/`        | Auth + data BFF (port 8787)                 |
+| `services/hocuspocus/` | Yjs WebSocket collaboration server          |
+| `deploy/`              | Configuration as code (pyinfra push deploy) |
+| `infra/`               | Infrastructure as code (Terraform only)     |
 
 **Path aliases:** `@editor/*`, `@gitea/*`, `@ui/*`, `@utils/*`
+
+Production is **one EC2 host** running the `docker-compose.prod.yml` stack (API,
+Gitea, Hocuspocus, Caddy, Litestream). `deploy/deploy.py` configures it over an
+SSH-through-SSM tunnel on every push to `main`; Terraform only provisions AWS
+resources. See `docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md` and
+`deploy/README.md`.
 
 ---
 
@@ -65,3 +85,5 @@ Settled. Do not reopen. If a task requires violating one, open a `human-needed` 
 4. **Two independent workflows.** File vault (external uploads) and inline editor are separate. Do not conflate them.
 
 5. **Editor UI changes need a flag.** If you change `packages/editor/` visuals, note it in your PR — the landing demo embed requires a manual `bun run sync-demo`.
+
+6. **`deploy/` configures the host; Terraform does not.** No serverless (no Lambda, Aurora, or API Gateway), no config bucket, no bootstrap logic in `user-data.sh`. Host config changes are commits to `deploy/`.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,42 @@ bun run up
 
 See [`tests/README.md`](tests/README.md) for full workflow details.
 
+## Deployment
+
+Two surfaces, both triggered by a push to `main`:
+
+| What                                      | Where                     | Workflow                                                     |
+| ----------------------------------------- | ------------------------- | ------------------------------------------------------------ |
+| SPA                                       | GitHub Pages              | [`pages.yml`](.github/workflows/pages.yml)                   |
+| API, Gitea, Hocuspocus, Caddy, Litestream | One EC2 host, via Compose | [`deploy-pyinfra.yml`](.github/workflows/deploy-pyinfra.yml) |
+
+The backend is a single EC2 instance, not a serverless stack. Its entire
+configuration lives in [`deploy/`](deploy/README.md) as a
+[pyinfra](https://pyinfra.com/) script. GitHub Actions **pushes** the deploy: it
+assumes an OIDC role, pushes a ~60-second ephemeral key with EC2 Instance
+Connect, tunnels SSH through `aws ssm start-session`, and runs
+`pyinfra deploy/inventory.py deploy/deploy.py`. The host has **no inbound port
+22** and there are **no long-lived keys**.
+
+`deploy.py` is idempotent — a fresh host converges to the current stack with no
+pre-configuration, and a re-run changes nothing unless config or secrets
+changed. Terraform under [`infra/`](infra/) provisions AWS resources only; it
+does not configure the host.
+
+Run it yourself (dry run applies nothing):
+
+```bash
+python3 -m venv deploy/.venv
+deploy/.venv/bin/pip install -r deploy/requirements.txt
+source deploy/.venv/bin/activate
+
+deploy/bin/ssm-connect.sh --dry
+```
+
+- Pipeline details, required GitHub variables, rollback: [`docs/ops/deploy.md`](docs/ops/deploy.md)
+- Recovering the host when CI is down: [`docs/ops/break-glass.md`](docs/ops/break-glass.md)
+- Why it is built this way: [`docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md`](docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md)
+
 ## Production Secrets
 
 Production no longer relies on a repo-side `.env.prod`. The pyinfra deploy
@@ -178,28 +214,35 @@ it from the production app host or an equivalent recovery environment.
 
 ## Production API Image
 
-The production API service now runs from a published GHCR image instead of a
-source bind mount. Build and publish happens in
-`.github/workflows/build-api.yml`, which pushes:
+The production API service runs from a published GHCR image instead of a source
+bind mount. `deploy-pyinfra.yml` calls the reusable
+`.github/workflows/build-api.yml` for the exact commit being deployed, which
+pushes:
 
 - `ghcr.io/davidgraymi/bindersnap-api:${GITHUB_SHA}`
 - `ghcr.io/davidgraymi/bindersnap-api:latest`
 
-Production hosts pull the image selected by `API_TAG` in
-`/opt/bindersnap/.env.prod`.
-On the EC2 host that value normally lives in `/opt/bindersnap/.env.prod`, which
-is generated from SSM at boot and can be regenerated for secret rotation.
+The host pulls the image selected by `API_TAG` in `/opt/bindersnap/.env.prod`.
+The deploy pins that to the deployed commit's SHA — the immutable tag, not
+mutable `:latest`. Normal rollback is a `git revert` on `main`, or running
+`deploy-pyinfra.yml` via **Run workflow** with the `api_tag` input set to a
+last-good SHA. For a pin that survives subsequent pushes, set the SSM `api_tag`
+override (see [`docs/ops/break-glass.md`](docs/ops/break-glass.md)).
 
-To deploy the currently selected API tag:
+The commands below are the manual fallback for when GitHub Actions is
+unavailable — the normal path is a deploy. To deploy the currently selected API
+tag by hand on the host:
 
 ```bash
+cd /opt/bindersnap
 docker compose -f docker-compose.prod.yml --env-file /opt/bindersnap/.env.prod pull api
 docker compose -f docker-compose.prod.yml --env-file /opt/bindersnap/.env.prod up -d api
 ```
 
-To roll back, set `API_TAG` to a previous commit SHA in
+To roll back by hand, set `API_TAG` to a previous commit SHA in
 `/opt/bindersnap/.env.prod`, then run the same `pull` and `up -d api` commands
-again.
+again. Note that the next pyinfra deploy re-renders `.env.prod` and undoes a
+hand-edited pin — use the SSM override for anything that must persist.
 
 The end-to-end production deploy workflow, required GitHub variables, and the
 GitHub Actions rollback path are documented in

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,12 +6,16 @@ flow (manual SSH, `infra/compute/user-data.sh.tftpl` bootstrap, and the S3
 config bucket). See epic
 [#302](https://github.com/davidgraymi/bindersnap-editor-demo/issues/302).
 
-> **Status:** Phase 4 — `.github/workflows/deploy-pyinfra.yml` runs this deploy
-> on every push to `main` (OIDC into the deploy role, SSH-over-SSM tunnel). The
-> old SSM `send-command` workflow (`deploy.yml`) and the S3 config-as-code path
+> **Status:** live. `.github/workflows/deploy-pyinfra.yml` runs this deploy on
+> every push to `main` (OIDC into the deploy role, SSH-over-SSM tunnel). The old
+> SSM `send-command` workflow (`deploy.yml`), the S3 config-as-code path
 > (`deploy-config.yml`, `infra/config-bucket/`,
-> [#306](https://github.com/davidgraymi/bindersnap-editor-demo/issues/306)) are
-> both removed: this directory is the only thing that configures the host.
+> [#306](https://github.com/davidgraymi/bindersnap-editor-demo/issues/306)) and
+> the serverless stack (Lambda/Aurora/API Gateway,
+> [#307](https://github.com/davidgraymi/bindersnap-editor-demo/issues/307)) are
+> all removed: this directory is the only thing that configures the host. The
+> rationale is recorded in
+> [`../docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md`](../docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md).
 
 ## How it connects
 

--- a/docs/adr/0002-mvp-backend-aws-s3-dynamodb-cognito.md
+++ b/docs/adr/0002-mvp-backend-aws-s3-dynamodb-cognito.md
@@ -1,8 +1,16 @@
 # ADR 0002: MVP Backend — AWS S3 + DynamoDB + Cognito (Replaces Gitea)
 
-Status: Accepted  
+Status: **Superseded by [ADR 0003](0003-single-ec2-host-pyinfra-push-deploys.md)** — kept for history  
 Date: 2026-04-02  
 Supersedes: ADR 0001 (git primitives are replaced by DynamoDB/S3 equivalents; role model and workflow states are preserved)
+
+> **This ADR does not describe the running system.** The migration off Gitea was
+> never completed: only a partial serverless stack (Lambda + Aurora + API
+> Gateway) was built, and it was removed by
+> [epic #302](https://github.com/davidgraymi/bindersnap-editor-demo/issues/302).
+> Gitea remains the only datastore and ADR 0001 remains the workflow contract.
+> See ADR 0003 for the current backend and deployment model. Read the below as a
+> record of a direction that was reversed, not as guidance.
 
 ## Context
 

--- a/docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md
+++ b/docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md
@@ -1,0 +1,127 @@
+# ADR 0003: Single EC2 Host with pyinfra Push Deploys
+
+Status: Accepted  
+Date: 2026-08-05  
+Related: [Epic #302](https://github.com/davidgraymi/bindersnap-editor-demo/issues/302) (phases #303–#308, #313)  
+Supersedes: ADR 0002 (the AWS-native serverless backend). ADR 0001 remains law
+for the file vault workflow, and Gitea remains the only datastore.
+
+## Why This Exists
+
+Two problems needed one decision.
+
+**Configuration drift.** The production host was configured by hand: SSH in,
+edit files, restart containers. Adding a config file meant editing an EC2
+bootstrap script (`infra/compute/user-data.sh.tftpl`) or pushing to an S3
+config bucket (`infra/config-bucket/`), so Terraform owned both
+infrastructure-as-code and configuration-as-code. What ran on the host and what
+was in version control diverged, and a rebuilt host was not reproducible.
+
+**A half-built serverless stack.** ADR 0002 planned an AWS-native backend
+(Cognito + DynamoDB + S3 + Lambda). What actually got built was a partial
+migration — Lambda + Aurora + API Gateway, plus a hack that routed the Lambda's
+egress through the Gitea EC2 instance acting as a NAT — while the product kept
+running on Gitea per ADR 0001. That left two backends to reason about, an Aurora
+cluster billing continuously pre-launch, and a networking dependency between two
+things that should not know about each other. The premise of ADR 0002 (drop the
+self-hosted Gitea dependency) never came true, so its operational model was
+paying costs without delivering its benefit.
+
+## Decision
+
+**Run the whole backend on one EC2 host, and deploy to it by pushing with
+pyinfra from GitHub Actions.**
+
+1. **One host.** Gitea, the API BFF, Hocuspocus, Caddy, and the Litestream
+   backup sidecar all run as Docker Compose services on a single EC2 instance.
+   API sessions are SQLite on the EBS data volume (`services/api/sessions.ts`),
+   not Aurora.
+
+2. **`deploy/` is the deployment.** `deploy/deploy.py` is a pyinfra script that
+   defines the host end to end: install Docker, mount the data volume, upload
+   `deploy/files/` runtime config, render `/opt/bindersnap/.env.prod` from SSM
+   Parameter Store, bootstrap the Gitea service token on first run, and bring
+   the compose stack up. It is idempotent — a re-run with no changes changes
+   nothing, and a fresh host converges to today's stack with no
+   pre-configuration.
+
+3. **Push, don't pull.** `.github/workflows/deploy-pyinfra.yml` runs pyinfra on
+   every push to `main`. The host runs no deploy agent and polls nothing.
+
+4. **SSH tunnelled over SSM.** The host keeps **no inbound port 22** and we
+   store **no long-lived SSH or AWS keys**. Each run assumes the OIDC deploy
+   role, resolves the instance by tag, pushes a ~60-second ephemeral key with
+   EC2 Instance Connect, and dials SSH through `aws ssm start-session`
+   (`AWS-StartSSHSession`) via a `ProxyCommand`.
+
+5. **Terraform provisions; pyinfra configures.** Terraform owns only
+   infrastructure: the instance, volumes, IAM, networking, backups, monitoring,
+   secrets storage. `infra/compute/user-data.sh` does exactly one thing —
+   confirm the SSM agent is running so pyinfra can reach a fresh host. No
+   bootstrap script, no config bucket.
+
+6. **Secrets stay in Parameter Store.** `deploy.py` reads `/bindersnap/prod/*`
+   on the **control plane** (CI's OIDC role or the operator's credentials),
+   holds the rendered env content in memory, and uploads `.env.prod` with `0600`
+   perms. Nothing is written to a control-plane disk file, printed, or
+   committed. The host needs no SSM read permissions of its own for this path.
+
+7. **Deploys are pinned and reversible.** Each deploy pins `API_TAG` to the
+   deployed commit's SHA (`ghcr.io/davidgraymi/bindersnap-api:<sha>`), never
+   mutable `:latest`. Rollback is `git revert` plus the resulting deploy, or a
+   `workflow_dispatch` run with an explicit `api_tag`.
+
+## Consequences
+
+Positive:
+
+1. The full deployment definition is readable Python in version control.
+   Adding a config file is a commit, not an infrastructure change.
+2. A fresh host is reproducible. Disaster recovery is: Terraform apply, push to
+   `main`, restore from Litestream.
+3. One backend, one datastore, one bill. No Aurora, no API Gateway, no Lambda,
+   no Gitea-as-NAT coupling.
+4. No inbound SSH and no static credentials anywhere in the deploy path.
+5. Terraform plans stop churning on configuration changes, because Terraform no
+   longer knows about configuration.
+
+Tradeoffs:
+
+1. **Single host, single point of failure.** There is no redundancy and deploys
+   have a brief restart window. Accepted for pre-launch: Litestream replicates
+   both SQLite databases to S3 continuously, DLM snapshots the volume, and the
+   break-glass runbook recovers over SSM. Revisit before we promise an SLA.
+2. **Self-hosting is back on the bill of work** — patching, disk, and monitoring
+   for one instance. This was ADR 0002's central objection; the counter is that
+   the serverless alternative never removed Gitea, so it added the managed
+   footprint on top of the self-hosted one rather than replacing it.
+3. **Deploys need AWS reachability from CI.** If the OIDC role, SSM, or EC2
+   Instance Connect is unavailable, the pipeline cannot deploy. The break-glass
+   path is a direct SSM session (`docs/ops/break-glass.md`).
+4. **pyinfra is a Python dependency in a Bun repo.** `deploy/` carries its own
+   `requirements.txt` and venv. Accepted: the deployment tool does not need to
+   match the application runtime.
+
+## Alternatives Considered
+
+| Alternative                                | Why not                                                                                                                     |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Finish the ADR 0002 serverless build       | Would have meant rewriting the entire Gitea-backed data layer. Cost and rewrite scope are wrong for a pre-launch solo team. |
+| Keep bootstrapping via Terraform user-data | Config changes require replacing the instance, and user-data runs only at first boot — the drift problem stays.             |
+| Ansible                                    | Same push model, heavier install and YAML indirection. pyinfra gives the same operations as plain Python.                   |
+| SSM `send-command` deploy scripts          | What we had. Deploy logic ends up as shell embedded in a workflow, with no dry run and no change detection.                 |
+| A pull agent on the host                   | Needs an agent to keep alive and patch, and inverts the audit trail — CI would no longer know whether a deploy landed.      |
+
+## Teardown
+
+The serverless _code_ (`infra/api-service/`, `deploy-api.yml`, the Lambda/NAT
+coupling) was removed in phase 5 ([#307](https://github.com/davidgraymi/bindersnap-editor-demo/issues/307)).
+The owner runs `terraform destroy` on `infra/api-service` manually. Aurora held
+no data needing preservation — the product is pre-launch and sessions moved back
+to SQLite.
+
+## Where to Look
+
+- `deploy/README.md` — how the connection and the deploy script work
+- `docs/ops/deploy.md` — the pipeline, required GitHub variables, rollback
+- `docs/ops/break-glass.md` — recovering the host without CI

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -58,6 +58,8 @@ uses no inbound port 22 and no long-lived AWS keys.
 > does nothing beyond confirming the SSM agent. The serverless stack
 > (Lambda/Aurora/API Gateway and the Gitea-as-NAT plumbing) was removed in
 > Phase 5 ([#307](https://github.com/davidgraymi/bindersnap-editor-demo/issues/307)).
+> The rationale for the whole model is recorded in
+> [`../adr/0003-single-ec2-host-pyinfra-push-deploys.md`](../adr/0003-single-ec2-host-pyinfra-push-deploys.md).
 
 ## GitHub Configuration
 


### PR DESCRIPTION
## Summary

Closes #308. Phase 6 of #302 — documentation for the pyinfra push-deploy model.

Docs still described a hand-configured host, and ADR 0002 (the AWS-native serverless backend) was sitting in `docs/adr/` as accepted guidance for a direction that was reversed. This brings the docs in line with what actually ships.

- **New `docs/adr/0003-single-ec2-host-pyinfra-push-deploys.md`** — records the move from serverless → single EC2 host with pyinfra push deploys, the SSH-over-SSM connection model (no inbound 22, no long-lived keys), the Terraform/CAC separation, consequences, and alternatives considered.
- **ADR 0002 marked superseded** with a note that the Gitea migration was never completed and the partial serverless stack was removed.
- **AGENTS.md** — `deploy/` added to the repo tree; deployment section now covers the pyinfra run, pinned `API_TAG`, rollback, and an explicit "Terraform provisions; pyinfra configures" boundary; new settled architecture decision against reintroducing serverless / a config bucket / user-data bootstrap; production secrets rule corrected to the SSM control-plane render.
- **CLAUDE.md** — `deploy/` and `infra/` in the architecture table, manual deploy commands, non-negotiable #6.
- **README.md** — new Deployment section. Also corrected two stale claims in "Production API Image": the build is called by `deploy-pyinfra.yml` (not standalone), and `.env.prod` is rendered per deploy, not "generated from SSM at boot".
- **deploy/README.md, docs/ops/deploy.md** — dropped the stale "Phase 4" status, linked the ADR.

## Scope Check

- [x] Changes are focused on one issue/task
- [x] No unrelated refactors or formatting-only churn included

Docs only — no code, config, or workflow changes. No `packages/editor/` visuals touched, so no `bun run sync-demo` needed.

## Validation

- [x] Local validation/tests run (list commands below)
- Commands run:
  - `bun run format` (prettier reflowed two tables in the new/edited docs)
  - Prose cross-checked against `deploy/deploy.py`, `deploy/bin/ssm-connect.sh`, `.github/workflows/deploy-pyinfra.yml`, `.github/workflows/build-api.yml`, and `infra/compute/user-data.sh` rather than written from memory.

## Merge Gate

- [x] Any fallback is explicitly documented and justified

The README's manual `docker compose pull/up` commands are now labelled as the GitHub-Actions-unavailable fallback, with a note that the next pyinfra deploy re-renders `.env.prod` and undoes a hand-edited `API_TAG` pin (the SSM `api_tag` override is the persistent path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)