### PR TITLE
feat: give every change its own page and stop the document layout shifting

### DIFF
--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -4103,6 +4103,10 @@ input {
   color: #f59e0b;
 }
 
+/* Published is the version on record; approved is a change cleared to become
+   one. Both are good news, so both are green — the label carries the
+   difference. */
+.dash-doc-badge--published,
 .dash-doc-badge--approved {
   background: var(--brand-green-dim);
   color: var(--brand-green);
@@ -5276,6 +5280,7 @@ input {
   color: #fbbf24;
 }
 
+.docs-status-badge--published,
 .docs-status-badge--approved {
   background: rgba(22, 163, 74, 0.1);
   color: var(--brand-green);

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -655,14 +655,17 @@ input {
 }
 
 /* Header — the one part of the page that never changes as you move
-   between tabs, so you always know which document you are looking at. */
+   between tabs, so you always know which document you are looking at.
+   It sits on the page rather than inside a card: a floating box that
+   resizes under you is the thing this page was accused of. */
 .doc-header {
   display: grid;
   gap: var(--brand-space-5);
-  padding: var(--brand-space-6) var(--brand-space-6) 0;
-  background: var(--bs-surface-1);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-xl);
+  padding: 0;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--bs-rule);
+  border-radius: 0;
 }
 
 .doc-header-top {
@@ -743,48 +746,21 @@ input {
   align-items: center;
 }
 
-/* Status pill — the answer to "where does this stand?" */
-.doc-status {
+/* Official version — a fact, not a status. "Published" and "In review" are
+   both true at once whenever a new version is under review, so the header
+   states the version on record and leaves the verdicts to the Changes tab. */
+.doc-version-pill {
   display: inline-flex;
   align-items: center;
-  gap: var(--brand-space-2);
   padding: var(--brand-space-1) var(--brand-space-3);
+  border: 1px solid var(--bs-rule);
   border-radius: var(--brand-radius-full);
+  background: var(--bs-surface-2);
+  color: var(--bs-text-secondary);
   font-family: var(--brand-font-mono);
   font-size: var(--brand-text-xs);
   font-weight: var(--brand-weight-medium);
   letter-spacing: var(--brand-tracking-wide);
-  text-transform: uppercase;
-  background: var(--bs-surface-2);
-  color: var(--bs-text-muted);
-}
-
-.doc-status::before {
-  content: "";
-  width: 6px;
-  height: 6px;
-  border-radius: var(--brand-radius-full);
-  background: currentColor;
-}
-
-.doc-status--published {
-  background: var(--brand-green-dim);
-  color: var(--brand-green);
-}
-
-.doc-status--approved {
-  background: var(--brand-green-dim);
-  color: var(--brand-green);
-}
-
-.doc-status--in_review {
-  background: rgba(217, 119, 6, 0.12);
-  color: #b45309;
-}
-
-.doc-status--changes_requested {
-  background: var(--bs-coral-dim);
-  color: var(--brand-coral-dark);
 }
 
 /* Tabs — GitHub's repo bar, in Bindersnap's voice. */
@@ -792,9 +768,8 @@ input {
   display: flex;
   flex-wrap: wrap;
   gap: var(--brand-space-1);
-  border-top: 1px solid var(--bs-rule-warm);
-  margin: 0 calc(var(--brand-space-6) * -1);
-  padding: 0 var(--brand-space-4);
+  margin: 0 0 -1px;
+  padding: 0;
 }
 
 .doc-tab {
@@ -1221,40 +1196,190 @@ input {
   gap: var(--brand-space-2);
 }
 
-/* Changes tab */
-.doc-changes {
+/* Changes tab — an index of open changes. One row each; the review itself
+   lives on its own page, so reaching #3 never means scrolling past #10. */
+.change-list {
   display: grid;
   gap: var(--brand-space-4);
 }
 
-.doc-change {
-  display: grid;
-  gap: var(--brand-space-3);
-  padding: var(--brand-space-5);
-}
-
-.doc-change-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--brand-space-4);
-}
-
-.doc-change-heading {
+.change-list-header {
   display: grid;
   gap: var(--brand-space-1);
+}
+
+.change-list-title {
+  margin: 0;
+  font-family: var(--brand-font-serif);
+  font-size: var(--brand-text-h3);
+}
+
+.change-list-note {
+  margin: 0;
+  max-width: 70ch;
+  font-size: var(--brand-text-sm);
+  color: var(--bs-text-muted);
+}
+
+.change-list-rows {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-lg);
+  background: var(--bs-surface-1);
+  overflow: hidden;
+}
+
+.change-row + .change-row {
+  border-top: 1px solid var(--bs-rule-warm);
+}
+
+.change-row-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--brand-space-3);
+  padding: var(--brand-space-4);
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--brand-transition-base);
+}
+
+.change-row-btn:hover,
+.change-row-btn:focus-visible {
+  background: var(--bs-surface-2);
+  outline: none;
+}
+
+.change-row-icon {
+  flex: none;
+  color: var(--bs-text-faint);
+}
+
+.change-row-main {
+  display: grid;
+  gap: var(--brand-space-1);
+  flex: 1 1 auto;
   min-width: 0;
 }
 
-.doc-change-meta {
+.change-row-title {
+  font-size: var(--brand-text-body);
+  font-weight: var(--brand-weight-medium);
+  color: var(--bs-text-primary);
+  overflow-wrap: anywhere;
+}
+
+.change-row-meta {
+  font-size: var(--brand-text-sm);
+  color: var(--bs-text-muted);
+  overflow-wrap: anywhere;
+}
+
+/* One change, on its own page. */
+.change-detail {
+  display: grid;
+  gap: var(--brand-space-5);
+}
+
+.change-detail-header {
+  display: grid;
+  gap: var(--brand-space-2);
+  padding-bottom: var(--brand-space-4);
+  border-bottom: 1px solid var(--bs-rule);
+}
+
+.change-detail-back {
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--brand-space-1);
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--bs-text-muted);
+  cursor: pointer;
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+  transition: color var(--brand-transition-base);
+}
+
+.change-detail-back:hover,
+.change-detail-back:focus-visible {
+  color: var(--bs-text-primary);
+}
+
+.change-detail-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--brand-space-3);
+}
+
+.change-detail-title {
+  margin: 0;
+  font-family: var(--brand-font-serif);
+  font-size: var(--brand-text-h3);
+  line-height: var(--brand-leading-tight);
+  overflow-wrap: anywhere;
+}
+
+.change-detail-number {
+  margin-left: var(--brand-space-2);
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-body);
+  font-weight: var(--brand-weight-regular);
+  color: var(--bs-text-faint);
+}
+
+.change-detail-meta {
   margin: 0;
   font-size: var(--brand-text-sm);
   color: var(--bs-text-muted);
 }
 
-.doc-change-number {
+.change-detail-material,
+.change-detail-decision {
+  display: grid;
+  gap: var(--brand-space-2);
+}
+
+.change-detail-section-title {
+  margin: 0;
   font-family: var(--brand-font-mono);
-  color: var(--bs-text-faint);
+  font-size: var(--brand-text-label);
+  letter-spacing: var(--brand-tracking-wide);
+  text-transform: uppercase;
+  color: var(--brand-coral);
+}
+
+.change-detail-section-note {
+  margin: 0 0 var(--brand-space-2);
+  max-width: 70ch;
+  font-size: var(--brand-text-sm);
+  color: var(--bs-text-muted);
+}
+
+/* The file under review scrolls inside its own frame. Approving is the point
+   of this page, so the buttons must never be a thousand pixels down. */
+.change-detail-material .doc-preview-body {
+  max-height: 60vh;
+  overflow: auto;
+}
+
+.change-detail-section-note code {
+  padding: 1px var(--brand-space-1);
+  border-radius: var(--brand-radius-xs);
+  background: var(--bs-surface-2);
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-xs);
 }
 
 .doc-empty {
@@ -1549,13 +1674,7 @@ input {
 }
 
 @media (max-width: 720px) {
-  .doc-header {
-    padding: var(--brand-space-5) var(--brand-space-4) 0;
-  }
-
   .doc-tabs {
-    margin: 0 calc(var(--brand-space-4) * -1);
-    padding: 0 var(--brand-space-2);
     overflow-x: auto;
     flex-wrap: nowrap;
   }
@@ -3279,6 +3398,12 @@ input {
   flex: none;
   min-height: 0;
   overflow-y: visible;
+  /* Without an explicit track the single implicit column is `auto`, which
+     sizes to its content — so every page (and every tab within a page) got a
+     different width and the whole layout jumped sideways on each click.
+     Pinning the track to the full area makes `.app-page-shell`'s max-width
+     and auto margins the only thing deciding where the content sits. */
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .app-main--page {
@@ -3286,6 +3411,10 @@ input {
 }
 
 .app-page-shell {
+  /* `width: 100%` is load-bearing. Without it the auto margins make this a
+     fit-content box, so the column width — and with it the whole page — was
+     decided by whatever the active tab happened to render. */
+  width: 100%;
   max-width: 1040px;
   margin: 0 auto;
   padding: var(--brand-space-8) var(--brand-space-8) var(--brand-space-12);

--- a/apps/app/components/AnonymousDocumentShell.tsx
+++ b/apps/app/components/AnonymousDocumentShell.tsx
@@ -65,12 +65,22 @@ export function AnonymousDocumentShell({
                   ? "overview"
                   : route.tab
               }
+              activeChangeNumber={route.changeNumber ?? null}
               onTabChange={(tab) =>
                 onNavigate({
                   kind: "document",
                   owner: route.owner,
                   repo: route.repo,
                   tab,
+                })
+              }
+              onOpenChange={(pullNumber) =>
+                onNavigate({
+                  kind: "document",
+                  owner: route.owner,
+                  repo: route.repo,
+                  tab: "changes",
+                  ...(pullNumber === null ? {} : { changeNumber: pullNumber }),
                 })
               }
               onBack={() => onNavigate({ kind: "home" })}

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -348,12 +348,24 @@ export function AppShell({
                 repo={route.repo}
                 uploaderSlug={user?.username ?? "unknown"}
                 activeView={route.tab}
+                activeChangeNumber={route.changeNumber ?? null}
                 onTabChange={(tab) =>
                   onNavigate({
                     kind: "document",
                     owner: route.owner,
                     repo: route.repo,
                     tab,
+                  })
+                }
+                onOpenChange={(pullNumber) =>
+                  onNavigate({
+                    kind: "document",
+                    owner: route.owner,
+                    repo: route.repo,
+                    tab: "changes",
+                    ...(pullNumber === null
+                      ? {}
+                      : { changeNumber: pullNumber }),
                   })
                 }
                 onBack={() => onNavigate({ kind: "workspace" })}

--- a/apps/app/components/DocumentChangeDetail.tsx
+++ b/apps/app/components/DocumentChangeDetail.tsx
@@ -1,0 +1,416 @@
+import { useState } from "react";
+import { ChevronLeft } from "lucide-react";
+
+import type {
+  PullRequestWithApprovalState,
+  RepoBranchProtection,
+} from "../api";
+import { publishDocument, submitDocumentReview } from "../api";
+import {
+  capitalizeFirst,
+  formatDate,
+  getApprovalStateBadgeClass,
+  getApprovalStateLabel,
+  parseSubmissionSummary,
+} from "../documentDisplay";
+import { DocumentPreview } from "./DocumentPreview";
+import { ReviewDiscussion } from "./ReviewDiscussion";
+
+interface DocumentChangeDetailProps {
+  owner: string;
+  repo: string;
+  currentUser: string;
+  isAnonymous: boolean;
+  pullRequest: PullRequestWithApprovalState;
+  branchProtection: RepoBranchProtection | null;
+  blockOnUnresolvedThreads: boolean;
+  nextVersion: number;
+  documentName: string;
+  /** Canonical file name, so the proposed version can be previewed and saved. */
+  fileName: string | null;
+  /** Set while this change's file is being fetched for download. */
+  downloading: boolean;
+  onDownload: (gitRef: string, loaded?: Blob | null) => void;
+  onChanged: () => void | Promise<void>;
+  onBackToList: () => void;
+}
+
+interface PRActionState {
+  status: "idle" | "submitting" | "error";
+  error: string | null;
+  changesComment: string;
+  showChangesForm: boolean;
+  showApproveConfirm: boolean;
+}
+
+const DEFAULT_PR_ACTION_STATE: PRActionState = {
+  status: "idle",
+  error: null,
+  changesComment: "",
+  showChangesForm: false,
+  showApproveConfirm: false,
+};
+
+function readActionError(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+function canUserReview(
+  currentUser: string,
+  prAuthor: string | undefined,
+  protection: RepoBranchProtection | null,
+): { allowed: boolean; reason: string | null } {
+  if (currentUser === prAuthor) {
+    // Rendered separately as a callout, not as a denial.
+    return { allowed: false, reason: null };
+  }
+  if (
+    protection?.enableApprovalsWhitelist &&
+    protection.approvalsWhitelistUsernames.length > 0 &&
+    !protection.approvalsWhitelistUsernames.includes(currentUser)
+  ) {
+    return {
+      allowed: false,
+      reason: "Your account is not authorized to approve this document.",
+    };
+  }
+  return { allowed: true, reason: null };
+}
+
+function canUserMerge(
+  currentUser: string,
+  protection: RepoBranchProtection | null,
+): { allowed: boolean; reason: string | null } {
+  if (
+    protection?.enableMergeWhitelist &&
+    protection.mergeWhitelistUsernames.length > 0 &&
+    !protection.mergeWhitelistUsernames.includes(currentUser)
+  ) {
+    return {
+      allowed: false,
+      reason: "Your account is not authorized to publish this document.",
+    };
+  }
+  return { allowed: true, reason: null };
+}
+
+/**
+ * One change, on its own page.
+ *
+ * You cannot sign off on something you have not read, so the proposed file is
+ * the body of the page — previewed inline and downloadable — with the decision
+ * and the discussion beneath it.
+ */
+export function DocumentChangeDetail({
+  owner,
+  repo,
+  currentUser,
+  isAnonymous,
+  pullRequest,
+  branchProtection,
+  blockOnUnresolvedThreads,
+  nextVersion,
+  documentName,
+  fileName,
+  downloading,
+  onDownload,
+  onChanged,
+  onBackToList,
+}: DocumentChangeDetailProps) {
+  const [actionState, setActionState] = useState<PRActionState>(
+    DEFAULT_PR_ACTION_STATE,
+  );
+  const [unresolvedCount, setUnresolvedCount] = useState(0);
+
+  const prNum = pullRequest.number ?? 0;
+  const isSubmitting = actionState.status === "submitting";
+
+  function updateActionState(update: Partial<PRActionState>) {
+    setActionState((prev) => ({ ...prev, ...update }));
+  }
+
+  async function handleApprove() {
+    updateActionState({ status: "submitting", error: null });
+    try {
+      await submitDocumentReview(owner, repo, prNum, "APPROVE", "APPROVED");
+      updateActionState({ status: "idle" });
+      await onChanged();
+    } catch (err) {
+      updateActionState({
+        status: "error",
+        error: readActionError(err, "Failed to submit approval."),
+      });
+    }
+  }
+
+  async function handleRequestChanges() {
+    const comment = actionState.changesComment.trim();
+    if (!comment) {
+      updateActionState({
+        error: "Enter a comment describing the required changes.",
+      });
+      return;
+    }
+    updateActionState({ status: "submitting", error: null });
+    try {
+      await submitDocumentReview(
+        owner,
+        repo,
+        prNum,
+        "REQUEST_CHANGES",
+        comment,
+      );
+      updateActionState({
+        status: "idle",
+        showChangesForm: false,
+        changesComment: "",
+      });
+      await onChanged();
+    } catch (err) {
+      updateActionState({
+        status: "error",
+        error: readActionError(err, "Failed to request changes."),
+      });
+    }
+  }
+
+  async function handlePublish() {
+    updateActionState({ status: "submitting", error: null });
+    try {
+      await publishDocument(owner, repo, prNum, nextVersion);
+      updateActionState({ status: "idle" });
+      await onChanged();
+    } catch (err) {
+      updateActionState({
+        status: "error",
+        error: readActionError(err, "Failed to publish document."),
+      });
+    }
+  }
+
+  const reviewPerms = canUserReview(
+    currentUser,
+    pullRequest.user?.login,
+    branchProtection,
+  );
+  const mergePerms = canUserMerge(currentUser, branchProtection);
+  const mergeReady = pullRequest.approvalState === "approved";
+  // The server enforces this too; the disabled button just avoids a pointless
+  // round trip that ends in a 409.
+  const threadsBlockPublish = blockOnUnresolvedThreads && unresolvedCount > 0;
+  const ownSubmission = currentUser === pullRequest.user?.login;
+  const summary = parseSubmissionSummary(pullRequest.body);
+  const submitter = pullRequest.user?.login
+    ? capitalizeFirst(pullRequest.user.login)
+    : "Someone";
+  const submittedDate = pullRequest.created_at
+    ? formatDate(pullRequest.created_at)
+    : null;
+  const reviewRef = pullRequest.branchName?.trim() || null;
+
+  return (
+    <article className="change-detail">
+      <header className="change-detail-header">
+        <button
+          className="change-detail-back"
+          type="button"
+          onClick={onBackToList}
+        >
+          <ChevronLeft size={14} strokeWidth={1.5} aria-hidden="true" />
+          All changes
+        </button>
+        <div className="change-detail-heading">
+          <h2 className="change-detail-title">
+            {summary ?? `Submitted by ${submitter}`}
+            <span className="change-detail-number">#{prNum}</span>
+          </h2>
+          <span
+            className={getApprovalStateBadgeClass(pullRequest.approvalState)}
+          >
+            {getApprovalStateLabel(pullRequest.approvalState)}
+          </span>
+        </div>
+        <p className="change-detail-meta">
+          Submitted by {submitter}
+          {submittedDate ? ` on ${submittedDate}` : ""} · Becomes v{nextVersion}{" "}
+          when published
+        </p>
+      </header>
+
+      <section className="change-detail-material">
+        <h3 className="change-detail-section-title">
+          The version under review
+        </h3>
+        {reviewRef ? (
+          <>
+            <p className="change-detail-section-note">
+              The file exactly as submitted, read from <code>{reviewRef}</code>.
+              Read it here or download it before you decide.
+            </p>
+            <DocumentPreview
+              owner={owner}
+              repo={repo}
+              gitRef={reviewRef}
+              fileName={fileName}
+              downloading={downloading}
+              onDownload={(loaded) => onDownload(reviewRef, loaded)}
+            />
+          </>
+        ) : (
+          <p className="vault-pr-notice">
+            This change has no branch on record, so the submitted file cannot be
+            shown here.
+          </p>
+        )}
+      </section>
+
+      {ownSubmission ? (
+        <p className="vault-pr-own-notice">
+          ℹ You submitted this version — waiting on other reviewers to approve.
+        </p>
+      ) : reviewPerms.allowed ? (
+        <section className="change-detail-decision">
+          <h3 className="change-detail-section-title">Your decision</h3>
+          <div className="vault-pr-actions">
+            {actionState.showApproveConfirm ? (
+              <div className="vault-pr-confirm">
+                <p className="vault-pr-confirm-heading">
+                  Approve version {nextVersion} of {documentName}?
+                </p>
+                <p className="vault-pr-confirm-sub">
+                  This approval will be recorded with your name and timestamp.
+                </p>
+                <div className="vault-pr-confirm-actions">
+                  <button
+                    className="bs-btn bs-btn-primary"
+                    type="button"
+                    disabled={isSubmitting}
+                    onClick={() => {
+                      updateActionState({ showApproveConfirm: false });
+                      void handleApprove();
+                    }}
+                  >
+                    {isSubmitting ? "Submitting…" : "Confirm Approval"}
+                  </button>
+                  <button
+                    className="bs-btn bs-btn-secondary"
+                    type="button"
+                    disabled={isSubmitting}
+                    onClick={() =>
+                      updateActionState({ showApproveConfirm: false })
+                    }
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                className="bs-btn bs-btn-primary"
+                type="button"
+                disabled={isSubmitting}
+                onClick={() => updateActionState({ showApproveConfirm: true })}
+              >
+                Approve
+              </button>
+            )}
+
+            {actionState.showChangesForm ? (
+              <div className="vault-pr-comment-form">
+                <textarea
+                  className="vault-pr-comment-input"
+                  placeholder="Describe what needs to change…"
+                  value={actionState.changesComment}
+                  rows={3}
+                  disabled={isSubmitting}
+                  onChange={(e) =>
+                    updateActionState({
+                      changesComment: e.target.value,
+                      error: null,
+                    })
+                  }
+                />
+                <div className="vault-pr-comment-actions">
+                  <button
+                    className="bs-btn bs-btn-secondary"
+                    type="button"
+                    disabled={isSubmitting}
+                    onClick={() => void handleRequestChanges()}
+                  >
+                    {isSubmitting ? "Submitting…" : "Send Feedback"}
+                  </button>
+                  <button
+                    className="bs-btn bs-btn-secondary"
+                    type="button"
+                    disabled={isSubmitting}
+                    onClick={() =>
+                      updateActionState({
+                        showChangesForm: false,
+                        changesComment: "",
+                        error: null,
+                      })
+                    }
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                className="bs-btn bs-btn-secondary"
+                type="button"
+                disabled={isSubmitting}
+                onClick={() =>
+                  updateActionState({ showChangesForm: true, error: null })
+                }
+              >
+                Request Changes
+              </button>
+            )}
+          </div>
+        </section>
+      ) : reviewPerms.reason ? (
+        <p className="vault-pr-notice">{reviewPerms.reason}</p>
+      ) : null}
+
+      <ReviewDiscussion
+        owner={owner}
+        repo={repo}
+        pullNumber={prNum}
+        canParticipate={!isAnonymous}
+        blockOnUnresolvedThreads={blockOnUnresolvedThreads}
+        onSummaryChange={(next) =>
+          setUnresolvedCount((prev) =>
+            prev === next.unresolvedCount ? prev : next.unresolvedCount,
+          )
+        }
+      />
+
+      {mergePerms.allowed && mergeReady ? (
+        <div className="vault-pr-actions">
+          <button
+            className="bs-btn bs-btn-primary vault-pr-publish-btn"
+            type="button"
+            disabled={isSubmitting || threadsBlockPublish}
+            title={
+              threadsBlockPublish
+                ? "Resolve every discussion thread before publishing."
+                : undefined
+            }
+            onClick={() => void handlePublish()}
+          >
+            {isSubmitting ? "Publishing…" : "Publish as Official Version"}
+          </button>
+        </div>
+      ) : mergeReady && !mergePerms.allowed ? (
+        <p className="vault-pr-notice">{mergePerms.reason}</p>
+      ) : null}
+
+      {actionState.error ? (
+        <p className="vault-pr-error" role="alert">
+          {actionState.error}
+        </p>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/app/components/DocumentChanges.tsx
+++ b/apps/app/components/DocumentChanges.tsx
@@ -1,10 +1,6 @@
-import { useState } from "react";
+import { GitPullRequest } from "lucide-react";
 
-import type {
-  PullRequestWithApprovalState,
-  RepoBranchProtection,
-} from "../api";
-import { publishDocument, submitDocumentReview } from "../api";
+import type { PullRequestWithApprovalState } from "../api";
 import {
   capitalizeFirst,
   formatDate,
@@ -12,190 +8,28 @@ import {
   getApprovalStateLabel,
   parseSubmissionSummary,
 } from "../documentDisplay";
-import { ReviewDiscussion } from "./ReviewDiscussion";
 
 interface DocumentChangesProps {
-  owner: string;
-  repo: string;
-  currentUser: string;
   isAnonymous: boolean;
   openPullRequests: PullRequestWithApprovalState[];
-  branchProtection: RepoBranchProtection | null;
-  blockOnUnresolvedThreads: boolean;
   nextVersion: number;
-  documentName: string;
-  onChanged: () => void | Promise<void>;
+  onOpenChange: (pullNumber: number) => void;
   onSubmitVersion: () => void;
 }
 
-interface PRActionState {
-  status: "idle" | "submitting" | "error";
-  error: string | null;
-  changesComment: string;
-  showChangesForm: boolean;
-  showApproveConfirm: boolean;
-}
-
-const DEFAULT_PR_ACTION_STATE: PRActionState = {
-  status: "idle",
-  error: null,
-  changesComment: "",
-  showChangesForm: false,
-  showApproveConfirm: false,
-};
-
-function readActionError(err: unknown, fallback: string): string {
-  return err instanceof Error ? err.message : fallback;
-}
-
-function canUserReview(
-  currentUser: string,
-  prAuthor: string | undefined,
-  protection: RepoBranchProtection | null,
-): { allowed: boolean; reason: string | null } {
-  if (currentUser === prAuthor) {
-    // Rendered separately as a callout, not as a denial.
-    return { allowed: false, reason: null };
-  }
-  if (
-    protection?.enableApprovalsWhitelist &&
-    protection.approvalsWhitelistUsernames.length > 0 &&
-    !protection.approvalsWhitelistUsernames.includes(currentUser)
-  ) {
-    return {
-      allowed: false,
-      reason: "Your account is not authorized to approve this document.",
-    };
-  }
-  return { allowed: true, reason: null };
-}
-
-function canUserMerge(
-  currentUser: string,
-  protection: RepoBranchProtection | null,
-): { allowed: boolean; reason: string | null } {
-  if (
-    protection?.enableMergeWhitelist &&
-    protection.mergeWhitelistUsernames.length > 0 &&
-    !protection.mergeWhitelistUsernames.includes(currentUser)
-  ) {
-    return {
-      allowed: false,
-      reason: "Your account is not authorized to publish this document.",
-    };
-  }
-  return { allowed: true, reason: null };
-}
-
 /**
- * Every version waiting on a decision, and the controls to make it.
+ * The index of everything waiting on a decision.
  *
- * This used to share the document page with the preview and the version list,
- * which meant approving something happened in a column next to two other
- * columns. Reviewing is its own job, so it gets its own tab.
+ * A list, not a stack of open reviews: each change gets its own page, so
+ * reaching #3 never means scrolling past #4 through #10.
  */
 export function DocumentChanges({
-  owner,
-  repo,
-  currentUser,
   isAnonymous,
   openPullRequests,
-  branchProtection,
-  blockOnUnresolvedThreads,
   nextVersion,
-  documentName,
-  onChanged,
+  onOpenChange,
   onSubmitVersion,
 }: DocumentChangesProps) {
-  const [actionStates, setActionStates] = useState<
-    Record<number, PRActionState>
-  >({});
-  const [unresolvedByPR, setUnresolvedByPR] = useState<Record<number, number>>(
-    {},
-  );
-
-  function getActionState(pullNumber: number): PRActionState {
-    return actionStates[pullNumber] ?? DEFAULT_PR_ACTION_STATE;
-  }
-
-  function updateActionState(
-    pullNumber: number,
-    update: Partial<PRActionState>,
-  ) {
-    setActionStates((prev) => ({
-      ...prev,
-      [pullNumber]: {
-        ...(prev[pullNumber] ?? DEFAULT_PR_ACTION_STATE),
-        ...update,
-      },
-    }));
-  }
-
-  async function handleApprove(pullNumber: number) {
-    updateActionState(pullNumber, { status: "submitting", error: null });
-    try {
-      await submitDocumentReview(
-        owner,
-        repo,
-        pullNumber,
-        "APPROVE",
-        "APPROVED",
-      );
-      updateActionState(pullNumber, { status: "idle" });
-      await onChanged();
-    } catch (err) {
-      updateActionState(pullNumber, {
-        status: "error",
-        error: readActionError(err, "Failed to submit approval."),
-      });
-    }
-  }
-
-  async function handleRequestChanges(pullNumber: number) {
-    const comment = getActionState(pullNumber).changesComment.trim();
-    if (!comment) {
-      updateActionState(pullNumber, {
-        error: "Enter a comment describing the required changes.",
-      });
-      return;
-    }
-    updateActionState(pullNumber, { status: "submitting", error: null });
-    try {
-      await submitDocumentReview(
-        owner,
-        repo,
-        pullNumber,
-        "REQUEST_CHANGES",
-        comment,
-      );
-      updateActionState(pullNumber, {
-        status: "idle",
-        showChangesForm: false,
-        changesComment: "",
-      });
-      await onChanged();
-    } catch (err) {
-      updateActionState(pullNumber, {
-        status: "error",
-        error: readActionError(err, "Failed to request changes."),
-      });
-    }
-  }
-
-  async function handlePublish(pullNumber: number) {
-    updateActionState(pullNumber, { status: "submitting", error: null });
-    try {
-      await publishDocument(owner, repo, pullNumber, nextVersion);
-      updateActionState(pullNumber, { status: "idle" });
-      await onChanged();
-    } catch (err) {
-      updateActionState(pullNumber, {
-        status: "error",
-        error: readActionError(err, "Failed to publish document."),
-      });
-    }
-  }
-
   if (openPullRequests.length === 0) {
     return (
       <section className="bs-card doc-empty">
@@ -218,209 +52,60 @@ export function DocumentChanges({
   }
 
   return (
-    <div className="doc-changes">
-      {openPullRequests.map((pr) => {
-        const prNum = pr.number ?? 0;
-        const actionState = getActionState(prNum);
-        const isSubmitting = actionState.status === "submitting";
-        const reviewPerms = canUserReview(
-          currentUser,
-          pr.user?.login,
-          branchProtection,
-        );
-        const mergePerms = canUserMerge(currentUser, branchProtection);
-        const mergeReady = pr.approvalState === "approved";
-        // The server enforces this too; the disabled button just avoids a
-        // pointless round trip that ends in a 409.
-        const threadsBlockPublish =
-          blockOnUnresolvedThreads && (unresolvedByPR[prNum] ?? 0) > 0;
-        const ownSubmission = currentUser === pr.user?.login;
-        const summary = parseSubmissionSummary(pr.body);
-        const submitter = pr.user?.login
-          ? capitalizeFirst(pr.user.login)
-          : "Someone";
-        const submittedDate = pr.created_at ? formatDate(pr.created_at) : null;
+    <section className="change-list" aria-label="Open changes">
+      <header className="change-list-header">
+        <h2 className="change-list-title">
+          {openPullRequests.length} change
+          {openPullRequests.length === 1 ? "" : "s"} waiting on a decision
+        </h2>
+        <p className="change-list-note">
+          Open one to read the submitted file, download it, and record your
+          decision.
+        </p>
+      </header>
 
-        return (
-          <article className="bs-card vault-pr-item doc-change" key={pr.number}>
-            <header className="doc-change-header">
-              <div className="doc-change-heading">
-                <h3 className="vault-pr-title">
-                  {summary ?? `Submitted by ${submitter}`}
-                </h3>
-                <p className="doc-change-meta">
-                  <span className="doc-change-number">#{prNum}</span>
-                  {submittedDate
-                    ? ` · Submitted by ${submitter} on ${submittedDate}`
-                    : ` · Submitted by ${submitter}`}
-                  {` · Becomes v${nextVersion} when published`}
-                </p>
-              </div>
-              <span className={getApprovalStateBadgeClass(pr.approvalState)}>
-                {getApprovalStateLabel(pr.approvalState)}
-              </span>
-            </header>
+      <ul className="change-list-rows">
+        {openPullRequests.map((pr) => {
+          const prNum = pr.number ?? 0;
+          const submitter = pr.user?.login
+            ? capitalizeFirst(pr.user.login)
+            : "Someone";
+          const submittedDate = pr.created_at
+            ? formatDate(pr.created_at)
+            : null;
 
-            {ownSubmission ? (
-              <p className="vault-pr-own-notice">
-                ℹ You submitted this version — waiting on other reviewers to
-                approve.
-              </p>
-            ) : reviewPerms.allowed ? (
-              <div className="vault-pr-actions">
-                {actionState.showApproveConfirm ? (
-                  <div className="vault-pr-confirm">
-                    <p className="vault-pr-confirm-heading">
-                      Approve version {nextVersion} of {documentName}?
-                    </p>
-                    <p className="vault-pr-confirm-sub">
-                      This approval will be recorded with your name and
-                      timestamp.
-                    </p>
-                    <div className="vault-pr-confirm-actions">
-                      <button
-                        className="bs-btn bs-btn-primary"
-                        type="button"
-                        disabled={isSubmitting}
-                        onClick={() => {
-                          updateActionState(prNum, {
-                            showApproveConfirm: false,
-                          });
-                          void handleApprove(prNum);
-                        }}
-                      >
-                        {isSubmitting ? "Submitting…" : "Confirm Approval"}
-                      </button>
-                      <button
-                        className="bs-btn bs-btn-secondary"
-                        type="button"
-                        disabled={isSubmitting}
-                        onClick={() =>
-                          updateActionState(prNum, {
-                            showApproveConfirm: false,
-                          })
-                        }
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <button
-                    className="bs-btn bs-btn-primary"
-                    type="button"
-                    disabled={isSubmitting}
-                    onClick={() =>
-                      updateActionState(prNum, { showApproveConfirm: true })
-                    }
-                  >
-                    Approve
-                  </button>
-                )}
-
-                {actionState.showChangesForm ? (
-                  <div className="vault-pr-comment-form">
-                    <textarea
-                      className="vault-pr-comment-input"
-                      placeholder="Describe what needs to change…"
-                      value={actionState.changesComment}
-                      rows={3}
-                      disabled={isSubmitting}
-                      onChange={(e) =>
-                        updateActionState(prNum, {
-                          changesComment: e.target.value,
-                          error: null,
-                        })
-                      }
-                    />
-                    <div className="vault-pr-comment-actions">
-                      <button
-                        className="bs-btn bs-btn-secondary"
-                        type="button"
-                        disabled={isSubmitting}
-                        onClick={() => void handleRequestChanges(prNum)}
-                      >
-                        {isSubmitting ? "Submitting…" : "Send Feedback"}
-                      </button>
-                      <button
-                        className="bs-btn bs-btn-secondary"
-                        type="button"
-                        disabled={isSubmitting}
-                        onClick={() =>
-                          updateActionState(prNum, {
-                            showChangesForm: false,
-                            changesComment: "",
-                            error: null,
-                          })
-                        }
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <button
-                    className="bs-btn bs-btn-secondary"
-                    type="button"
-                    disabled={isSubmitting}
-                    onClick={() =>
-                      updateActionState(prNum, {
-                        showChangesForm: true,
-                        error: null,
-                      })
-                    }
-                  >
-                    Request Changes
-                  </button>
-                )}
-              </div>
-            ) : reviewPerms.reason ? (
-              <p className="vault-pr-notice">{reviewPerms.reason}</p>
-            ) : null}
-
-            <ReviewDiscussion
-              owner={owner}
-              repo={repo}
-              pullNumber={prNum}
-              canParticipate={!isAnonymous}
-              blockOnUnresolvedThreads={blockOnUnresolvedThreads}
-              onSummaryChange={(next) =>
-                setUnresolvedByPR((prev) =>
-                  prev[prNum] === next.unresolvedCount
-                    ? prev
-                    : { ...prev, [prNum]: next.unresolvedCount },
-                )
-              }
-            />
-
-            {mergePerms.allowed && mergeReady ? (
-              <div className="vault-pr-actions">
-                <button
-                  className="bs-btn bs-btn-primary vault-pr-publish-btn"
-                  type="button"
-                  disabled={isSubmitting || threadsBlockPublish}
-                  title={
-                    threadsBlockPublish
-                      ? "Resolve every discussion thread before publishing."
-                      : undefined
-                  }
-                  onClick={() => void handlePublish(prNum)}
-                >
-                  {isSubmitting ? "Publishing…" : "Publish as Official Version"}
-                </button>
-              </div>
-            ) : mergeReady && !mergePerms.allowed ? (
-              <p className="vault-pr-notice">{mergePerms.reason}</p>
-            ) : null}
-
-            {actionState.error ? (
-              <p className="vault-pr-error" role="alert">
-                {actionState.error}
-              </p>
-            ) : null}
-          </article>
-        );
-      })}
-    </div>
+          return (
+            <li className="change-row" key={prNum}>
+              <button
+                className="change-row-btn"
+                type="button"
+                onClick={() => onOpenChange(prNum)}
+              >
+                <GitPullRequest
+                  className="change-row-icon"
+                  size={16}
+                  strokeWidth={1.5}
+                  aria-hidden="true"
+                />
+                <span className="change-row-main">
+                  <span className="change-row-title">
+                    {parseSubmissionSummary(pr.body) ??
+                      `Submitted by ${submitter}`}
+                  </span>
+                  <span className="change-row-meta">
+                    #{prNum} · Submitted by {submitter}
+                    {submittedDate ? ` on ${submittedDate}` : ""} · Becomes v
+                    {nextVersion} when published
+                  </span>
+                </span>
+                <span className={getApprovalStateBadgeClass(pr.approvalState)}>
+                  {getApprovalStateLabel(pr.approvalState)}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
   );
 }

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -16,10 +16,9 @@ import {
   formatDate,
   formatDocumentName,
   getApprovalStateLabel,
-  getDocumentStatusLabel,
   parseSubmissionSummary,
-  resolveDocumentStatus,
 } from "../documentDisplay";
+import { DocumentChangeDetail } from "./DocumentChangeDetail";
 import { DocumentChanges } from "./DocumentChanges";
 import { DocumentCollaborators } from "./DocumentCollaborators";
 import { DocumentHistory } from "./DocumentHistory";
@@ -32,7 +31,10 @@ interface DocumentDetailProps {
   repo: string;
   uploaderSlug: string | null;
   activeView: DocumentTab;
+  /** Which change has its own page open, or null for the change list. */
+  activeChangeNumber: number | null;
   onTabChange: (tab: DocumentTab) => void;
+  onOpenChange: (pullNumber: number | null) => void;
   onBack: () => void;
 }
 
@@ -63,16 +65,18 @@ function triggerBrowserDownload(blob: Blob, fileName: string): void {
  * The document workspace.
  *
  * One document, five views: what it says now, what is waiting on a decision,
- * how it got here, who can see it, and how it gets approved. The header carries
- * the answer to "where does this stand?" and never changes as you move between
- * tabs, so you always know which document you are looking at.
+ * how it got here, who can see it, and how it gets approved. The header names
+ * the document and the version on record, and holds still at the same width on
+ * every tab — it is a page, not a stack of boxes that resize under you.
  */
 export function DocumentDetail({
   owner,
   repo,
   uploaderSlug,
   activeView,
+  activeChangeNumber,
   onTabChange,
+  onOpenChange,
   onBack,
 }: DocumentDetailProps) {
   const [tags, setTags] = useState<DocTag[]>([]);
@@ -128,10 +132,10 @@ export function DocumentDetail({
   const documentName = formatDocumentName(repo);
   const latestTag = tags.length > 0 ? tags[0] : null;
   const nextVersion = (latestTag?.version ?? 0) + 1;
-  const status = resolveDocumentStatus({
-    hasPublishedVersion: latestTag !== null,
-    openApprovalStates: openPRs.map((pr) => pr.approvalState),
-  });
+  const activeChange =
+    activeChangeNumber === null
+      ? null
+      : (openPRs.find((pr) => pr.number === activeChangeNumber) ?? null);
 
   /**
    * Save a version to disk. `loaded` lets a caller that already holds the
@@ -239,15 +243,18 @@ export function DocumentDetail({
             </p>
             <h1 className="doc-header-title">{documentName}</h1>
             <div className="doc-header-facts">
-              <span className={`doc-status doc-status--${status}`}>
-                {getDocumentStatusLabel(status)}
+              {/* The official version, not a status. A document can have v3
+                  published and v4 in review at the same time, so a single
+                  status word here was always going to be a lie. */}
+              <span className="doc-version-pill">
+                {latestTag ? `v${latestTag.version}` : "No version yet"}
               </span>
               {latestTag ? (
                 <span className="doc-header-fact">
-                  v{latestTag.version} approved {formatDate(latestTag.created)}
+                  Approved {formatDate(latestTag.created)}
                 </span>
               ) : (
-                <span className="doc-header-fact">No approved version yet</span>
+                <span className="doc-header-fact">Nothing published yet</span>
               )}
               {canonicalFileInfo ? (
                 <span className="doc-header-fact doc-header-file">
@@ -316,21 +323,40 @@ export function DocumentDetail({
             currentUsername={currentUser}
           />
         </div>
-      ) : activeView === "changes" ? (
+      ) : activeView === "changes" && activeChange ? (
         <div className="document-detail-tab-panel">
-          <DocumentChanges
+          <DocumentChangeDetail
             owner={owner}
             repo={repo}
             currentUser={currentUser}
             isAnonymous={isAnonymous}
-            openPullRequests={openPRs}
+            pullRequest={activeChange}
             branchProtection={branchProtection}
             blockOnUnresolvedThreads={
               reviewSettings?.blockOnUnresolvedThreads ?? false
             }
             nextVersion={nextVersion}
             documentName={documentName}
+            fileName={canonicalFileInfo?.downloadFileName ?? null}
+            downloading={downloadState.ref === activeChange.branchName}
+            onDownload={(gitRef, loaded) => void handleDownload(gitRef, loaded)}
             onChanged={loadDocumentData}
+            onBackToList={() => onOpenChange(null)}
+          />
+        </div>
+      ) : activeView === "changes" ? (
+        <div className="document-detail-tab-panel">
+          {activeChangeNumber !== null ? (
+            <p className="vault-pr-notice">
+              Change #{activeChangeNumber} is not open on this document. It may
+              have been published or withdrawn.
+            </p>
+          ) : null}
+          <DocumentChanges
+            isAnonymous={isAnonymous}
+            openPullRequests={openPRs}
+            nextVersion={nextVersion}
+            onOpenChange={onOpenChange}
             onSubmitVersion={() => setShowUploadModal(true)}
           />
         </div>
@@ -436,7 +462,7 @@ export function DocumentDetail({
                         <button
                           className="doc-rail-link"
                           type="button"
-                          onClick={() => onTabChange("changes")}
+                          onClick={() => onOpenChange(pr.number ?? null)}
                         >
                           <span className="doc-rail-link-title">
                             {parseSubmissionSummary(pr.body) ??

--- a/apps/app/components/DocumentsPage.tsx
+++ b/apps/app/components/DocumentsPage.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import { FileText, GitPullRequest, Search, Tag, Users } from "lucide-react";
 import { getWorkspaceDocuments, type WorkspaceDocumentSummary } from "../api";
+import {
+  getDocumentStatusLabel,
+  resolveWorkspaceDocumentStatus,
+  type DocumentStatus,
+} from "../documentDisplay";
 import { parseDocumentSearchQuery } from "../documentSearch";
 import { BindersnapLogoMark } from "./BindersnapLogoMark";
 
@@ -56,41 +61,12 @@ function formatDocumentName(repoName: string): string {
     .join(" ");
 }
 
-function getDocStatus(
-  doc: WorkspaceDocumentSummary,
-): "in_review" | "approved" | "changes_requested" | "draft" {
-  const first = doc.pendingPRs[0];
-  if (first) {
-    const s = first.approvalState;
-    if (s === "in_review" || s === "changes_requested" || s === "approved") {
-      return s;
-    }
-  }
-  if (doc.latestTag) return "approved";
-  return "draft";
-}
-
-function getStatusLabel(
-  status: "in_review" | "approved" | "changes_requested" | "draft",
-): string {
-  switch (status) {
-    case "in_review":
-      return "In Review";
-    case "approved":
-      return "Approved";
-    case "changes_requested":
-      return "Changes Requested";
-    case "draft":
-      return "Draft";
-  }
-}
-
-function getStatusClass(
-  status: "in_review" | "approved" | "changes_requested" | "draft",
-): string {
+function getStatusClass(status: DocumentStatus): string {
   switch (status) {
     case "in_review":
       return "docs-status-badge docs-status-badge--review";
+    case "published":
+      return "docs-status-badge docs-status-badge--published";
     case "approved":
       return "docs-status-badge docs-status-badge--approved";
     case "changes_requested":
@@ -109,13 +85,17 @@ function sortDocs(
       case "name":
         return a.repo.name.localeCompare(b.repo.name);
       case "status": {
-        const order = {
+        const order: Record<DocumentStatus, number> = {
           approved: 0,
-          in_review: 1,
-          changes_requested: 2,
-          draft: 3,
+          published: 1,
+          in_review: 2,
+          changes_requested: 3,
+          draft: 4,
         };
-        return order[getDocStatus(a)] - order[getDocStatus(b)];
+        return (
+          order[resolveWorkspaceDocumentStatus(a)] -
+          order[resolveWorkspaceDocumentStatus(b)]
+        );
       }
       case "updated":
       default:
@@ -335,7 +315,7 @@ export function DocumentsPage({
         ) : (
           <div className={`docs-list${loading ? " docs-list--loading" : ""}`}>
             {filtered.map((doc) => {
-              const status = getDocStatus(doc);
+              const status = resolveWorkspaceDocumentStatus(doc);
               const name = formatDocumentName(doc.repo.name);
               const updated = formatRelativeTime(doc.repo.updated_at);
               const openPRs = doc.pendingPRs.length;
@@ -355,7 +335,7 @@ export function DocumentsPage({
                     <div className="docs-list-item-top">
                       <span className="docs-list-item-name">{name}</span>
                       <span className={getStatusClass(status)}>
-                        {getStatusLabel(status)}
+                        {getDocumentStatusLabel(status)}
                       </span>
                     </div>
                     {doc.repo.description && (

--- a/apps/app/components/HomePage.tsx
+++ b/apps/app/components/HomePage.tsx
@@ -14,6 +14,11 @@ import {
 } from "lucide-react";
 
 import { getWorkspaceDocuments, type WorkspaceDocumentSummary } from "../api";
+import {
+  getDocumentStatusLabel,
+  resolveWorkspaceDocumentStatus,
+  type DocumentStatus,
+} from "../documentDisplay";
 import { BindersnapLogoMark } from "./BindersnapLogoMark";
 
 interface HomePageProps {
@@ -77,47 +82,18 @@ function getTodayLabel(): string {
   });
 }
 
-function getDocStatus(
-  doc: WorkspaceDocumentSummary,
-): "in_review" | "approved" | "changes_requested" | "draft" {
-  const first = doc.pendingPRs[0];
-  if (first) {
-    const s = first.approvalState;
-    if (s === "in_review" || s === "changes_requested" || s === "approved") {
-      return s;
-    }
-  }
-  if (doc.latestTag) return "approved";
-  return "draft";
-}
-
-function getStatusBadgeClass(
-  status: "in_review" | "approved" | "changes_requested" | "draft",
-): string {
+function getStatusBadgeClass(status: DocumentStatus): string {
   switch (status) {
     case "in_review":
       return "dash-doc-badge dash-doc-badge--review";
+    case "published":
+      return "dash-doc-badge dash-doc-badge--published";
     case "approved":
       return "dash-doc-badge dash-doc-badge--approved";
     case "changes_requested":
       return "dash-doc-badge dash-doc-badge--changes";
     default:
       return "dash-doc-badge dash-doc-badge--draft";
-  }
-}
-
-function getStatusLabel(
-  status: "in_review" | "approved" | "changes_requested" | "draft",
-): string {
-  switch (status) {
-    case "in_review":
-      return "In Review";
-    case "approved":
-      return "Approved";
-    case "changes_requested":
-      return "Changes Requested";
-    default:
-      return "Draft";
   }
 }
 
@@ -482,7 +458,7 @@ export function HomePage({
               <div className="dash-empty">No documents yet.</div>
             ) : (
               recentDocs.map((doc) => {
-                const status = getDocStatus(doc);
+                const status = resolveWorkspaceDocumentStatus(doc);
                 const firstPR = doc.pendingPRs[0];
                 const submitter = firstPR?.user?.login ?? doc.repo.owner.login;
                 const updatedTime = formatRelativeTime(doc.repo.updated_at);
@@ -534,7 +510,7 @@ export function HomePage({
 
                     <span className={getStatusBadgeClass(status)}>
                       <span className="dash-badge-dot" aria-hidden="true" />
-                      {getStatusLabel(status)}
+                      {getDocumentStatusLabel(status)}
                     </span>
                   </div>
                 );

--- a/apps/app/documentDisplay.test.ts
+++ b/apps/app/documentDisplay.test.ts
@@ -7,6 +7,7 @@ import {
   getReviewStateLabel,
   parseSubmissionSummary,
   resolveDocumentStatus,
+  resolveWorkspaceDocumentStatus,
 } from "./documentDisplay";
 
 test("formatDocumentName turns a repo slug into a title", () => {
@@ -55,8 +56,45 @@ test("resolveDocumentStatus falls back to the published state when nothing is op
 
 test("status labels read like a person wrote them", () => {
   expect(getDocumentStatusLabel("approved")).toBe("Ready to publish");
-  expect(getDocumentStatusLabel("draft")).toBe("No version yet");
+  expect(getDocumentStatusLabel("published")).toBe("Published");
+  expect(getDocumentStatusLabel("draft")).toBe("Draft");
   expect(getReviewStateLabel("changes_requested")).toBe("Requested changes");
+});
+
+test("resolveWorkspaceDocumentStatus scans every open change, not just the first", () => {
+  // The bug this replaced: both list pages read `pendingPRs[0]` and stopped,
+  // so a second change asking for work was invisible on the row.
+  expect(
+    resolveWorkspaceDocumentStatus({
+      latestTag: { version: 3 },
+      pendingPRs: [
+        { approvalState: "in_review" },
+        { approvalState: "changes_requested" },
+      ],
+    }),
+  ).toBe("changes_requested");
+});
+
+test("resolveWorkspaceDocumentStatus separates published from ready-to-publish", () => {
+  // Both used to render "Approved" on the list, which made a document with
+  // nothing outstanding look identical to one waiting to be published.
+  expect(
+    resolveWorkspaceDocumentStatus({
+      latestTag: { version: 3 },
+      pendingPRs: [],
+    }),
+  ).toBe("published");
+
+  expect(
+    resolveWorkspaceDocumentStatus({
+      latestTag: { version: 3 },
+      pendingPRs: [{ approvalState: "approved" }],
+    }),
+  ).toBe("approved");
+
+  expect(
+    resolveWorkspaceDocumentStatus({ latestTag: null, pendingPRs: [] }),
+  ).toBe("draft");
 });
 
 test("parseSubmissionSummary rewrites the generated upload body", () => {

--- a/apps/app/documentDisplay.ts
+++ b/apps/app/documentDisplay.ts
@@ -81,9 +81,12 @@ export function getApprovalStateBadgeClass(state: string): string {
 }
 
 /**
- * The one-line answer to "where does this document stand right now?" — the
- * question the whole page exists to answer, so it is derived once and shown in
- * the header rather than inferred from three separate cards.
+ * The one-line answer to "where does this document stand right now?"
+ *
+ * A document page has room to say that a version is published *and* another is
+ * in review; a row in a list does not, so a list has to pick one word. This
+ * picks it, worst news first: an open change asking for work outranks an open
+ * change that is ready, which outranks anything already on the record.
  */
 export function resolveDocumentStatus(params: {
   hasPublishedVersion: boolean;
@@ -99,6 +102,22 @@ export function resolveDocumentStatus(params: {
   return hasPublishedVersion ? "published" : "draft";
 }
 
+/**
+ * The same question, asked of a row in the workspace document list.
+ *
+ * Structurally typed rather than importing `WorkspaceDocumentSummary`, so this
+ * module stays free of schema imports and testable with a plain object.
+ */
+export function resolveWorkspaceDocumentStatus(doc: {
+  latestTag: unknown | null;
+  pendingPRs: { approvalState: string }[];
+}): DocumentStatus {
+  return resolveDocumentStatus({
+    hasPublishedVersion: doc.latestTag !== null,
+    openApprovalStates: doc.pendingPRs.map((pr) => pr.approvalState),
+  });
+}
+
 export function getDocumentStatusLabel(status: DocumentStatus): string {
   switch (status) {
     case "published":
@@ -110,7 +129,7 @@ export function getDocumentStatusLabel(status: DocumentStatus): string {
     case "in_review":
       return "In review";
     default:
-      return "No version yet";
+      return "Draft";
   }
 }
 

--- a/apps/app/routes.test.ts
+++ b/apps/app/routes.test.ts
@@ -59,6 +59,32 @@ test("getRoute maps the changes and history tabs", () => {
   });
 });
 
+test("getRoute gives every change its own page", () => {
+  expect(getRoute("/docs/alice/quarterly-report/changes/7")).toEqual({
+    kind: "document",
+    owner: "alice",
+    repo: "quarterly-report",
+    tab: "changes",
+    changeNumber: 7,
+  });
+
+  expect(
+    routeToPath({
+      kind: "document",
+      owner: "alice",
+      repo: "quarterly-report",
+      tab: "changes",
+      changeNumber: 7,
+    }),
+  ).toBe("/docs/alice/quarterly-report/changes/7");
+});
+
+test("a non-numeric change segment is not a change page", () => {
+  expect(getRoute("/docs/alice/quarterly-report/changes/latest")).toEqual({
+    kind: "home",
+  });
+});
+
 test("getRoute falls back to home for an unknown document tab", () => {
   expect(getRoute("/docs/alice/quarterly-report/nonsense")).toEqual({
     kind: "home",

--- a/apps/app/routes.ts
+++ b/apps/app/routes.ts
@@ -14,6 +14,11 @@ export type AppRoute =
       owner: string;
       repo: string;
       tab: DocumentTab;
+      /**
+       * One change, on its own page. Only ever set on the `changes` tab —
+       * reviewing #3 should not mean scrolling past #4 through #10.
+       */
+      changeNumber?: number;
     };
 
 /**
@@ -81,6 +86,19 @@ export function getRoute(pathname: string): AppRoute {
     return { kind: "billing" };
   }
 
+  const changeMatch = normalizedPath.match(
+    /^\/docs\/([^/]+)\/([^/]+)\/changes\/(\d+)$/,
+  );
+  if (changeMatch) {
+    return {
+      kind: "document",
+      owner: changeMatch[1]!,
+      repo: changeMatch[2]!,
+      tab: "changes",
+      changeNumber: Number(changeMatch[3]),
+    };
+  }
+
   const docTabMatch = normalizedPath.match(
     /^\/docs\/([^/]+)\/([^/]+)\/([^/]+)$/,
   );
@@ -124,6 +142,9 @@ export function routeToPath(route: AppRoute): string {
     case "document": {
       const base = `/docs/${route.owner}/${route.repo}`;
       if (route.tab === "overview") return base;
+      if (route.tab === "changes" && route.changeNumber !== undefined) {
+        return `${base}/changes/${route.changeNumber}`;
+      }
       return `${base}/${DOCUMENT_TAB_PATHS[route.tab]}`;
     }
     case "documents":

--- a/services/api/gitea-client/pullRequests.ts
+++ b/services/api/gitea-client/pullRequests.ts
@@ -114,6 +114,10 @@ function withApprovalState(
 ): PullRequestWithApprovalState {
   return {
     ...pullRequest,
+    // The branch the submitted version lives on. Declared in the response
+    // contract but never populated, which left the browser with no ref to
+    // read or download the file under review from.
+    branchName: pullRequest.head?.ref ?? "",
     approvalState: resolveApprovalState(pullRequest, reviews),
   };
 }

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -1121,13 +1121,18 @@ async function resolveLatestUploadRef(
     state: "open",
   });
 
-  const uploadPullRequests = pullRequests
-    .filter((pullRequest) =>
-      (pullRequest.head?.ref ?? "").startsWith("upload/"),
-    )
-    .sort((left, right) => (right.number ?? 0) - (left.number ?? 0));
+  const newestFirst = [...pullRequests].sort(
+    (left, right) => (right.number ?? 0) - (left.number ?? 0),
+  );
 
-  return uploadPullRequests[0]?.head?.ref ?? null;
+  const uploadPullRequests = newestFirst.filter((pullRequest) =>
+    (pullRequest.head?.ref ?? "").startsWith("upload/"),
+  );
+
+  // A document whose first version is still under review has no file on
+  // `main` at all. Bindersnap's own uploads win, but any open branch beats
+  // telling the reviewer there is no file to read.
+  return uploadPullRequests[0]?.head?.ref ?? newestFirst[0]?.head?.ref ?? null;
 }
 
 function readInputString(

--- a/tests/document-download.pw.ts
+++ b/tests/document-download.pw.ts
@@ -32,6 +32,7 @@ import {
   installMemorySessionStorage,
   makeClient,
   navigateToDocument,
+  openDocumentChange,
   openDocumentTab,
   openNewDocumentModal,
   pollUntil,
@@ -156,8 +157,8 @@ test.describe("Document download", () => {
     await signInAsAlice(page);
     await navigateToDocument(page, cardSearchText);
 
-    // Reviewing lives on its own tab now
-    await openDocumentTab(page, "Changes");
+    // Each change has its own page; the review controls live there.
+    await openDocumentChange(page);
 
     // The Publish button must appear now that the PR is approved
     await expect(
@@ -277,7 +278,7 @@ test.describe("Document download", () => {
     await navigateToDocument(page, cardSearchText);
 
     // Publish v2
-    await openDocumentTab(page, "Changes");
+    await openDocumentChange(page);
     await expect(
       page.getByRole("button", {
         name: "Publish as Official Version",

--- a/tests/document-version-upload.pw.ts
+++ b/tests/document-version-upload.pw.ts
@@ -31,6 +31,7 @@ import {
   installMemorySessionStorage,
   makeClient,
   navigateToDocument,
+  openDocumentChange,
   openDocumentTab,
   openNewDocumentModal,
   pollUntil,
@@ -156,8 +157,8 @@ test.describe("UI document version upload flow", () => {
     await signInAsAlice(page);
     await navigateToDocument(page, cardSearchText);
 
-    // Reviewing lives on its own tab now
-    await openDocumentTab(page, "Changes");
+    // Each change has its own page; the review controls live there.
+    await openDocumentChange(page);
 
     // The Publish button should be visible (PR is approved and alice can merge)
     await expect(
@@ -261,7 +262,7 @@ test.describe("UI document version upload flow", () => {
     await navigateToDocument(page, cardSearchText);
 
     // Publish
-    await openDocumentTab(page, "Changes");
+    await openDocumentChange(page);
     await expect(
       page.getByRole("button", {
         name: "Publish as Official Version",

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -428,16 +428,55 @@ export async function openDocumentTab(
   await control.click();
 }
 
+/**
+ * Open one change's own page.
+ *
+ * The Changes tab is an index of what is waiting on a decision; Approve,
+ * Request Changes and Publish live on each change's own page, so getting to
+ * them means opening a row. Gitea returns pull requests newest first, so
+ * `"last"` is the oldest open change.
+ */
+export async function openDocumentChange(
+  page: Page,
+  which: "first" | "last" = "first",
+): Promise<void> {
+  await openDocumentTab(page, "Changes");
+  const rows = page.locator(".change-row-btn");
+  await expect(rows.first()).toBeVisible({ timeout: 30_000 });
+  await (which === "last" ? rows.last() : rows.first()).click();
+  await expect(page.locator(".change-detail")).toBeVisible({ timeout: 15_000 });
+}
+
+/** Open the first change if there is one. Returns false when the list is empty. */
+async function openFirstChangeIfAny(page: Page): Promise<boolean> {
+  const row = page.locator(".change-row-btn").first();
+  const hasRow = await row.isVisible({ timeout: 3_000 }).catch(() => false);
+  if (!hasRow) return false;
+  await row.click();
+  return await page
+    .locator(".change-detail")
+    .isVisible({ timeout: 10_000 })
+    .catch(() => false);
+}
+
+/** Assert how many changes the Changes tab lists. */
+export async function expectChangeRowCount(
+  page: Page,
+  count: number,
+  timeout = 30_000,
+): Promise<void> {
+  await expect(page.locator(".change-row")).toHaveCount(count, { timeout });
+}
+
 /** Assert the header reports version `version` as the official record. */
 export async function expectPublishedVersion(
   page: Page,
   version: number,
   timeout = 30_000,
 ): Promise<void> {
-  await expect(page.locator(".doc-header-facts")).toContainText(
-    `v${version} approved`,
-    { timeout },
-  );
+  await expect(page.locator(".doc-version-pill")).toHaveText(`v${version}`, {
+    timeout,
+  });
 }
 
 /** Assert how many changes are waiting on a decision, per the Changes tab. */
@@ -476,6 +515,8 @@ export async function waitForNoPendingReviews(
   while (Date.now() < deadline) {
     // Reviewing happens on the Changes tab, so make sure we are on it.
     await openDocumentTab(page, "Changes").catch(() => undefined);
+    // …and the publish button lives on the change's own page, not the index.
+    await openFirstChangeIfAny(page);
 
     // New UI: publish button is "Publish as Official Version"
     const publishButton = page.getByRole("button", {
@@ -525,7 +566,7 @@ export async function waitForNoPendingReviews(
     if (isVisible) return;
 
     const mergeErrorLocator = page
-      .locator(".vault-pr-item")
+      .locator(".change-detail")
       .locator('[role="alert"]');
     const hasMergeError = await mergeErrorLocator
       .isVisible({ timeout: 500 })

--- a/tests/merge-conflict-resolution.pw.ts
+++ b/tests/merge-conflict-resolution.pw.ts
@@ -23,12 +23,14 @@
 import { expect, test } from "@playwright/test";
 
 import {
+  expectChangeRowCount,
   expectOpenChangeCount,
   expectPublishedVersion,
   expectedPrefilledDocumentName,
   GITEA_BOB_USER,
   installMemorySessionStorage,
   navigateToDocument,
+  openDocumentChange,
   openDocumentTab,
   openNewDocumentModal,
   openCollaboratorsTab,
@@ -126,7 +128,7 @@ test.describe("Merge conflict resolution on publish", () => {
     await navigateToDocument(page, cardSearchText);
 
     // Bob approves v1 on the Changes tab — two-step confirm flow
-    await openDocumentTab(page, "Changes");
+    await openDocumentChange(page);
     await expect(page.getByRole("button", { name: "Approve" })).toBeVisible({
       timeout: 30_000,
     });
@@ -147,7 +149,7 @@ test.describe("Merge conflict resolution on publish", () => {
     // Switch back to Alice to publish v1
     await signInAsAlice(page);
     await navigateToDocument(page, cardSearchText);
-    await openDocumentTab(page, "Changes");
+    await openDocumentChange(page);
 
     await expect(
       page.getByRole("button", {
@@ -217,18 +219,16 @@ test.describe("Merge conflict resolution on publish", () => {
     // Both PRs have the same "Upload v2:" title because version numbering is
     // based on published tags only — since neither is published yet, both get
     // "Upload v2:". Use position-based selection instead: Gitea returns PRs
-    // newest-first (descending by PR number), so .last() is the older PR
+    // newest-first (descending by PR number), so the last row is the older PR
     // (lower PR number, created first). We approve the older PR first so it
     // can be published cleanly before the newer PR creates a conflict.
     await signInAsBob(page);
     await navigateToDocument(page, cardSearchText);
     await openDocumentTab(page, "Changes");
+    await expectChangeRowCount(page, 2);
+    await openDocumentChange(page, "last");
 
-    await expect(page.locator(".vault-pr-item")).toHaveCount(2, {
-      timeout: 30_000,
-    });
-    const firstPr = page.locator(".vault-pr-item").last();
-    await firstPr.getByRole("button", { name: "Approve" }).click();
+    await page.getByRole("button", { name: "Approve" }).click();
     // Confirm the approval in the two-step confirm dialog
     await expect(
       page.getByRole("button", { name: "Confirm Approval" }),
@@ -236,15 +236,18 @@ test.describe("Merge conflict resolution on publish", () => {
       timeout: 5_000,
     });
     await page.getByRole("button", { name: "Confirm Approval" }).click();
-    await expect(firstPr.locator(".vault-status-approved")).toBeVisible({
+    await expect(
+      page.locator(".change-detail .vault-status-approved"),
+    ).toBeVisible({
       timeout: 30_000,
     });
 
     // --- Alice publishes v2 ---
-    // Only v2 is approved, so there is exactly one Publish button.
+    // Both changes are still open and only v2 is approved, so open the same
+    // older change Bob just approved — the newer one has no Publish button.
     await signInAsAlice(page);
     await navigateToDocument(page, cardSearchText);
-    await openDocumentTab(page, "Changes");
+    await openDocumentChange(page, "last");
 
     await expect(
       page.getByRole("button", {
@@ -269,12 +272,10 @@ test.describe("Merge conflict resolution on publish", () => {
     await signInAsBob(page);
     await navigateToDocument(page, cardSearchText);
     await openDocumentTab(page, "Changes");
+    await expectChangeRowCount(page, 1);
+    await openDocumentChange(page);
 
-    await expect(page.locator(".vault-pr-item")).toHaveCount(1, {
-      timeout: 30_000,
-    });
-    const secondPr = page.locator(".vault-pr-item");
-    await secondPr.getByRole("button", { name: "Approve" }).click();
+    await page.getByRole("button", { name: "Approve" }).click();
     // Confirm the approval in the two-step confirm dialog
     await expect(
       page.getByRole("button", { name: "Confirm Approval" }),
@@ -282,14 +283,16 @@ test.describe("Merge conflict resolution on publish", () => {
       timeout: 5_000,
     });
     await page.getByRole("button", { name: "Confirm Approval" }).click();
-    await expect(secondPr.locator(".vault-status-approved")).toBeVisible({
+    await expect(
+      page.locator(".change-detail .vault-status-approved"),
+    ).toBeVisible({
       timeout: 30_000,
     });
 
     // --- Alice publishes v3 (conflict resolution path) ---
     await signInAsAlice(page);
     await navigateToDocument(page, cardSearchText);
-    await openDocumentTab(page, "Changes");
+    await openDocumentChange(page);
 
     await expect(
       page.getByRole("button", {


### PR DESCRIPTION
Fixes four complaints about `/docs/:username/:document`.

## Every change gets its own page

`/docs/:owner/:repo/changes/:number`. The Changes tab is now an index — one row per open change, GitHub-style — so reviewing #3 no longer means scrolling past #4 through #10.

## You can read and download the review material

The change page leads with **the version under review**: the submitted file, previewed inline from that change's own branch, with a Download button. The decision controls and the discussion follow beneath it. You cannot sign off on something you have not read.

Two server-side gaps were in the way:

- `branchName` is declared in the document-detail response contract but was never populated, so the browser had no ref to read the file from. `withApprovalState` now fills it from the pull request head.
- The canonical-file fallback only looked at `upload/*` branches, so a document whose first version is still under review reported "no file". It now falls back to any open pull request branch, with `upload/*` still winning.

## The header states the version, not a status

A document can have v3 published and v4 in review at the same time, so a single status word was always going to be wrong. The pill now reads `v3` — or "No version yet" — and the fact line beside it carries the approval date.

`resolveDocumentStatus` / `getDocumentStatusLabel` in `documentDisplay.ts` are now unused. Left in place with their tests rather than stripped in this PR.

## The page holds still

`.app-main` is a grid whose single implicit column sized to its content, and `.app-page-shell` used `margin: 0 auto` with no width — so the page width was whatever the active tab happened to render. Measured on the same document at a 1440px viewport, before:

| Tab | Shell width | Header left edge |
| --- | --- | --- |
| Document | 900px | 299px |
| Changes | 736px | 381px |
| History | 766px | 366px |
| Team | 1040px | 229px |
| Settings | 862px | 318px |

After: **1040px / 229px on all five**. Pinning the grid track and giving the shell `width: 100%` is the whole fix. The header also stops being a floating card and becomes a page header on a rule.

## Editor visuals

No changes under `packages/editor/` — no `bun run sync-demo` needed.

## Verification

- `bun run test` — 302 pass, 0 fail
- Driven in the local Docker stack as both the submitter (own-submission notice, no decision panel) and a reviewer (Approve / Request Changes present); confirmed the Download button hits `download?ref=feature%2Facme-renewal` → 200
- Re-measured every tab's width; checked mobile at 375px for horizontal overflow (none)
- No console errors on a fresh load

🤖 Generated with [Claude Code](https://claude.com/claude-code)