### PR TITLE
docs: approved workspace UX redesign spec and mockups

### DIFF
--- a/docs/design/mockups/ChangeReview.dc.html
+++ b/docs/design/mockups/ChangeReview.dc.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&family=Geist:wght@300..700&family=Geist+Mono:wght@400..600&display=swap">
+  <style>
+    body { margin: 0; font-family: 'Geist', system-ui, -apple-system, sans-serif; background: #fafaf7; color: #1c1917; -webkit-font-smoothing: antialiased; }
+    a { color: #c94d1a; text-decoration: none; } a:hover { color: #e85d26; }
+    .nav { display: flex; align-items: center; gap: 24px; height: 64px; padding: 0 32px; border-bottom: 1px solid rgba(28,25,23,0.1); background: rgba(250,250,247,0.88); }
+    .btn-green { display: inline-flex; align-items: center; gap: 6px; background: #16a34a; color: #ffffff; border: none; border-radius: 9999px; padding: 10px 20px; font-family: 'Geist', sans-serif; font-size: 13.5px; font-weight: 600; cursor: pointer; }
+    .btn-ghost { display: inline-flex; align-items: center; gap: 6px; background: #ffffff; color: #1c1917; border: 1.5px solid rgba(28,25,23,0.1); border-radius: 8px; padding: 9px 16px; font-family: 'Geist', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; }
+    .avatar { border-radius: 9999px; display: flex; align-items: center; justify-content: center; font-weight: 600; flex-shrink: 0; }
+    .pill { display: inline-flex; align-items: center; gap: 5px; font-family: 'Geist Mono', monospace; font-size: 11px; font-weight: 500; letter-spacing: 0.04em; border-radius: 9999px; padding: 3px 10px; white-space: nowrap; }
+    .pill--approved { background: rgba(22,163,74,0.1); color: #16a34a; }
+    .tab { font-size: 14px; font-weight: 500; color: #78716c; padding: 10px 2px; border-bottom: 2px solid transparent; display: inline-flex; align-items: center; gap: 6px; }
+    .tab--on { color: #1c1917; border-bottom-color: #e85d26; }
+    .tabcount { font-family: 'Geist Mono', monospace; font-size: 10.5px; background: #f5f0e8; color: #78716c; border-radius: 9999px; padding: 1px 7px; }
+    .meta { font-size: 12.5px; color: #78716c; }
+    .rstate { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; color: #78716c; }
+    /* Timeline: a spine on the page, not a box. Dots are fully opaque. */
+    .timeline { position: relative; padding-left: 40px; display: flex; flex-direction: column; gap: 18px; }
+    .timeline::before { content: ""; position: absolute; left: 13px; top: 8px; bottom: 8px; width: 1.5px; background: #ebeae7; }
+    .tdot { position: absolute; left: -40px; top: 0; width: 28px; height: 28px; border-radius: 9999px; background: #fafaf7; border: 1.5px solid #e4e3e0; display: flex; align-items: center; justify-content: center; z-index: 1; }
+    .tdot--green { background: #e3f1e6; border-color: #b6e0c3; }
+    .tentry { position: relative; }
+    .tevent { display: flex; align-items: center; gap: 8px; min-height: 28px; padding-top: 5px; }
+    .tcard { background: #ffffff; border: 1px solid rgba(28,25,23,0.1); border-radius: 12px; padding: 16px 18px; }
+    .chead { display: flex; align-items: center; gap: 8px; }
+    .csub { border-top: 1px solid rgba(28,25,23,0.06); margin-top: 12px; padding-top: 12px; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; min-height: 1280px; background: #fafaf7; display: flex; flex-direction: column; position: relative;">
+
+  <!-- Top nav -->
+  <header class="nav">
+    <div style="display: flex; align-items: center; gap: 10px;">
+      <div style="width: 28px; height: 28px; border-radius: 8px; background: #e85d26; display: flex; align-items: center; justify-content: center;">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 2h8v12l-4-3-4 3V2z" stroke="#ffffff" stroke-width="1.6" stroke-linejoin="round"/></svg>
+      </div>
+      <span style="font-family: 'Lora', Georgia, serif; font-weight: 600; font-size: 16px;">Bindersnap</span>
+    </div>
+    <span style="color: #a8a29e;">/</span>
+    <span style="font-size: 14px; font-weight: 500;">Vendor Agreement</span>
+    <div style="flex: 1;"></div>
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none"><path d="M10 2a5 5 0 0 0-5 5v3l-1.5 3h13L15 10V7a5 5 0 0 0-5-5z" stroke="#78716c" stroke-width="1.5" stroke-linejoin="round"/><path d="M8 16a2 2 0 0 0 4 0" stroke="#78716c" stroke-width="1.5"/></svg>
+    <div class="avatar" style="width: 32px; height: 32px; font-size: 12px; background: rgba(29,78,216,0.1); color: #1d4ed8;">DG</div>
+  </header>
+
+  <!-- Body -->
+  <main style="width: 1080px; margin: 0 auto; padding: 32px 0 96px 0;">
+
+    <!-- Document header stays put: the review lives INSIDE the Changes tab -->
+    <div style="display: flex; align-items: flex-start; gap: 20px; margin-bottom: 8px;">
+      <div style="flex: 1;">
+        <h1 style="font-family: 'Lora', Georgia, serif; font-size: 26px; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 6px 0;">Vendor Agreement</h1>
+        <div style="display: flex; align-items: center; gap: 12px;">
+          <span class="pill pill--approved">v3 · Current</span>
+          <span class="meta">Approved Jan 12, 2026</span>
+        </div>
+      </div>
+    </div>
+    <nav style="display: flex; gap: 24px; border-bottom: 1px solid rgba(28,25,23,0.1); margin-bottom: 24px;">
+      <span class="tab">Document</span>
+      <span class="tab tab--on">Changes <span class="tabcount">2</span></span>
+      <span class="tab">History</span>
+      <span class="tab">Access &amp; approvals</span>
+    </nav>
+
+    <div style="width: 820px;">
+      <a href="#" style="font-size: 13px; font-weight: 500; color: #78716c;">← All changes</a>
+
+      <!-- Change header -->
+      <div style="margin: 14px 0 6px 0; display: flex; align-items: flex-start; gap: 16px;">
+        <div style="flex: 1;">
+          <h2 style="font-family: 'Lora', Georgia, serif; font-size: 22px; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 6px 0;">Updated liability clause</h2>
+          <p class="meta" style="margin: 0 0 10px 0; font-size: 13.5px;">Maya opened this on Aug 20 · becomes <strong style="color: #1c1917;">v4</strong> when published</p>
+          <p style="margin: 0; font-size: 14px; line-height: 1.6; color: #44403c; max-width: 620px;">Legal asked us to cap liability at 12 months of fees instead of the flat amount. Section 8.2 is rewritten and the indemnification cross-reference in 9.1 now points at the new cap. Nothing else changed.</p>
+        </div>
+        <!-- Approval meter -->
+        <div style="text-align: right; flex-shrink: 0;">
+          <div style="display: flex; gap: 4px; justify-content: flex-end; margin-bottom: 5px;">
+            <div style="width: 26px; height: 6px; border-radius: 9999px; background: #16a34a;"></div>
+            <div style="width: 26px; height: 6px; border-radius: 9999px; background: #16a34a;"></div>
+            <div style="width: 26px; height: 6px; border-radius: 9999px; background: #ede8df;"></div>
+          </div>
+          <span class="meta" style="font-family: 'Geist Mono', monospace; font-size: 11px;">2 of 3 approvals</span>
+        </div>
+      </div>
+
+      <!-- Proposed version: fixed chrome, same place on every change request -->
+      <div style="display: flex; align-items: center; gap: 14px; background: #ffffff; border: 1px solid rgba(28,25,23,0.1); border-radius: 12px; padding: 14px 18px; margin: 18px 0 20px 0;">
+        <div style="width: 36px; height: 36px; border-radius: 8px; background: #f5f0e8; color: #78716c; display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 1.5h5.5L13 5v9.5H4V1.5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/><path d="M9.5 1.5V5H13" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14px; font-weight: 600;">Proposed version</div>
+          <div class="meta" style="font-family: 'Geist Mono', monospace; font-size: 11.5px;">vendor-agreement.docx · update 2 of 2 · Aug 21</div>
+        </div>
+        <a href="#" style="font-size: 12.5px; font-weight: 500; color: #78716c;">All updates</a>
+        <button class="btn-ghost" type="button">Open</button>
+      </div>
+
+      <!-- Reviewers -->
+      <div style="display: flex; align-items: center; gap: 18px; margin-bottom: 26px;">
+        <span class="meta" style="font-family: 'Geist Mono', monospace; font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;">Reviewers</span>
+        <div class="rstate">
+          <div class="avatar" style="width: 26px; height: 26px; font-size: 10.5px; background: rgba(22,163,74,0.1); color: #16a34a;">PS</div>
+          Priya
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5L13 5" stroke="#16a34a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+        <div class="rstate">
+          <div class="avatar" style="width: 26px; height: 26px; font-size: 10.5px; background: rgba(124,58,237,0.1); color: #7c3aed;">TW</div>
+          Tom
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5L13 5" stroke="#16a34a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+        <div class="rstate">
+          <div class="avatar" style="width: 26px; height: 26px; font-size: 10.5px; background: rgba(29,78,216,0.1); color: #1d4ed8;">DG</div>
+          You
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6" stroke="#a8a29e" stroke-width="1.5"/><path d="M8 4.5V8l2.5 1.5" stroke="#a8a29e" stroke-width="1.5" stroke-linecap="round"/></svg>
+        </div>
+        <button class="btn-ghost" type="button" style="padding: 5px 12px; font-size: 12.5px; border-radius: 9999px;">
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none"><path d="M6 1v10M1 6h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+          Add reviewer
+        </button>
+      </div>
+
+      <!-- Timeline: comments are cards on the spine; events sit on the paper -->
+      <div class="timeline">
+
+        <div class="tentry">
+          <div class="tdot">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M2 8h8M10 8l-3-3M10 8l-3 3" stroke="#78716c" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M13 3v10" stroke="#78716c" stroke-width="1.5" stroke-linecap="round"/></svg>
+          </div>
+          <div class="tevent"><span class="meta"><strong style="color: #44403c;">Maya</strong> opened this change request · Aug 20, 9:14 AM</span></div>
+        </div>
+
+        <!-- Unresolved thread, expanded: chat glyph on the spine, avatars in the card -->
+        <div class="tentry">
+          <div class="tdot">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M14 10a1.5 1.5 0 0 1-1.5 1.5H6l-4 3V3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5V10z" stroke="#78716c" stroke-width="1.4" stroke-linejoin="round"/></svg>
+          </div>
+          <div class="tcard">
+            <div class="chead">
+              <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(124,58,237,0.1); color: #7c3aed;">TW</div>
+              <strong style="font-size: 13.5px;">Tom</strong>
+              <span class="meta">Aug 20</span>
+              <span style="flex: 1;"></span>
+              <span class="meta" style="display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px;"><span style="width: 6px; height: 6px; border-radius: 9999px; background: #e85d26;"></span>Unresolved</span>
+              <a href="#" style="font-size: 12px; color: #a8a29e; font-weight: 400;">Collapse</a>
+            </div>
+            <p style="margin: 8px 0 0 0; font-size: 14px; line-height: 1.55; color: #44403c;">Does the 12-month cap include indemnification claims, or only direct damages?</p>
+            <div class="csub">
+              <div class="chead">
+                <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(180,83,9,0.08); color: #b45309;">MK</div>
+                <strong style="font-size: 13.5px;">Maya</strong>
+                <span class="meta">Aug 21</span>
+              </div>
+              <p style="margin: 8px 0 0 0; font-size: 14px; line-height: 1.55; color: #44403c;">Only direct damages — indemnification stays uncapped per 9.1. I added the cross-reference in the latest update.</p>
+            </div>
+            <div style="display: flex; justify-content: flex-end; gap: 14px; margin-top: 12px;">
+              <a href="#" style="font-size: 12.5px; font-weight: 500; color: #78716c;">Resolve</a>
+              <a href="#" style="font-size: 12.5px; font-weight: 500; color: #78716c;">Reply</a>
+            </div>
+          </div>
+        </div>
+
+        <!-- Proposal update event -->
+        <div class="tentry">
+          <div class="tdot">
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M13.5 8A5.5 5.5 0 1 1 8 2.5c2 0 3.8 1.1 4.8 2.7" stroke="#78716c" stroke-width="1.5" stroke-linecap="round"/><path d="M13 2v3.5H9.5" stroke="#78716c" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </div>
+          <div class="tevent"><span class="meta"><strong style="color: #44403c;">Maya</strong> updated the proposed version <span style="font-family: 'Geist Mono', monospace; font-size: 11px;">(update 2)</span> · Aug 21 · earlier approvals were reset · <a href="#" style="font-size: 12.5px;">compare</a></span></div>
+        </div>
+
+        <!-- Approvals: the loud green moments -->
+        <div class="tentry">
+          <div class="tdot tdot--green">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5L13 5" stroke="#16a34a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </div>
+          <div class="tevent"><span class="meta" style="color: #44403c;"><strong>Priya</strong> <strong style="color: #16a34a;">approved</strong> · Aug 21 · "Matches what legal sent over."</span></div>
+        </div>
+
+        <div class="tentry">
+          <div class="tdot tdot--green">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5L13 5" stroke="#16a34a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </div>
+          <div class="tevent"><span class="meta" style="color: #44403c;"><strong>Tom</strong> <strong style="color: #16a34a;">approved</strong> · Aug 22</span></div>
+        </div>
+
+        <!-- Resolved thread: still a comment card, collapsed, quiet marker, toggle at the top -->
+        <div class="tentry">
+          <div class="tdot">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M14 10a1.5 1.5 0 0 1-1.5 1.5H6l-4 3V3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5V10z" stroke="#78716c" stroke-width="1.4" stroke-linejoin="round"/></svg>
+          </div>
+          <div class="tcard" style="padding: 13px 18px;">
+            <div class="chead">
+              <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(22,163,74,0.1); color: #16a34a;">PS</div>
+              <strong style="font-size: 13.5px;">Priya</strong>
+              <span class="meta">Aug 20</span>
+              <span style="flex: 1;"></span>
+              <span class="meta" style="display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px; color: #a8a29e;">
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none"><path d="M4 8.5l2.5 2.5L12 5.5" stroke="#a8a29e" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Resolved
+              </span>
+              <a href="#" style="font-size: 12px; color: #a8a29e; font-weight: 400;">Show 2 replies</a>
+            </div>
+            <p style="margin: 6px 0 0 0; font-size: 13.5px; line-height: 1.5; color: #78716c;">Should the renewal date move to Jan 1 to match the new cap?</p>
+          </div>
+        </div>
+
+        <!-- Reply box -->
+        <div class="tentry">
+          <div class="tdot">
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M11.5 2.5l2 2L6 12l-2.7.7L4 10l7.5-7.5z" stroke="#78716c" stroke-width="1.4" stroke-linejoin="round"/></svg>
+          </div>
+          <div style="border: 1.5px solid rgba(28,25,23,0.1); border-radius: 12px; padding: 12px 16px; font-size: 14px; color: #a8a29e; background: #ffffff;">Add a comment…</div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+  <!-- Floating decision pill: always reachable, no scrolling to decide -->
+  <div style="position: absolute; right: 48px; bottom: 40px; display: flex; align-items: center; gap: 10px; background: #ffffff; border: 1px solid rgba(28,25,23,0.1); border-radius: 9999px; padding: 10px 12px; box-shadow: 0 20px 60px rgba(28,25,23,0.15), 0 4px 12px rgba(28,25,23,0.08);">
+    <button class="btn-ghost" type="button" style="border-radius: 9999px;">Request changes</button>
+    <button class="btn-green" type="button">Approve</button>
+  </div>
+
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/mockups/DocumentDetail.dc.html
+++ b/docs/design/mockups/DocumentDetail.dc.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&family=Geist:wght@300..700&family=Geist+Mono:wght@400..600&display=swap">
+  <style>
+    body { margin: 0; font-family: 'Geist', system-ui, -apple-system, sans-serif; background: #fafaf7; color: #1c1917; -webkit-font-smoothing: antialiased; }
+    a { color: #c94d1a; text-decoration: none; } a:hover { color: #e85d26; }
+    .nav { display: flex; align-items: center; gap: 24px; height: 64px; padding: 0 32px; border-bottom: 1px solid rgba(28,25,23,0.1); background: rgba(250,250,247,0.88); }
+    .search { display: flex; align-items: center; gap: 8px; width: 260px; height: 36px; padding: 0 12px; background: #ffffff; border: 1.5px solid rgba(28,25,23,0.1); border-radius: 12px; color: #a8a29e; font-size: 13px; }
+    .btn-coral { display: inline-flex; align-items: center; gap: 6px; background: #e85d26; color: #ffffff; border: none; border-radius: 8px; padding: 9px 16px; font-family: 'Geist', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; }
+    .btn-ghost { display: inline-flex; align-items: center; gap: 6px; background: #ffffff; color: #1c1917; border: 1.5px solid rgba(28,25,23,0.1); border-radius: 8px; padding: 8px 14px; font-family: 'Geist', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; }
+    .avatar { width: 32px; height: 32px; border-radius: 9999px; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; flex-shrink: 0; }
+    .card { background: #ffffff; border: 1px solid rgba(28,25,23,0.1); border-radius: 16px; }
+    .pill { display: inline-flex; align-items: center; gap: 5px; font-family: 'Geist Mono', monospace; font-size: 11px; font-weight: 500; letter-spacing: 0.04em; border-radius: 9999px; padding: 3px 10px; white-space: nowrap; }
+    .pill--approved { background: rgba(22,163,74,0.1); color: #16a34a; }
+    .pill--review { background: rgba(232,93,38,0.1); color: #c94d1a; }
+    .tab { font-size: 14px; font-weight: 500; color: #78716c; padding: 10px 2px; border-bottom: 2px solid transparent; display: inline-flex; align-items: center; gap: 6px; }
+    .tab--on { color: #1c1917; border-bottom-color: #e85d26; }
+    .tabcount { font-family: 'Geist Mono', monospace; font-size: 10.5px; background: #f5f0e8; color: #78716c; border-radius: 9999px; padding: 1px 7px; }
+    .railtitle { font-family: 'Geist Mono', monospace; font-size: 11px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: #78716c; margin: 0 0 10px 0; }
+    .railrow { display: flex; align-items: center; gap: 10px; padding: 9px 0; border-top: 1px solid rgba(28,25,23,0.06); font-size: 13px; }
+    .meta { font-size: 12.5px; color: #78716c; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; min-height: 880px; background: #fafaf7; display: flex; flex-direction: column;">
+
+  <!-- Top nav -->
+  <header class="nav">
+    <div style="display: flex; align-items: center; gap: 10px;">
+      <div style="width: 28px; height: 28px; border-radius: 8px; background: #e85d26; display: flex; align-items: center; justify-content: center;">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 2h8v12l-4-3-4 3V2z" stroke="#ffffff" stroke-width="1.6" stroke-linejoin="round"/></svg>
+      </div>
+      <span style="font-family: 'Lora', Georgia, serif; font-weight: 600; font-size: 16px;">Bindersnap</span>
+    </div>
+    <span style="color: #a8a29e;">/</span>
+    <span style="font-size: 14px; font-weight: 500;">Vendor Agreement</span>
+    <div style="flex: 1;"></div>
+    <div class="search">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="4.5" stroke="#a8a29e" stroke-width="1.5"/><path d="M10.5 10.5L14 14" stroke="#a8a29e" stroke-width="1.5" stroke-linecap="round"/></svg>
+      <span>Search documents</span>
+    </div>
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none"><path d="M10 2a5 5 0 0 0-5 5v3l-1.5 3h13L15 10V7a5 5 0 0 0-5-5z" stroke="#78716c" stroke-width="1.5" stroke-linejoin="round"/><path d="M8 16a2 2 0 0 0 4 0" stroke="#78716c" stroke-width="1.5"/></svg>
+    <div class="avatar" style="background: rgba(29,78,216,0.1); color: #1d4ed8;">DG</div>
+  </header>
+
+  <!-- Body -->
+  <main style="width: 1080px; margin: 0 auto; padding: 32px 0 64px 0;">
+
+    <!-- Document header -->
+    <div style="display: flex; align-items: flex-start; gap: 20px; margin-bottom: 8px;">
+      <div style="flex: 1;">
+        <h1 style="font-family: 'Lora', Georgia, serif; font-size: 26px; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 6px 0;">Vendor Agreement</h1>
+        <div style="display: flex; align-items: center; gap: 12px;">
+          <span class="pill pill--approved">v3 · Current</span>
+          <span class="meta">Approved Jan 12, 2026</span>
+          <span class="meta" style="font-family: 'Geist Mono', monospace; font-size: 11.5px;">vendor-agreement.docx</span>
+        </div>
+      </div>
+      <button class="btn-coral" type="button">Submit new version</button>
+    </div>
+
+    <!-- Tabs -->
+    <nav style="display: flex; gap: 24px; border-bottom: 1px solid rgba(28,25,23,0.1); margin-bottom: 28px;">
+      <span class="tab tab--on">Document</span>
+      <span class="tab">Changes <span class="tabcount">2</span></span>
+      <span class="tab">History</span>
+      <span class="tab">Access &amp; approvals</span>
+    </nav>
+
+    <!-- Two-column: preview + rail -->
+    <div style="display: flex; gap: 28px; align-items: flex-start;">
+
+      <!-- Document preview -->
+      <div class="card" style="flex: 1; padding: 48px 56px; min-height: 540px;">
+        <div style="max-width: 620px; margin: 0 auto;">
+          <p style="font-family: 'Geist Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #a8a29e; margin: 0 0 18px 0;">Master services agreement</p>
+          <h2 style="font-family: 'Lora', Georgia, serif; font-size: 22px; font-weight: 600; margin: 0 0 20px 0;">Vendor Agreement</h2>
+          <div style="display: flex; flex-direction: column; gap: 10px;">
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 100%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 94%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 97%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 62%;"></div>
+            <div style="height: 18px;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 40%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 100%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 96%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 88%;"></div>
+            <div style="height: 18px;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 35%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 98%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 91%;"></div>
+            <div style="height: 10px; background: #f5f0e8; border-radius: 2px; width: 73%;"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right rail -->
+      <aside style="width: 280px; display: flex; flex-direction: column; gap: 24px;">
+
+        <section>
+          <p class="railtitle" style="color: #c94d1a;">Waiting on a decision</p>
+          <div class="card" style="padding: 14px 16px;">
+            <div style="font-size: 13.5px; font-weight: 500;">Updated liability clause</div>
+            <div class="meta" style="margin: 3px 0 8px 0;">Maya · 2h ago · 2 of 3 approvals</div>
+            <a href="#" style="font-size: 13px; font-weight: 600;">Review →</a>
+          </div>
+          <div class="card" style="padding: 14px 16px; margin-top: 10px;">
+            <div style="font-size: 13.5px; font-weight: 500;">Renewal terms for 2027</div>
+            <div class="meta" style="margin: 3px 0 8px 0;">Tom · yesterday · no approvals yet</div>
+            <a href="#" style="font-size: 13px; font-weight: 600;">Review →</a>
+          </div>
+        </section>
+
+        <section>
+          <p class="railtitle">Versions</p>
+          <div class="card" style="padding: 6px 16px;">
+            <div class="railrow" style="border-top: none;">
+              <span class="pill pill--approved">v3</span>
+              <span style="flex: 1;">Jan 12, 2026</span>
+              <span class="meta">Current</span>
+            </div>
+            <div class="railrow">
+              <span class="pill" style="background: #f5f0e8; color: #78716c;">v2</span>
+              <span style="flex: 1;">Nov 3, 2025</span>
+            </div>
+            <div class="railrow">
+              <span class="pill" style="background: #f5f0e8; color: #78716c;">v1</span>
+              <span style="flex: 1;">Sep 22, 2025</span>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <p class="railtitle">Team</p>
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <div class="avatar" style="width: 28px; height: 28px; font-size: 11px; background: rgba(29,78,216,0.1); color: #1d4ed8;">DG</div>
+            <div class="avatar" style="width: 28px; height: 28px; font-size: 11px; background: rgba(180,83,9,0.08); color: #b45309;">MK</div>
+            <div class="avatar" style="width: 28px; height: 28px; font-size: 11px; background: rgba(22,163,74,0.1); color: #16a34a;">PS</div>
+            <div class="avatar" style="width: 28px; height: 28px; font-size: 11px; background: rgba(124,58,237,0.1); color: #7c3aed;">TW</div>
+            <a href="#" style="font-size: 12.5px; font-weight: 500; margin-left: 4px;">Manage</a>
+          </div>
+        </section>
+
+      </aside>
+    </div>
+  </main>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/mockups/Documents.dc.html
+++ b/docs/design/mockups/Documents.dc.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&family=Geist:wght@300..700&family=Geist+Mono:wght@400..600&display=swap">
+  <style>
+    body { margin: 0; font-family: 'Geist', system-ui, -apple-system, sans-serif; background: #fafaf7; color: #1c1917; -webkit-font-smoothing: antialiased; }
+    a { color: #c94d1a; text-decoration: none; } a:hover { color: #e85d26; }
+    .nav { display: flex; align-items: center; gap: 24px; height: 64px; padding: 0 32px; border-bottom: 1px solid rgba(28,25,23,0.1); background: rgba(250,250,247,0.88); }
+    .navlink { font-size: 14px; font-weight: 500; color: #78716c; padding: 6px 10px; border-radius: 8px; }
+    .navlink--on { color: #1c1917; background: #f5f0e8; }
+    .search { display: flex; align-items: center; gap: 8px; width: 260px; height: 36px; padding: 0 12px; background: #ffffff; border: 1.5px solid rgba(28,25,23,0.1); border-radius: 12px; color: #a8a29e; font-size: 13px; }
+    .btn-coral { display: inline-flex; align-items: center; gap: 6px; background: #e85d26; color: #ffffff; border: none; border-radius: 8px; padding: 9px 16px; font-family: 'Geist', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; }
+    .avatar { width: 32px; height: 32px; border-radius: 9999px; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; flex-shrink: 0; }
+    .card { background: #ffffff; border: 1px solid rgba(28,25,23,0.1); border-radius: 16px; }
+    .pill { display: inline-flex; align-items: center; gap: 5px; font-family: 'Geist Mono', monospace; font-size: 11px; font-weight: 500; letter-spacing: 0.04em; border-radius: 9999px; padding: 3px 10px; white-space: nowrap; }
+    .pill--review { background: rgba(232,93,38,0.1); color: #c94d1a; }
+    .pill--approved { background: rgba(22,163,74,0.1); color: #16a34a; }
+    .pill--waiting { background: #f5f0e8; color: #78716c; }
+    .rowitem { display: flex; align-items: center; gap: 14px; padding: 16px 20px; border-top: 1px solid rgba(28,25,23,0.06); }
+    .docicon { width: 36px; height: 36px; border-radius: 8px; background: #f5f0e8; color: #78716c; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+    .meta { font-size: 12.5px; color: #78716c; }
+    .chip { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 500; color: #78716c; padding: 6px 14px; border-radius: 9999px; border: 1px solid rgba(28,25,23,0.1); background: #ffffff; }
+    .chip--on { background: #1c1917; color: #f5f0e8; border-color: #1c1917; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; min-height: 840px; background: #fafaf7; display: flex; flex-direction: column;">
+
+  <!-- Top nav -->
+  <header class="nav">
+    <div style="display: flex; align-items: center; gap: 10px;">
+      <div style="width: 28px; height: 28px; border-radius: 8px; background: #e85d26; display: flex; align-items: center; justify-content: center;">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 2h8v12l-4-3-4 3V2z" stroke="#ffffff" stroke-width="1.6" stroke-linejoin="round"/></svg>
+      </div>
+      <span style="font-family: 'Lora', Georgia, serif; font-weight: 600; font-size: 16px;">Bindersnap</span>
+    </div>
+    <nav style="display: flex; align-items: center; gap: 4px;">
+      <span class="navlink">Home</span>
+      <span class="navlink navlink--on">Documents</span>
+    </nav>
+    <div style="flex: 1;"></div>
+    <div class="search">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="4.5" stroke="#a8a29e" stroke-width="1.5"/><path d="M10.5 10.5L14 14" stroke="#a8a29e" stroke-width="1.5" stroke-linecap="round"/></svg>
+      <span>Search documents</span>
+      <span style="margin-left: auto; font-family: 'Geist Mono', monospace; font-size: 11px; border: 1px solid rgba(28,25,23,0.1); border-radius: 4px; padding: 1px 5px;">/</span>
+    </div>
+    <button class="btn-coral" type="button">
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 1v10M1 6h10" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/></svg>
+      New document
+    </button>
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none"><path d="M10 2a5 5 0 0 0-5 5v3l-1.5 3h13L15 10V7a5 5 0 0 0-5-5z" stroke="#78716c" stroke-width="1.5" stroke-linejoin="round"/><path d="M8 16a2 2 0 0 0 4 0" stroke="#78716c" stroke-width="1.5"/></svg>
+    <div class="avatar" style="background: rgba(29,78,216,0.1); color: #1d4ed8;">DG</div>
+  </header>
+
+  <!-- Body -->
+  <main style="width: 880px; margin: 0 auto; padding: 36px 0 64px 0;">
+
+    <h1 style="font-family: 'Lora', Georgia, serif; font-size: 28px; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 18px 0;">Documents</h1>
+
+    <!-- Views: saved scopes + a person filter -->
+    <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 20px;">
+      <span class="chip chip--on">I contribute to</span>
+      <span class="chip">I own</span>
+      <span class="chip">Everything I can see</span>
+      <span style="width: 1px; height: 20px; background: rgba(28,25,23,0.1);"></span>
+      <span class="chip">
+        Owned by <strong style="font-weight: 600;">Jack</strong>
+        <svg width="10" height="10" viewBox="0 0 12 12" fill="none"><path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+      </span>
+      <span class="chip" style="border-style: dashed; color: #a8a29e;">
+        <svg width="11" height="11" viewBox="0 0 12 12" fill="none"><path d="M6 1v10M1 6h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+        Filter by person
+      </span>
+      <span style="flex: 1;"></span>
+      <span class="meta">Sorted by last updated</span>
+    </div>
+
+    <section class="card" style="overflow: hidden;">
+      <div class="rowitem" style="border-top: none;">
+        <div class="docicon" style="background: rgba(232,93,38,0.1); color: #c94d1a;">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 1.5h5.5L13 5v9.5H4V1.5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/><path d="M9.5 1.5V5H13" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Vendor Agreement</div>
+          <div class="meta">Jack owns · v3 · 2 open changes · updated 2h ago</div>
+        </div>
+        <span class="pill pill--review">Needs your review</span>
+      </div>
+      <div class="rowitem">
+        <div class="docicon">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 1.5h5.5L13 5v9.5H4V1.5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/><path d="M9.5 1.5V5H13" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Q3 Compliance Policy</div>
+          <div class="meta">You own · v3 · your v4 proposal in review · updated yesterday</div>
+        </div>
+        <span class="pill pill--waiting">In review</span>
+      </div>
+      <div class="rowitem">
+        <div class="docicon">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 1.5h5.5L13 5v9.5H4V1.5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/><path d="M9.5 1.5V5H13" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Data Retention Policy</div>
+          <div class="meta">You own · v1 · 1 open change, ready to publish · updated 3h ago</div>
+        </div>
+        <span class="pill pill--review">Ready to publish</span>
+      </div>
+      <div class="rowitem">
+        <div class="docicon">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 1.5h5.5L13 5v9.5H4V1.5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/><path d="M9.5 1.5V5H13" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Employee Handbook</div>
+          <div class="meta">Priya owns · v6 · no open changes · approved Aug 19</div>
+        </div>
+        <span class="pill pill--approved">Current</span>
+      </div>
+      <div class="rowitem">
+        <div class="docicon">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 1.5h5.5L13 5v9.5H4V1.5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/><path d="M9.5 1.5V5H13" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Incident Response Plan</div>
+          <div class="meta">Jack owns · v2 · no open changes · approved Aug 14</div>
+        </div>
+        <span class="pill pill--approved">Current</span>
+      </div>
+      <div class="rowitem">
+        <div class="docicon">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 1.5h5.5L13 5v9.5H4V1.5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/><path d="M9.5 1.5V5H13" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Mutual NDA</div>
+          <div class="meta">You own · v4 · no open changes · approved Jul 30</div>
+        </div>
+        <span class="pill pill--approved">Current</span>
+      </div>
+    </section>
+
+    <p style="margin: 14px 4px 0 4px; font-size: 12.5px; color: #a8a29e;">6 documents you contribute to</p>
+
+  </main>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/mockups/Main.dc.html
+++ b/docs/design/mockups/Main.dc.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&family=Geist:wght@300..700&family=Geist+Mono:wght@400..600&display=swap">
+  <style>
+    body { margin: 0; font-family: 'Geist', system-ui, -apple-system, sans-serif; background: #fafaf7; color: #1c1917; -webkit-font-smoothing: antialiased; }
+    a { color: #c94d1a; text-decoration: none; } a:hover { color: #e85d26; }
+    .nav { display: flex; align-items: center; gap: 24px; height: 64px; padding: 0 32px; border-bottom: 1px solid rgba(28,25,23,0.1); background: rgba(250,250,247,0.88); }
+    .navlink { font-size: 14px; font-weight: 500; color: #78716c; padding: 6px 10px; border-radius: 8px; }
+    .navlink--on { color: #1c1917; background: #f5f0e8; }
+    .search { display: flex; align-items: center; gap: 8px; width: 260px; height: 36px; padding: 0 12px; background: #ffffff; border: 1.5px solid rgba(28,25,23,0.1); border-radius: 12px; color: #a8a29e; font-size: 13px; }
+    .btn-coral { display: inline-flex; align-items: center; gap: 6px; background: #e85d26; color: #ffffff; border: none; border-radius: 8px; padding: 9px 16px; font-family: 'Geist', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; }
+    .btn-ghost { display: inline-flex; align-items: center; gap: 6px; background: #ffffff; color: #1c1917; border: 1.5px solid rgba(28,25,23,0.1); border-radius: 8px; padding: 8px 14px; font-family: 'Geist', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; }
+    .avatar { width: 32px; height: 32px; border-radius: 9999px; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; flex-shrink: 0; }
+    .card { background: #ffffff; border: 1px solid rgba(28,25,23,0.1); border-radius: 16px; }
+    .seclabel { font-family: 'Geist Mono', monospace; font-size: 11px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: #78716c; }
+    .pill { display: inline-flex; align-items: center; gap: 5px; font-family: 'Geist Mono', monospace; font-size: 11px; font-weight: 500; letter-spacing: 0.04em; border-radius: 9999px; padding: 3px 10px; white-space: nowrap; }
+    .pill--review { background: rgba(232,93,38,0.1); color: #c94d1a; }
+    .pill--approved { background: rgba(22,163,74,0.1); color: #16a34a; }
+    .pill--waiting { background: #f5f0e8; color: #78716c; }
+    .rowitem { display: flex; align-items: center; gap: 14px; padding: 16px 20px; border-top: 1px solid rgba(28,25,23,0.06); }
+    .cricon { width: 36px; height: 36px; border-radius: 8px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+    .meta { font-size: 12.5px; color: #78716c; }
+    .docref { font-size: 12.5px; font-weight: 500; color: #44403c; }
+  </style>
+</helmet>
+
+<div style="width: 1280px; min-height: 820px; background: #fafaf7; display: flex; flex-direction: column;">
+
+  <!-- Top nav -->
+  <header class="nav">
+    <div style="display: flex; align-items: center; gap: 10px;">
+      <div style="width: 28px; height: 28px; border-radius: 8px; background: #e85d26; display: flex; align-items: center; justify-content: center;">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 2h8v12l-4-3-4 3V2z" stroke="#ffffff" stroke-width="1.6" stroke-linejoin="round"/></svg>
+      </div>
+      <span style="font-family: 'Lora', Georgia, serif; font-weight: 600; font-size: 16px;">Bindersnap</span>
+    </div>
+    <nav style="display: flex; align-items: center; gap: 4px;">
+      <span class="navlink navlink--on">Home</span>
+      <span class="navlink">Documents</span>
+    </nav>
+    <div style="flex: 1;"></div>
+    <div class="search">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="4.5" stroke="#a8a29e" stroke-width="1.5"/><path d="M10.5 10.5L14 14" stroke="#a8a29e" stroke-width="1.5" stroke-linecap="round"/></svg>
+      <span>Search documents</span>
+      <span style="margin-left: auto; font-family: 'Geist Mono', monospace; font-size: 11px; border: 1px solid rgba(28,25,23,0.1); border-radius: 4px; padding: 1px 5px;">/</span>
+    </div>
+    <button class="btn-coral" type="button">
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 1v10M1 6h10" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/></svg>
+      New document
+    </button>
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none"><path d="M10 2a5 5 0 0 0-5 5v3l-1.5 3h13L15 10V7a5 5 0 0 0-5-5z" stroke="#78716c" stroke-width="1.5" stroke-linejoin="round"/><path d="M8 16a2 2 0 0 0 4 0" stroke="#78716c" stroke-width="1.5"/></svg>
+    <div class="avatar" style="background: rgba(29,78,216,0.1); color: #1d4ed8;">DG</div>
+  </header>
+
+  <!-- Body: every row on this page is a CHANGE REQUEST you are part of -->
+  <main style="width: 880px; margin: 0 auto; padding: 40px 0 64px 0;">
+
+    <h1 style="font-family: 'Lora', Georgia, serif; font-size: 28px; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 4px 0;">Good morning, David.</h1>
+    <p style="margin: 0 0 32px 0; font-size: 14px; color: #78716c;">2 change requests are waiting on you.</p>
+
+    <!-- Waiting on you -->
+    <section class="card" style="margin-bottom: 24px; overflow: hidden;">
+      <div style="display: flex; align-items: center; gap: 10px; padding: 16px 20px;">
+        <span class="seclabel" style="color: #c94d1a;">Waiting on you</span>
+        <span style="font-family: 'Geist Mono', monospace; font-size: 11px; background: rgba(232,93,38,0.1); color: #c94d1a; border-radius: 9999px; padding: 1px 8px;">2</span>
+      </div>
+
+      <div class="rowitem">
+        <div class="cricon" style="background: rgba(232,93,38,0.1); color: #c94d1a;">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M2 8h8M10 8l-3-3M10 8l-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M13 3v10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Updated liability clause</div>
+          <div class="meta"><span class="docref">Vendor Agreement</span> · Maya submitted 2h ago · 2 of 3 approvals</div>
+        </div>
+        <span class="pill pill--review">Needs your review</span>
+        <button class="btn-ghost" type="button">Review</button>
+      </div>
+
+      <div class="rowitem">
+        <div class="cricon" style="background: rgba(22,163,74,0.1); color: #16a34a;">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5L13 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Retention window extended to 7 years</div>
+          <div class="meta"><span class="docref">Data Retention Policy</span> · all approvals in · becomes v2 when you publish</div>
+        </div>
+        <span class="pill pill--approved">Ready to publish</span>
+        <button class="btn-ghost" type="button">Publish</button>
+      </div>
+    </section>
+
+    <!-- Your submissions -->
+    <section class="card" style="margin-bottom: 24px; overflow: hidden;">
+      <div style="display: flex; align-items: center; gap: 10px; padding: 16px 20px;">
+        <span class="seclabel">Your submissions</span>
+      </div>
+      <div class="rowitem">
+        <div class="cricon" style="background: #f5f0e8; color: #78716c;">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.4"/><path d="M8 4.5V8l2.5 1.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Q3 policy refresh</div>
+          <div class="meta"><span class="docref">Q3 Compliance Policy</span> · waiting on Priya and Tom · submitted yesterday</div>
+        </div>
+        <span class="pill pill--waiting">1 of 3 approvals</span>
+      </div>
+    </section>
+
+    <!-- Recently decided: closed change requests, not documents -->
+    <section class="card" style="overflow: hidden;">
+      <div style="display: flex; align-items: center; gap: 10px; padding: 16px 20px;">
+        <span class="seclabel">Recently decided</span>
+        <span style="flex: 1;"></span>
+        <a href="#" style="font-size: 13px; font-weight: 500;">Browse documents →</a>
+      </div>
+      <div class="rowitem">
+        <div class="cricon" style="background: rgba(22,163,74,0.1); color: #16a34a;">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5L13 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">New onboarding checklist</div>
+          <div class="meta"><span class="docref">Employee Handbook</span> · you and 2 others approved</div>
+        </div>
+        <span class="pill pill--approved">Published as v6 · Aug 19</span>
+      </div>
+      <div class="rowitem">
+        <div class="cricon" style="background: rgba(22,163,74,0.1); color: #16a34a;">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5L13 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Rewrote escalation contacts</div>
+          <div class="meta"><span class="docref">Incident Response Plan</span> · you approved</div>
+        </div>
+        <span class="pill pill--approved">Published as v2 · Aug 14</span>
+      </div>
+      <div class="rowitem">
+        <div class="cricon" style="background: #f5f0e8; color: #78716c;">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-size: 14.5px; font-weight: 500;">Shorter NDA for one-day contractors</div>
+          <div class="meta"><span class="docref">Mutual NDA</span> · withdrawn by Tom</div>
+        </div>
+        <span class="pill pill--waiting">Closed · Aug 12</span>
+      </div>
+    </section>
+
+  </main>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/mockups/ThreadStates.dc.html
+++ b/docs/design/mockups/ThreadStates.dc.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&family=Geist:wght@300..700&family=Geist+Mono:wght@400..600&display=swap">
+  <style>
+    body { margin: 0; font-family: 'Geist', system-ui, -apple-system, sans-serif; background: #fafaf7; color: #1c1917; -webkit-font-smoothing: antialiased; }
+    a { color: #c94d1a; text-decoration: none; } a:hover { color: #e85d26; }
+    .statelabel { font-family: 'Geist Mono', monospace; font-size: 11px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: #78716c; margin: 0 0 10px 0; }
+    .tcard { background: #ffffff; border: 1px solid rgba(28,25,23,0.1); border-radius: 12px; padding: 16px 18px; }
+    .avatar { border-radius: 9999px; display: flex; align-items: center; justify-content: center; font-weight: 600; flex-shrink: 0; }
+    .meta { font-size: 12.5px; color: #78716c; }
+    .chead { display: flex; align-items: center; gap: 8px; }
+    .csub { border-top: 1px solid rgba(28,25,23,0.06); margin-top: 12px; padding-top: 12px; }
+    .mark-open { display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px; color: #78716c; }
+    .mark-resolved { display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px; color: #a8a29e; }
+    .toggle { font-size: 12px; color: #a8a29e; font-weight: 400; }
+    .actions { display: flex; justify-content: flex-end; gap: 14px; margin-top: 12px; }
+    .threadevent { display: flex; align-items: center; gap: 8px; margin: 12px 0 0 0; padding: 10px 0 0 0; border-top: 1px solid rgba(28,25,23,0.06); font-size: 12px; color: #a8a29e; }
+  </style>
+</helmet>
+
+<div style="width: 1240px; min-height: 900px; background: #fafaf7; padding: 40px 48px; box-sizing: border-box;">
+
+  <h1 style="font-family: 'Lora', Georgia, serif; font-size: 22px; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 4px 0;">Thread states</h1>
+  <p class="meta" style="margin: 0 0 28px 0; max-width: 720px;">One comment primitive. A reply makes it a thread. Anyone can resolve; resolution is logged inside the thread. A new comment on a resolved thread reopens it — and unresolved threads block publishing when that setting is on. The show/collapse toggle always lives at the top, so it never moves.</p>
+
+  <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 32px 40px;">
+
+    <!-- 1. Expanded · unresolved -->
+    <div>
+      <p class="statelabel">Unresolved · expanded</p>
+      <div class="tcard">
+        <div class="chead">
+          <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(124,58,237,0.1); color: #7c3aed;">TW</div>
+          <strong style="font-size: 13.5px;">Tom</strong>
+          <span class="meta">Aug 20</span>
+          <span style="flex: 1;"></span>
+          <span class="mark-open"><span style="width: 6px; height: 6px; border-radius: 9999px; background: #e85d26;"></span>Unresolved</span>
+          <a href="#" class="toggle">Collapse</a>
+        </div>
+        <p style="margin: 8px 0 0 0; font-size: 14px; line-height: 1.55; color: #44403c;">Does the 12-month cap include indemnification claims, or only direct damages?</p>
+        <div class="csub">
+          <div class="chead">
+            <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(180,83,9,0.08); color: #b45309;">MK</div>
+            <strong style="font-size: 13.5px;">Maya</strong>
+            <span class="meta">Aug 21</span>
+          </div>
+          <p style="margin: 8px 0 0 0; font-size: 14px; line-height: 1.55; color: #44403c;">Only direct damages — indemnification stays uncapped per 9.1.</p>
+        </div>
+        <div class="actions">
+          <a href="#" style="font-size: 12.5px; font-weight: 500; color: #78716c;">Resolve</a>
+          <a href="#" style="font-size: 12.5px; font-weight: 500; color: #78716c;">Reply</a>
+        </div>
+      </div>
+    </div>
+
+    <!-- 2. Collapsed · unresolved -->
+    <div>
+      <p class="statelabel">Unresolved · collapsed</p>
+      <div class="tcard" style="padding: 13px 18px;">
+        <div class="chead">
+          <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(124,58,237,0.1); color: #7c3aed;">TW</div>
+          <strong style="font-size: 13.5px;">Tom</strong>
+          <span class="meta">Aug 20</span>
+          <span style="flex: 1;"></span>
+          <span class="mark-open"><span style="width: 6px; height: 6px; border-radius: 9999px; background: #e85d26;"></span>Unresolved</span>
+          <a href="#" class="toggle" style="color: #78716c; font-weight: 500; font-size: 12.5px;">Show 1 reply</a>
+        </div>
+        <p style="margin: 6px 0 0 0; font-size: 13.5px; line-height: 1.5; color: #44403c;">Does the 12-month cap include indemnification claims, or only direct damages?</p>
+      </div>
+    </div>
+
+    <!-- 3. Expanded · resolved -->
+    <div>
+      <p class="statelabel">Resolved · expanded</p>
+      <div class="tcard">
+        <div class="chead">
+          <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(22,163,74,0.1); color: #16a34a;">PS</div>
+          <strong style="font-size: 13.5px;">Priya</strong>
+          <span class="meta">Aug 20</span>
+          <span style="flex: 1;"></span>
+          <span class="mark-resolved">
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none"><path d="M4 8.5l2.5 2.5L12 5.5" stroke="#a8a29e" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            Resolved
+          </span>
+          <a href="#" class="toggle">Collapse</a>
+        </div>
+        <p style="margin: 8px 0 0 0; font-size: 14px; line-height: 1.55; color: #44403c;">Should the renewal date move to Jan 1 to match the new cap?</p>
+        <div class="csub">
+          <div class="chead">
+            <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(180,83,9,0.08); color: #b45309;">MK</div>
+            <strong style="font-size: 13.5px;">Maya</strong>
+            <span class="meta">Aug 20</span>
+          </div>
+          <p style="margin: 8px 0 0 0; font-size: 14px; line-height: 1.55; color: #44403c;">No — renewal stays on the anniversary date. The cap change doesn't touch section 4.</p>
+        </div>
+        <div class="csub">
+          <div class="chead">
+            <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(22,163,74,0.1); color: #16a34a;">PS</div>
+            <strong style="font-size: 13.5px;">Priya</strong>
+            <span class="meta">Aug 21</span>
+          </div>
+          <p style="margin: 8px 0 0 0; font-size: 14px; line-height: 1.55; color: #44403c;">Got it, thanks.</p>
+        </div>
+        <!-- Resolution is part of the thread's own history -->
+        <div class="threadevent">
+          <svg width="11" height="11" viewBox="0 0 16 16" fill="none"><path d="M4 8.5l2.5 2.5L12 5.5" stroke="#a8a29e" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          Priya marked this as resolved · Aug 21 · a new comment reopens it
+        </div>
+        <div class="actions">
+          <a href="#" style="font-size: 12.5px; font-weight: 500; color: #a8a29e;">Reply</a>
+        </div>
+      </div>
+    </div>
+
+    <!-- 4. Collapsed · resolved -->
+    <div>
+      <p class="statelabel">Resolved · collapsed</p>
+      <div class="tcard" style="padding: 13px 18px;">
+        <div class="chead">
+          <div class="avatar" style="width: 24px; height: 24px; font-size: 10px; background: rgba(22,163,74,0.1); color: #16a34a;">PS</div>
+          <strong style="font-size: 13.5px;">Priya</strong>
+          <span class="meta">Aug 20</span>
+          <span style="flex: 1;"></span>
+          <span class="mark-resolved">
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none"><path d="M4 8.5l2.5 2.5L12 5.5" stroke="#a8a29e" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            Resolved
+          </span>
+          <a href="#" class="toggle">Show 2 replies</a>
+        </div>
+        <p style="margin: 6px 0 0 0; font-size: 13.5px; line-height: 1.5; color: #78716c;">Should the renewal date move to Jan 1 to match the new cap?</p>
+      </div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/mockups/canvas.json
+++ b/docs/design/mockups/canvas.json
@@ -1,0 +1,17 @@
+{
+  "artboards": [
+    { "file": "Main.dc.html", "title": "Home — your change requests", "x": 0, "y": 0, "w": 1280, "h": 820 },
+    { "file": "Documents.dc.html", "title": "Documents", "x": 1400, "y": 0, "w": 1280, "h": 840 },
+    { "file": "DocumentDetail.dc.html", "title": "Document workspace", "x": 0, "y": 1040, "w": 1280, "h": 880 },
+    { "file": "ChangeReview.dc.html", "title": "Change review", "x": 1400, "y": 1040, "w": 1280, "h": 1280 },
+    { "file": "ThreadStates.dc.html", "title": "Thread states", "x": 2800, "y": 1040, "w": 1240, "h": 900 }
+  ],
+  "annotations": [
+    { "id": "what-changed", "x": -560, "y": 0, "w": 480, "text": "Direction locked: task-first home (Option A).\n\n- Every row on Home is a CHANGE REQUEST you are part of — including \"Recently decided,\" which lists closed change requests, never documents.\n- Documents live on their own page with saved views: I contribute to / I own / everything I can see, plus person filters (\"Owned by Jack\").\n- One coral element per screen; no owner/repo paths; no vanity stats." },
+    { "id": "home-note", "x": 0, "y": -150, "w": 380, "text": "Home: three buckets, all change requests — waiting on you, your submissions, recently decided. Clicking any row opens that change request's review page. Replaces the Inbox page." },
+    { "id": "documents-note", "x": 1400, "y": -150, "w": 380, "text": "Documents: saved views as chips (I contribute to / I own / everything I can see) plus removable person filters. Rows link to the document workspace. Search stays plain-language; the query syntax becomes an advanced affordance." },
+    { "id": "detail-note", "x": 0, "y": 1960, "w": 400, "text": "Document workspace: 4 tabs — Document, Changes, History (no count bubble), Access & approvals (renamed from Sharing since it also holds approver rules and required-approval count)." },
+    { "id": "review-note", "x": 1400, "y": 2360, "w": 460, "text": "Change review lives INSIDE the Changes tab — document header and tabs stay visible, \"← All changes\" returns to the list.\n\n- The conversation is a timeline spine on the page: comments are cards on the line, events sit on the paper — no growing box.\n- Green checks mean approvals, and only approvals. Resolved threads stay comment cards, collapsed by default, with a faint gray check and a blended \"Show N replies\".\n- Unresolved threads carry only a small dot + \"Unresolved\" — quiet until they matter.\n- Resolution is logged INSIDE the thread (\"Priya marked this as resolved\"); a new comment reopens it. See the Thread states board for all four states.\n- \"Proposed version\" is fixed chrome in the same place on every change request.\n- Approve is green (success semantic); no assignee; decision floats bottom-right." }
+  ],
+  "launch": { "view": "canvas" }
+}

--- a/docs/design/workspace-redesign-spec.md
+++ b/docs/design/workspace-redesign-spec.md
@@ -1,0 +1,121 @@
+# Workspace UX Redesign — Decision Record & Build Plan
+
+Approved by David, 2026-08-22, after three mockup iterations.
+Live mockup canvas: https://claude.ai/code/artifact/4a819079-ceb3-4d5f-904f-6060eaa820ac
+Static copies of the approved mockups (exact markup + pixel values) live in
+`docs/design/mockups/*.dc.html` — treat them as the visual source of truth.
+Design tokens: `packages/ui-tokens/css/bindersnap-tokens.css`. Read `AGENTS.md`
+before any change; every architecture decision there still holds. This is a
+**presentation-layer redesign only** — no backend, BFF, or Gitea model changes
+except where explicitly listed under "Backend touchpoints".
+
+## Scope
+
+Workspace app only (`apps/app/components/`). Landing page, auth screens, and
+billing/admin pages are untouched. Git vocabulary is softened but the
+structure (change requests, approvals, versions) stays.
+
+## Cross-cutting rules (every screen)
+
+- One coral element per screen: the next action. Green = approval/success only.
+- Kill: 4-stat dashboard row, Quick Actions card, in-app `.bs-eyebrow`
+  marketing labels, `owner/repo` paths anywhere in the UI, git icons
+  (GitPullRequest etc.) in user-facing chrome.
+- Meta lines say one thing: "Maya proposed a new version 2h ago".
+- Status pills (mono 11px, pill radius): `Current`, `In review`,
+  `Needs your review`, `Ready to publish`, `Draft`.
+- Top nav (all pages): logo + wordmark, Home, Documents, spacer, search
+  ("Search documents", `/` shortcut), coral "New document", bell, avatar.
+  No "Changes" nav link.
+
+## Screen decisions
+
+### Home (`Main.dc.html`) — replaces HomePage AND InboxPage
+Task-first. **Every row is a change request the user is part of** (author,
+reviewer, or on a document they own) — never a document link. Three sections:
+1. **Waiting on you** (coral section label + count): needs-your-review and
+   ready-to-publish items, each with a Review/Publish ghost button.
+2. **Your submissions**: user's open change requests with approval progress.
+3. **Recently decided**: *closed* change requests with outcome
+   ("Published as v6 · Aug 19", "Closed · withdrawn by Tom").
+Only path to the library is the "Browse documents →" link.
+
+### Documents (`Documents.dc.html`)
+Library page with saved views as chips: **I contribute to** (default) /
+**I own** / **Everything I can see**, plus removable person-filter chips
+("Owned by Jack ×") and a dashed "+ Filter by person" affordance. Rows:
+name, meta ("Jack owns · v3 · 2 open changes · updated 2h ago"), status pill.
+Plain-language search; the `owner:@me` query syntax stays as a power feature,
+not the placeholder.
+
+### Document workspace (`DocumentDetail.dc.html`)
+Header: title (Lora 26), `v3 · Current` pill, approved date, filename. No
+owner/repo path. Coral "Submit new version" button. **Four tabs**: Document,
+Changes (count bubble), History (NO count bubble), **Access & approvals**
+(merges old Team + Settings tabs; named honestly because it holds approver
+rules and required-approval count too). Document tab: preview + slim rail
+(Waiting on a decision / Versions / Team avatars).
+
+### Change review (`ChangeReview.dc.html`)
+Opens **inside the Changes tab** — document header and tabs stay visible;
+"← All changes" returns to the list. No assignee concept anywhere (submitter +
+reviewers only; the Gitea assignee field goes unused).
+- Description paragraph under the title, written by the author.
+- **Proposed version** card is fixed chrome, same place on every change:
+  file icon, "Proposed version", `filename · update N of M · date` (mono),
+  quiet "All updates" link, "Open" ghost button.
+- Reviewers row: avatar + name + state mark (green check = approved, gray
+  clock = pending) + "+ Add reviewer" pill button.
+- **Timeline is a spine on the page, not a box**: 1.5px solid hairline
+  (#ebeae7) at left; 28px opaque dots (solid colors, never alpha) sit on it.
+  Dot glyphs by event type: arrow = opened, speech bubble = comment/thread,
+  refresh = proposal update, green check on solid green tint (#e3f1e6 bg /
+  #b6e0c3 border) = approval, pencil = composer. Avatars appear in card
+  headers next to names, never on the spine.
+- Events (opened / updated / approved) are plain text rows on the paper;
+  comments are white cards.
+- Proposal updates are timeline events: "Maya updated the proposed version
+  (update 2) · Aug 21 · earlier approvals were reset · compare".
+- Decision is a **floating pill** bottom-right (Request changes ghost +
+  **green** Approve), always reachable without scrolling.
+
+### Threads (`ThreadStates.dc.html` — all four states)
+One comment primitive. A reply turns a comment into a thread. Anyone can
+resolve; **a new comment on a resolved thread reopens it**; unresolved
+threads block publishing when `blockOnUnresolvedThreads` is on.
+- Unresolved marker: 6px coral dot + "Unresolved" muted text (no pill).
+- Resolved marker: small gray check + "Resolved" in faint #a8a29e.
+- Show/Collapse toggle lives in the card header (top-right), toggling in
+  place — it never moves as content expands. Collapsed shows author +
+  first line + toggle. Unresolved "Show N replies" is slightly darker than
+  resolved (it may need action).
+- Replies are full-width, same structure as the root (avatar + name + date
+  header, then text), separated by hairlines — no indentation.
+- Resolution logged INSIDE the thread: "Priya marked this as resolved ·
+  Aug 21 · a new comment reopens it".
+- Actions right-aligned bottom: Resolve · Reply.
+
+## Backend touchpoints (small, deliberate)
+
+- Review-history/updates: PR branch commits ARE the updates; "compare" is a
+  ref-to-ref view; approval reset is the existing `dismiss_stale_approvals`
+  flag. New work is timeline rendering + notifications.
+- Reopen-on-comment: resolution is already an append-only event log in
+  `services/api/gitea-client/discussions.ts`; derive "unresolved" when a
+  comment follows the latest resolve event.
+- Everything else is derivable from existing endpoints.
+
+## Build order (one branch + PR each; per memory: always branches and PRs)
+
+1. **Shell + Home**: new top nav in `AppShell.tsx`; task-first `HomePage`;
+   delete/redirect `InboxPage`. Home needs a "my change requests" aggregation
+   (may extend `GET /api/app/documents` response or add an endpoint).
+2. **Documents page**: saved-view chips, person filters, new row design.
+3. **Document workspace**: header, 4 tabs (merge Collaborators + Permissions
+   into Access & approvals), Document tab rail.
+4. **Change review**: timeline spine, thread model, proposed-version card,
+   floating decision pill, updates-as-events (largest PR; may split timeline
+   rendering and update-events into two PRs).
+
+Editor package (`packages/editor/`) is untouched — no `sync-demo` needed
+unless that changes.


### PR DESCRIPTION
## Summary

Adds the decision record and approved mockups from the workspace UX redesign sessions, so implementation (delegated to follow-up PRs, one per phase) has a durable source of truth in the repo.

- `docs/design/workspace-redesign-spec.md` — every locked decision: task-first Home listing only change requests (replaces Inbox), Documents page with saved views + person filters, four-tab document workspace (Team + Settings merged into **Access & approvals**), change review inside the Changes tab with a timeline spine, unified comment/thread semantics (reply makes a thread, new comment reopens a resolved one), proposal updates as timeline events, floating green Approve pill, no assignee in the UI. Plus the small backend touchpoints and the four-PR build order.
- `docs/design/mockups/*.dc.html` — the approved mockups themselves; exact markup, colors, and spacing to copy from during implementation. Live canvas: https://claude.ai/code/artifact/4a819079-ceb3-4d5f-904f-6060eaa820ac

Reviewer note: docs-only — no app, service, or deploy code touched. `packages/editor/` untouched, so no `sync-demo` needed.

## Scope Check

- [x] Changes are focused on one issue/task
- [x] No unrelated refactors or formatting-only churn included

## Validation

- [x] Local validation/tests run (list commands below)
- Commands run: none — documentation and static mockup assets only; no source code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)