### PR TITLE
feat: workspace redesign phase 2 — Documents library

### DIFF
--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -4925,534 +4925,308 @@ input {
 
 /* ══════════════════════════════════════════════════════════════
    DOCUMENTS PAGE
+   The library. Home is the queue; this is the shelf — one scope at
+   a time, narrowed by people, and nothing else to set.
    ══════════════════════════════════════════════════════════════ */
 
 .docs-page {
-  display: grid;
-  gap: var(--brand-space-5);
-  align-content: start;
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
+  padding: var(--brand-space-10) 0 var(--brand-space-16);
+  box-sizing: border-box;
 }
 
-.docs-page.app-page-shell {
-  max-width: none;
-  margin: 0;
-  padding-left: var(--brand-space-6);
-  padding-right: var(--brand-space-6);
-}
-
-/* ── Hero search bar ── */
-
-.docs-hero-search {
-  display: flex;
-  align-items: center;
-  gap: 0;
-  background: var(--bs-surface-1);
-  border: 1.5px solid var(--bs-rule);
-  border-radius: var(--brand-radius-lg);
-  overflow: hidden;
-  transition:
-    border-color var(--brand-transition-fast),
-    box-shadow var(--brand-transition-fast);
-}
-
-.docs-hero-search:has(.docs-hero-search-input:focus) {
-  border-color: var(--brand-coral);
-  box-shadow: 0 0 0 3px var(--brand-coral-glow, rgba(232, 93, 38, 0.12));
-}
-
-.docs-hero-search-input {
-  flex: 1;
-  height: 40px;
-  padding: 0 var(--brand-space-3) 0 var(--brand-space-4);
-  background: transparent;
-  border: none;
-  outline: none;
-  font-family: var(--brand-font-mono);
-  font-size: 14px;
+.docs-title {
+  font-family: var(--brand-font-serif);
+  font-size: 28px;
+  font-weight: var(--brand-weight-semibold);
+  letter-spacing: var(--brand-tracking-snug);
   color: var(--bs-text-primary);
-  min-width: 0;
+  margin: 0 0 var(--brand-space-5);
 }
 
-.docs-hero-search-input::placeholder {
-  color: var(--bs-text-faint);
-  font-family: var(--brand-font-sans);
-}
+/* ── Saved views and person filters ── */
 
-.docs-hero-search-clear {
+.docs-views {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  background: var(--bs-surface-3);
-  border: none;
-  border-radius: var(--brand-radius-full);
-  font-size: 16px;
-  line-height: 1;
-  color: var(--bs-text-muted);
-  cursor: pointer;
-  flex-shrink: 0;
-  margin-right: var(--brand-space-2);
-  transition:
-    background var(--brand-transition-fast),
-    color var(--brand-transition-fast);
-}
-
-.docs-hero-search-clear:hover {
-  background: var(--brand-coral);
-  color: #fff;
-}
-
-.docs-hero-search-submit {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  background: var(--bs-surface-2);
-  border: none;
-  border-left: 1.5px solid var(--bs-rule);
-  cursor: pointer;
-  color: var(--bs-text-muted);
-  flex-shrink: 0;
-  transition:
-    background var(--brand-transition-fast),
-    color var(--brand-transition-fast);
-}
-
-.docs-hero-search-submit:hover {
-  background: var(--bs-surface-3);
-  color: var(--bs-text-primary);
-}
-
-/* ── Panel (header + list joined) ── */
-
-.docs-panel {
-  background: var(--bs-surface-1);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-md);
-  overflow: hidden;
-}
-
-.docs-panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background: var(--bs-surface-2);
-  border-bottom: 1px solid var(--bs-rule);
-  padding-right: var(--brand-space-4);
-}
-
-.docs-sort-control {
-  display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: var(--brand-space-2);
-  flex-shrink: 0;
+  margin-bottom: var(--brand-space-5);
 }
 
-/* ── Scope tabs (My Contributions / My Documents) ── */
-
-.docs-scope-tabs {
-  display: flex;
-  align-items: center;
-  gap: 0;
-  padding: 0 var(--brand-space-2);
-  background: transparent;
-}
-
-.docs-scope-tab {
+.docs-chip {
   display: inline-flex;
   align-items: center;
-  gap: var(--brand-space-2);
-  padding: var(--brand-space-3) var(--brand-space-5);
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
+  gap: 6px;
   font-family: var(--brand-font-sans);
   font-size: 13px;
   font-weight: var(--brand-weight-medium);
   color: var(--bs-text-muted);
+  padding: 6px 14px;
+  border-radius: var(--brand-radius-full);
+  border: 1px solid var(--bs-rule);
+  background: var(--bs-surface-1);
   cursor: pointer;
-  transition:
-    color var(--brand-transition-fast),
-    border-color var(--brand-transition-fast);
   white-space: nowrap;
 }
 
-.docs-scope-tab:hover {
+.docs-chip:hover {
   color: var(--bs-text-primary);
+  border-color: var(--bs-text-faint);
 }
 
-.docs-scope-tab--active {
-  color: var(--bs-text-primary);
-  border-bottom-color: var(--brand-coral);
-  font-weight: var(--brand-weight-semibold);
+/* The chosen scope is stated in ink, not coral — coral belongs to the one
+   row that owes the reader something. */
+.docs-chip--on,
+.docs-chip--on:hover {
+  background: var(--bs-text-primary);
+  color: var(--bs-surface-2);
+  border-color: var(--bs-text-primary);
 }
 
-/* ── Toolbar (sort) ── */
-
-.docs-toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--brand-space-4);
-  padding: var(--brand-space-3) var(--brand-space-4);
-  border-top: 1px solid var(--bs-rule);
+.docs-chip:focus-visible {
+  outline: 2px solid var(--brand-coral);
+  outline-offset: 2px;
 }
 
-.docs-toolbar-search {
-  position: relative;
-  flex: 1;
-  max-width: 480px;
-}
-
-.docs-toolbar-search-icon {
-  position: absolute;
-  left: var(--brand-space-3);
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--bs-text-faint);
-  pointer-events: none;
-}
-
-.docs-toolbar-search-input {
-  width: 100%;
-  height: 34px;
-  padding: 0 var(--brand-space-3) 0
-    calc(var(--brand-space-3) + 14px + var(--brand-space-2));
-  background: var(--bs-surface-2);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-md);
-  font-family: var(--brand-font-sans);
-  font-size: 13px;
-  color: var(--bs-text-primary);
-  transition:
-    border-color var(--brand-transition-fast),
-    box-shadow var(--brand-transition-fast);
-  outline: none;
-}
-
-.docs-toolbar-search-input::placeholder {
-  color: var(--bs-text-faint);
-}
-
-.docs-toolbar-search-input:focus {
-  border-color: var(--brand-coral);
-  box-shadow: 0 0 0 3px rgba(232, 93, 38, 0.1);
-}
-
-.docs-toolbar-right {
-  display: flex;
-  align-items: center;
-  gap: var(--brand-space-2);
-  flex-shrink: 0;
-}
-
-.docs-toolbar-label {
-  font-size: 12px;
+.docs-chip--person {
+  cursor: default;
   color: var(--bs-text-muted);
-  font-family: var(--brand-font-mono);
-  text-transform: uppercase;
-  letter-spacing: var(--brand-tracking-wide);
 }
 
-.docs-toolbar-select {
-  height: 34px;
-  padding: 0 var(--brand-space-3);
-  background: var(--bs-surface-2);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-md);
-  font-family: var(--brand-font-sans);
-  font-size: 13px;
-  color: var(--bs-text-secondary);
-  cursor: pointer;
-  outline: none;
-  transition: border-color var(--brand-transition-fast);
-}
-
-.docs-toolbar-select:hover {
-  border-color: var(--bs-rule);
+.docs-chip--person strong {
+  font-weight: var(--brand-weight-semibold);
   color: var(--bs-text-primary);
 }
 
-.docs-toolbar-select:focus {
-  border-color: var(--brand-coral);
-  box-shadow: 0 0 0 3px rgba(232, 93, 38, 0.1);
+.docs-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--bs-text-muted);
+  cursor: pointer;
 }
 
-/* ── Document list ── */
+.docs-chip-remove:hover {
+  color: var(--bs-text-primary);
+}
+
+/* An affordance, not a filter: dashed until it holds something. */
+.docs-chip--add {
+  border-style: dashed;
+  color: var(--bs-text-faint);
+}
+
+.docs-views-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--bs-rule);
+}
+
+.docs-views-spacer {
+  flex: 1;
+}
+
+.docs-sorted-by {
+  font-size: 12.5px;
+  color: var(--bs-text-muted);
+  white-space: nowrap;
+}
+
+.docs-person-picker {
+  position: relative;
+  display: inline-flex;
+}
+
+.docs-person-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: var(--brand-z-raised);
+  min-width: 180px;
+  padding: var(--brand-space-1);
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-lg);
+  box-shadow: var(--bs-shadow-lg);
+}
+
+.docs-person-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 7px 10px;
+  border: none;
+  border-radius: var(--brand-radius-md);
+  background: transparent;
+  font-family: var(--brand-font-sans);
+  font-size: 13px;
+  color: var(--bs-text-primary);
+  cursor: pointer;
+}
+
+.docs-person-menu-item:hover {
+  background: var(--bs-surface-2);
+}
+
+.docs-person-menu-empty {
+  margin: 0;
+  padding: 7px 10px;
+  font-size: 12.5px;
+  color: var(--bs-text-muted);
+}
+
+/* ── The list ── */
 
 .docs-list {
-  display: grid;
-  gap: 0;
   background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-xl);
+  overflow: hidden;
 }
 
 .docs-list-item {
   display: flex;
-  align-items: flex-start;
-  gap: var(--brand-space-4);
-  padding: var(--brand-space-5) var(--brand-space-6);
-  background: none;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: var(--brand-space-4) var(--brand-space-5);
   border: none;
-  border-bottom: 1px solid var(--bs-rule-warm);
+  border-top: 1px solid var(--bs-rule-warm);
+  background: transparent;
   text-align: left;
   cursor: pointer;
-  transition: background var(--brand-transition-fast);
-  width: 100%;
+  box-sizing: border-box;
 }
 
-.docs-list-item:last-child {
-  border-bottom: none;
+.docs-list-item:first-child {
+  border-top: none;
 }
 
-.docs-list-item-icon {
-  flex-shrink: 0;
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.docs-list-item:hover {
   background: var(--bs-surface-2);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-md);
-  color: var(--brand-coral);
-  margin-top: 2px;
 }
 
-.docs-list-item-body {
-  flex: 1;
-  min-width: 0;
-  display: grid;
-  gap: var(--brand-space-1);
-}
-
-.docs-list-item-top {
-  display: flex;
-  align-items: center;
-  gap: var(--brand-space-2);
-  flex-wrap: wrap;
-}
-
-.docs-list-item-name {
-  font-family: var(--brand-font-serif);
-  font-size: 15px;
-  font-weight: var(--brand-weight-semibold);
-  color: var(--bs-text-primary);
-  line-height: 1.3;
-}
-
-.docs-list-item:hover .docs-list-item-name {
-  color: var(--brand-coral);
-}
-
-.docs-list-item-visibility {
-  display: inline-flex;
-  align-items: center;
-  padding: 1px 7px;
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-full);
-  font-family: var(--brand-font-mono);
-  font-size: 10px;
-  font-weight: var(--brand-weight-medium);
-  color: var(--bs-text-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--brand-tracking-wide);
-  line-height: 1.6;
-}
-
-.docs-list-item-description {
-  margin: 0;
-  font-size: 13px;
-  color: var(--bs-text-muted);
-  line-height: var(--brand-leading-normal);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.docs-list-item-meta {
-  display: flex;
-  align-items: center;
-  gap: var(--brand-space-4);
-  flex-wrap: wrap;
-  margin-top: 2px;
-}
-
-.docs-list-item-owner,
-.docs-list-item-prs,
-.docs-list-item-tag,
-.docs-list-item-updated {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-  color: var(--bs-text-faint);
-}
-
-/* ── Status badges ── */
-
-.docs-status-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  border-radius: var(--brand-radius-sm);
-  font-family: var(--brand-font-mono);
-  font-size: 10px;
-  font-weight: var(--brand-weight-medium);
-  text-transform: uppercase;
-  letter-spacing: var(--brand-tracking-wide);
-  line-height: 1.6;
-  flex-shrink: 0;
-}
-
-.docs-status-badge--draft {
-  background: var(--bs-surface-3);
-  color: var(--bs-text-muted);
-}
-
-.docs-status-badge--review {
-  background: rgba(234, 179, 8, 0.12);
-  color: #a16207;
-}
-
-[data-theme="dark"] .docs-status-badge--review {
-  background: rgba(234, 179, 8, 0.15);
-  color: #fbbf24;
-}
-
-.docs-status-badge--published,
-.docs-status-badge--approved {
-  background: rgba(22, 163, 74, 0.1);
-  color: var(--brand-green);
-}
-
-.docs-status-badge--changes {
-  background: rgba(232, 93, 38, 0.1);
-  color: var(--brand-coral);
-}
-
-/* ── Skeleton loading ── */
-
-.docs-list--loading {
-  opacity: 0.45;
-  pointer-events: none;
-  transition: opacity 0.15s ease;
+.docs-list-item:focus-visible {
+  outline: 2px solid var(--brand-coral);
+  outline-offset: -2px;
 }
 
 .docs-list-item--skeleton {
-  pointer-events: none;
+  cursor: default;
 }
 
-.docs-skeleton {
-  background: var(--bs-surface-3);
-  border-radius: var(--brand-radius-sm);
-  animation: docs-pulse 1.4s ease-in-out infinite;
-}
-
-.docs-skeleton--icon {
+.docs-list-item-icon {
   width: 36px;
   height: 36px;
   border-radius: var(--brand-radius-md);
+  background: var(--bs-surface-2);
+  color: var(--bs-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
 }
 
-.docs-skeleton-body {
-  flex: 1;
-  display: grid;
-  gap: var(--brand-space-2);
-  padding-top: 4px;
-}
-
-.docs-skeleton--title {
-  height: 16px;
-  width: 40%;
-}
-
-.docs-skeleton--desc {
-  height: 12px;
-  width: 72%;
-}
-
-.docs-skeleton--meta {
-  height: 12px;
-  width: 55%;
-}
-
-@keyframes docs-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.4;
-  }
-}
-
-/* ── Empty state ── */
-
-.docs-empty {
-  display: grid;
-  place-items: center;
-  gap: var(--brand-space-3);
-  padding: var(--brand-space-12) var(--brand-space-8);
-  text-align: center;
-}
-
-.docs-empty-icon {
-  color: var(--bs-text-faint);
-}
-
-.docs-empty-title {
-  margin: 0;
-  font-family: var(--brand-font-serif);
-  font-size: 18px;
-  font-weight: var(--brand-weight-semibold);
-  color: var(--bs-text-secondary);
-}
-
-.docs-empty-sub {
-  margin: 0;
-  font-size: 14px;
-  color: var(--bs-text-muted);
-}
-
-.docs-empty-reset {
-  background: none;
-  border: none;
-  padding: 0;
-  font: inherit;
-  color: var(--brand-coral);
-  cursor: pointer;
-  text-decoration: underline;
-}
-
-/* ── Error card ── */
-
-.docs-error-card {
-  padding: var(--brand-space-6);
-  min-height: 160px;
-  display: grid;
-  place-items: center;
-}
-
-.docs-error-text {
-  margin: 0;
-  font-size: 13px;
+/* The only coral on the page: the row that is waiting on the reader. */
+.docs-list-item-icon--urgent {
+  background: var(--bs-coral-dim);
   color: var(--brand-coral-dark);
 }
 
-/* ── Result count ── */
+.docs-list-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
 
-.docs-result-count {
-  margin: 0;
+.docs-list-item-name {
+  font-size: 14.5px;
+  font-weight: var(--brand-weight-medium);
+  color: var(--bs-text-primary);
+}
+
+.docs-list-item-meta {
+  font-size: 12.5px;
+  color: var(--bs-text-muted);
+}
+
+/* ── Status pills ── */
+
+.docs-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
+  font-size: var(--brand-text-label);
+  font-weight: var(--brand-weight-medium);
+  letter-spacing: 0.04em;
+  border-radius: var(--brand-radius-full);
+  padding: 3px 10px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.docs-pill--review {
+  background: var(--bs-coral-dim);
+  color: var(--brand-coral-dark);
+}
+
+.docs-pill--approved {
+  background: var(--bs-green-dim);
+  color: var(--brand-green);
+}
+
+.docs-pill--waiting {
+  background: var(--bs-surface-2);
+  color: var(--bs-text-muted);
+}
+
+/* ── Loading, empty, and the count under the list ── */
+
+.docs-skeleton-lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--brand-space-2);
+  flex: 1;
+}
+
+.docs-skeleton-line {
+  height: 10px;
+  border-radius: var(--brand-radius-sm);
+  background: var(--bs-surface-2);
+}
+
+.docs-skeleton-line--wide {
+  width: 44%;
+}
+
+.docs-skeleton-line--short {
+  width: 28%;
+}
+
+.docs-notice {
+  padding: var(--brand-space-5);
+}
+
+.docs-notice p {
+  margin: 0;
+  font-size: 13.5px;
+  color: var(--bs-text-muted);
+  max-width: 52ch;
+}
+
+.docs-count {
+  margin: 14px 4px 0;
+  font-size: 12.5px;
   color: var(--bs-text-faint);
-  text-align: right;
-  letter-spacing: var(--brand-tracking-wide);
 }
 
 @media (max-width: 960px) {
@@ -5466,38 +5240,29 @@ input {
   }
 }
 
-/* ── Responsive ── */
+@media (max-width: 768px) {
+  .docs-page {
+    padding: var(--brand-space-6) var(--brand-space-5) var(--brand-space-12);
+  }
+}
 
 @media (max-width: 640px) {
-  .docs-panel-header {
-    flex-wrap: wrap;
-    padding-right: 0;
-  }
-
-  .docs-sort-control {
-    padding: var(--brand-space-2) var(--brand-space-4);
-    border-top: 1px solid var(--bs-rule);
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .docs-hero-search-input {
-    height: 36px;
-    font-size: 13px;
-  }
-
-  .docs-hero-search-submit {
-    width: 36px;
-    height: 36px;
-  }
-
-  .docs-scope-tabs {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+  .docs-views-spacer,
+  .docs-sorted-by {
+    display: none;
   }
 
   .docs-list-item {
+    flex-wrap: wrap;
     padding: var(--brand-space-4) var(--brand-space-4);
+  }
+
+  .docs-list-item-body {
+    flex-basis: calc(100% - 50px);
+  }
+
+  .docs-pill {
+    margin-left: 50px;
   }
 
   .activity-placeholder-head {

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Bell,
   FileText,
@@ -9,6 +9,7 @@ import {
   Shield,
 } from "lucide-react";
 import type { SessionUser } from "../api";
+import { buildDocumentsUrl, parseDocumentsViewState } from "../documentsView";
 import type { AppRoute } from "../routes";
 import { ActivityLogPage } from "./ActivityLogPage";
 import { AdminSubscriptionManagementPage } from "./AdminSubscriptionManagementPage";
@@ -31,6 +32,22 @@ function toggleTheme() {
   const next = isDark ? "light" : "dark";
   html.setAttribute("data-theme", next);
   localStorage.setItem("bs-theme", next);
+}
+
+/**
+ * Search lands on the library, because that is where a document is found.
+ *
+ * The nav owns the search box on every page, so it moves the address bar
+ * directly rather than going through the route table — a route is a page, and
+ * this is a page plus a question.
+ */
+function navigateToSearch(freeText: string): void {
+  window.history.pushState(
+    {},
+    "",
+    buildDocumentsUrl({ view: "contributing", people: [], freeText }),
+  );
+  window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
 /** Derive uppercase initials from a username or full name. */
@@ -78,6 +95,12 @@ export function AppShell({
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [showCreateDocumentModal, setShowCreateDocumentModal] = useState(false);
+  // A search that was linked to or reloaded is still the search that is on
+  // screen, so the box says so.
+  const [search, setSearch] = useState(
+    () => parseDocumentsViewState(window.location.search, "").freeText,
+  );
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const openCreateDocumentModal = useCallback(() => {
     setShowCreateDocumentModal(true);
@@ -92,6 +115,31 @@ export function AppShell({
       );
     };
   }, [openCreateDocumentModal]);
+
+  // "/" puts the cursor in search from anywhere — unless the reader is already
+  // typing somewhere, where a slash is just a slash.
+  useEffect(() => {
+    const focusSearch = (event: KeyboardEvent) => {
+      if (event.key !== "/" || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+      event.preventDefault();
+      searchInputRef.current?.focus();
+    };
+
+    document.addEventListener("keydown", focusSearch);
+    return () => document.removeEventListener("keydown", focusSearch);
+  }, []);
 
   return (
     <div className="app-shell">
@@ -133,8 +181,16 @@ export function AppShell({
         <div className="app-topnav-spacer" />
 
         <div className="app-topnav-right">
-          {/* Search */}
-          <div className="app-nav-search" role="search">
+          {/* Search — the only search there is, on every page */}
+          <form
+            className="app-nav-search"
+            role="search"
+            onSubmit={(event) => {
+              event.preventDefault();
+              searchInputRef.current?.blur();
+              navigateToSearch(search.trim());
+            }}
+          >
             <Search
               className="app-nav-search-icon"
               aria-hidden="true"
@@ -142,15 +198,26 @@ export function AppShell({
               strokeWidth={1.5}
             />
             <input
+              ref={searchInputRef}
               className="app-nav-search-input"
               type="text"
               placeholder="Search documents"
               aria-label="Search documents"
+              value={search}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(event) => setSearch(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setSearch("");
+                  searchInputRef.current?.blur();
+                }
+              }}
             />
             <span className="app-nav-search-kbd" aria-hidden="true">
               /
             </span>
-          </div>
+          </form>
 
           {/* Create document */}
           <button

--- a/apps/app/components/DocumentsPage.tsx
+++ b/apps/app/components/DocumentsPage.tsx
@@ -1,386 +1,327 @@
-import { useEffect, useRef, useState } from "react";
-import { FileText, GitPullRequest, Search, Tag, Users } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { FileText, Plus, X } from "lucide-react";
+
 import { getWorkspaceDocuments, type WorkspaceDocumentSummary } from "../api";
+import { capitalizeFirst } from "../documentDisplay";
 import {
-  getDocumentStatusLabel,
-  resolveWorkspaceDocumentStatus,
-  type DocumentStatus,
-} from "../documentDisplay";
-import { parseDocumentSearchQuery } from "../documentSearch";
-import { BindersnapLogoMark } from "./BindersnapLogoMark";
+  applyPersonFilter,
+  buildDocumentRows,
+  buildDocumentsUrl,
+  collectOwners,
+  describeDocumentCount,
+  getSavedViewLabel,
+  parseDocumentsViewState,
+  SAVED_VIEWS,
+  toSearchParams,
+  type DocumentRow,
+  type DocumentsViewState,
+  type SavedView,
+} from "../documentsView";
 
 interface DocumentsPageProps {
   currentUsername: string;
   onSelectDocument: (owner: string, repo: string) => void;
 }
 
-type SortOption = "updated" | "name" | "status";
-
-const DEFAULT_QUERY = "contributed-by:@me";
-const MY_DOCS_QUERY = "owner:@me";
-
-function readQueryFromUrl(): string {
-  return new URLSearchParams(window.location.search).get("q") ?? "";
-}
-
-function queryToSearchBarValue(q: string): string {
-  return q === "" ? DEFAULT_QUERY : q;
-}
-
-function formatRelativeTime(timestamp: string): string {
-  if (!timestamp) return "Unknown";
-  try {
-    const date = new Date(timestamp);
-    if (Number.isNaN(date.getTime())) return "Unknown";
-    const now = Date.now();
-    const diff = now - date.getTime();
-    const seconds = Math.floor(diff / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-    const days = Math.floor(hours / 24);
-    const weeks = Math.floor(days / 7);
-    const months = Math.floor(days / 30);
-
-    if (months > 0)
-      return `Updated ${months} month${months > 1 ? "s" : ""} ago`;
-    if (weeks > 0) return `Updated ${weeks} week${weeks > 1 ? "s" : ""} ago`;
-    if (days > 0) return `Updated ${days} day${days > 1 ? "s" : ""} ago`;
-    if (hours > 0) return `Updated ${hours} hour${hours > 1 ? "s" : ""} ago`;
-    if (minutes > 0)
-      return `Updated ${minutes} minute${minutes > 1 ? "s" : ""} ago`;
-    return "Updated just now";
-  } catch {
-    return "Unknown";
-  }
-}
-
-function formatDocumentName(repoName: string): string {
-  return repoName
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
-
-function getStatusClass(status: DocumentStatus): string {
-  switch (status) {
-    case "in_review":
-      return "docs-status-badge docs-status-badge--review";
-    case "published":
-      return "docs-status-badge docs-status-badge--published";
-    case "approved":
-      return "docs-status-badge docs-status-badge--approved";
-    case "changes_requested":
-      return "docs-status-badge docs-status-badge--changes";
-    case "draft":
-      return "docs-status-badge docs-status-badge--draft";
-  }
-}
-
-function sortDocs(
-  docs: WorkspaceDocumentSummary[],
-  sort: SortOption,
-): WorkspaceDocumentSummary[] {
-  return [...docs].sort((a, b) => {
-    switch (sort) {
-      case "name":
-        return a.repo.name.localeCompare(b.repo.name);
-      case "status": {
-        const order: Record<DocumentStatus, number> = {
-          approved: 0,
-          published: 1,
-          in_review: 2,
-          changes_requested: 3,
-          draft: 4,
-        };
-        return (
-          order[resolveWorkspaceDocumentStatus(a)] -
-          order[resolveWorkspaceDocumentStatus(b)]
-        );
-      }
-      case "updated":
-      default:
-        return (
-          new Date(b.repo.updated_at).getTime() -
-          new Date(a.repo.updated_at).getTime()
-        );
-    }
-  });
-}
-
-function navigateToQuery(q: string, replace = false): void {
-  const normalised = q.trim();
-  const url =
-    normalised === "" || normalised === DEFAULT_QUERY
-      ? "/documents"
-      : `/documents?q=${encodeURIComponent(normalised)}`;
-  const method = replace ? "replaceState" : "pushState";
-  window.history[method]({}, "", url);
+/** Move the page, and let the app's popstate listener redraw it. */
+function navigateTo(state: DocumentsViewState): void {
+  window.history.pushState({}, "", buildDocumentsUrl(state));
   window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
-function isScopeTab(
-  activeQ: string,
-  tab: "contributions" | "my-docs",
-): boolean {
-  if (tab === "contributions") {
-    return activeQ === "" || activeQ === DEFAULT_QUERY;
-  }
-  return activeQ === MY_DOCS_QUERY;
-}
-
+/**
+ * The library: every document the reader can reach, under one scope at a time.
+ *
+ * Home answers "what is waiting on me?"; this page answers the other question —
+ * "where is that document?" — so it is a list with a scope, a few people, and
+ * nothing else. The scope lives in the URL, which is what makes a saved view
+ * saveable.
+ */
 export function DocumentsPage({
   currentUsername,
   onSelectDocument,
 }: DocumentsPageProps) {
-  const [documents, setDocuments] = useState<WorkspaceDocumentSummary[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // The active query (from URL) drives data fetching.
-  const [activeQ, setActiveQ] = useState<string>(readQueryFromUrl);
-  // The search bar input (may differ from activeQ while the user types).
-  const [inputValue, setInputValue] = useState<string>(() =>
-    queryToSearchBarValue(readQueryFromUrl()),
+  const [state, setState] = useState<DocumentsViewState>(() =>
+    parseDocumentsViewState(window.location.search, currentUsername),
   );
+  const [documents, setDocuments] = useState<WorkspaceDocumentSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [personPickerOpen, setPersonPickerOpen] = useState(false);
 
-  const [sort, setSort] = useState<SortOption>("updated");
-
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // Sync state when the user navigates with browser back/forward.
+  // Back and forward are the way out of a saved view, so the page follows the
+  // address bar rather than its own memory of what was clicked.
   useEffect(() => {
     const handler = () => {
-      const q = readQueryFromUrl();
-      setActiveQ(q);
-      setInputValue(queryToSearchBarValue(q));
+      setState(
+        parseDocumentsViewState(window.location.search, currentUsername),
+      );
     };
     window.addEventListener("popstate", handler);
     return () => window.removeEventListener("popstate", handler);
-  }, []);
+  }, [currentUsername]);
 
-  // Fetch documents whenever activeQ changes.
+  // Only the scope and the words travel to the server; a person filter is
+  // applied to what comes back.
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
+    setIsLoading(true);
     setError(null);
 
-    const params =
-      activeQ && activeQ !== DEFAULT_QUERY
-        ? parseDocumentSearchQuery(activeQ, currentUsername)
-        : undefined;
-
-    getWorkspaceDocuments(params)
-      .then((docs) => {
-        if (!cancelled) {
-          setDocuments(docs);
-          setLoading(false);
-        }
+    getWorkspaceDocuments(
+      toSearchParams(
+        { view: state.view, people: [], freeText: state.freeText },
+        currentUsername,
+      ),
+    )
+      .then((fetched) => {
+        if (cancelled) return;
+        setDocuments(fetched);
+        setIsLoading(false);
       })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          setError(
-            err instanceof Error ? err.message : "Unable to load documents.",
-          );
-          setLoading(false);
-        }
+      .catch((loadError: unknown) => {
+        if (cancelled) return;
+        setError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Unable to load documents.",
+        );
+        setDocuments([]);
+        setIsLoading(false);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [activeQ]);
+  }, [state.view, state.freeText, currentUsername]);
 
-  function handleSearchSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const q = inputValue.trim();
-    navigateToQuery(q === DEFAULT_QUERY ? "" : q);
+  const visible = useMemo(
+    () => applyPersonFilter(documents, state.people),
+    [documents, state.people],
+  );
+  const rows = useMemo(
+    () => buildDocumentRows(visible, currentUsername),
+    [visible, currentUsername],
+  );
+  const owners = useMemo(
+    () =>
+      collectOwners(documents).filter((owner) => !state.people.includes(owner)),
+    [documents, state.people],
+  );
+
+  function selectView(view: SavedView) {
+    setPersonPickerOpen(false);
+    navigateTo({ ...state, view });
   }
 
-  function handleTabClick(tab: "contributions" | "my-docs") {
-    const q = tab === "my-docs" ? MY_DOCS_QUERY : "";
-    navigateToQuery(q);
+  function addPerson(login: string) {
+    setPersonPickerOpen(false);
+    navigateTo({ ...state, people: [...state.people, login] });
   }
 
-  const filtered = sortDocs(documents, sort);
-
-  const totalDocuments = documents.length;
-  const totalResults = filtered.length;
-
-  const isContributionsTab = isScopeTab(activeQ, "contributions");
-  const isMyDocsTab = isScopeTab(activeQ, "my-docs");
+  function removePerson(login: string) {
+    navigateTo({
+      ...state,
+      people: state.people.filter((person) => person !== login),
+    });
+  }
 
   return (
-    <div className="docs-page app-page-shell">
-      {/* Hero search bar */}
-      <form
-        className="docs-hero-search"
-        onSubmit={handleSearchSubmit}
-        role="search"
-      >
-        <input
-          ref={inputRef}
-          type="text"
-          className="docs-hero-search-input"
-          placeholder={`Try owner:@${currentUsername || "me"} or contributed-by:@someone`}
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          aria-label="Search documents"
-          autoComplete="off"
-          spellCheck={false}
-        />
-        {inputValue !== "" && (
+    <div className="docs-page">
+      <h1 className="docs-title">Documents</h1>
+
+      <div className="docs-views">
+        {SAVED_VIEWS.map((view) => (
           <button
+            key={view}
             type="button"
-            className="docs-hero-search-clear"
-            aria-label="Clear search"
-            onClick={() => {
-              setInputValue("");
-              inputRef.current?.focus();
-            }}
+            className={`docs-chip${view === state.view ? " docs-chip--on" : ""}`}
+            aria-pressed={view === state.view}
+            onClick={() => selectView(view)}
           >
-            ×
+            {getSavedViewLabel(view)}
           </button>
-        )}
-        <button
-          type="submit"
-          className="docs-hero-search-submit"
-          aria-label="Search"
-        >
-          <Search size={16} strokeWidth={1.5} aria-hidden="true" />
-        </button>
-      </form>
+        ))}
 
-      <div className="docs-panel">
-        {/* Header: scope tabs + sort */}
-        <div className="docs-panel-header">
-          <div className="docs-scope-tabs">
+        <span className="docs-views-divider" aria-hidden="true" />
+
+        {state.people.map((person) => (
+          <span key={person} className="docs-chip docs-chip--person">
+            Owned by <strong>{capitalizeFirst(person)}</strong>
             <button
               type="button"
-              className={`docs-scope-tab${isContributionsTab ? " docs-scope-tab--active" : ""}`}
-              onClick={() => handleTabClick("contributions")}
+              className="docs-chip-remove"
+              aria-label={`Remove the filter on ${capitalizeFirst(person)}`}
+              onClick={() => removePerson(person)}
             >
-              My Contributions
+              <X size={10} strokeWidth={1.5} aria-hidden="true" />
             </button>
-            <button
-              type="button"
-              className={`docs-scope-tab${isMyDocsTab ? " docs-scope-tab--active" : ""}`}
-              onClick={() => handleTabClick("my-docs")}
-            >
-              My Documents
-            </button>
-          </div>
-          <div className="docs-sort-control">
-            <select
-              className="docs-toolbar-select"
-              value={sort}
-              onChange={(e) => setSort(e.target.value as SortOption)}
-              aria-label="Sort documents"
-            >
-              <option value="updated">Last updated</option>
-              <option value="name">Name</option>
-              <option value="status">Status</option>
-            </select>
-          </div>
-        </div>
+          </span>
+        ))}
 
-        {loading && documents.length === 0 ? (
-          <div className="docs-list">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="docs-list-item docs-list-item--skeleton">
-                <div className="docs-skeleton docs-skeleton--icon" />
-                <div className="docs-skeleton-body">
-                  <div className="docs-skeleton docs-skeleton--title" />
-                  <div className="docs-skeleton docs-skeleton--desc" />
-                  <div className="docs-skeleton docs-skeleton--meta" />
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : error ? (
-          <div className="docs-error-card">
-            <p className="docs-error-text">{error}</p>
-          </div>
-        ) : filtered.length === 0 ? (
-          <div className="docs-empty">
-            <div className="docs-empty-icon">
-              <FileText size={32} strokeWidth={1} aria-hidden="true" />
-            </div>
-            <p className="docs-empty-title">No documents found.</p>
-            <p className="docs-empty-sub">
-              {isContributionsTab
-                ? "You haven't contributed to any documents yet."
-                : "No documents matched your search."}
-            </p>
-          </div>
-        ) : (
-          <div className={`docs-list${loading ? " docs-list--loading" : ""}`}>
-            {filtered.map((doc) => {
-              const status = resolveWorkspaceDocumentStatus(doc);
-              const name = formatDocumentName(doc.repo.name);
-              const updated = formatRelativeTime(doc.repo.updated_at);
-              const openPRs = doc.pendingPRs.length;
-              const owner = doc.repo.owner.login;
+        <PersonPicker
+          owners={owners}
+          open={personPickerOpen}
+          onToggle={() => setPersonPickerOpen((open) => !open)}
+          onPick={addPerson}
+        />
 
-              return (
-                <button
-                  key={`${owner}/${doc.repo.name}`}
-                  type="button"
-                  className="docs-list-item"
-                  onClick={() => onSelectDocument(owner, doc.repo.name)}
-                >
-                  <div className="docs-list-item-icon" aria-hidden="true">
-                    <BindersnapLogoMark width={18} height={18} />
-                  </div>
-                  <div className="docs-list-item-body">
-                    <div className="docs-list-item-top">
-                      <span className="docs-list-item-name">{name}</span>
-                      <span className={getStatusClass(status)}>
-                        {getDocumentStatusLabel(status)}
-                      </span>
-                    </div>
-                    {doc.repo.description && (
-                      <p className="docs-list-item-description">
-                        {doc.repo.description}
-                      </p>
-                    )}
-                    <div className="docs-list-item-meta">
-                      <span className="docs-list-item-owner">
-                        <Users size={12} strokeWidth={1.5} aria-hidden="true" />
-                        {owner}
-                      </span>
-                      {openPRs > 0 && (
-                        <span className="docs-list-item-prs">
-                          <GitPullRequest
-                            size={12}
-                            strokeWidth={1.5}
-                            aria-hidden="true"
-                          />
-                          {openPRs} open{" "}
-                          {openPRs === 1 ? "request" : "requests"}
-                        </span>
-                      )}
-                      {doc.latestTag && (
-                        <span className="docs-list-item-tag">
-                          <Tag size={12} strokeWidth={1.5} aria-hidden="true" />
-                          {doc.latestTag.name}
-                        </span>
-                      )}
-                      <span className="docs-list-item-updated">{updated}</span>
-                    </div>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        )}
+        <span className="docs-views-spacer" />
+        <span className="docs-sorted-by">Sorted by last updated</span>
       </div>
 
-      {!loading && !error && filtered.length > 0 && (
-        <p className="docs-result-count">
-          Showing {totalResults} of {totalDocuments} document
-          {totalDocuments !== 1 ? "s" : ""}
+      <section className="docs-list">
+        {isLoading ? (
+          <DocumentSkeletonRows count={3} />
+        ) : error ? (
+          <div className="docs-notice">
+            <p>{error}</p>
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="docs-notice">
+            <p>{describeEmpty(state)}</p>
+          </div>
+        ) : (
+          rows.map((row) => (
+            <DocumentRowItem
+              key={row.key}
+              row={row}
+              onOpen={() => onSelectDocument(row.owner, row.repo)}
+            />
+          ))
+        )}
+      </section>
+
+      {!isLoading && !error && rows.length > 0 ? (
+        <p className="docs-count">
+          {describeDocumentCount(state.view, rows.length, documents.length)}
         </p>
-      )}
+      ) : null}
     </div>
+  );
+}
+
+/** Why the list is empty, in terms of what the reader last clicked. */
+function describeEmpty(state: DocumentsViewState): string {
+  if (state.freeText) {
+    return `Nothing matched "${state.freeText}".`;
+  }
+  if (state.people.length > 0) {
+    return "Nobody you filtered by owns a document in this view.";
+  }
+  return state.view === "owned"
+    ? "You do not own any documents yet."
+    : "No documents here yet.";
+}
+
+function PersonPicker({
+  owners,
+  open,
+  onToggle,
+  onPick,
+}: {
+  owners: string[];
+  open: boolean;
+  onToggle: () => void;
+  onPick: (login: string) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) onToggle();
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [open, onToggle]);
+
+  return (
+    <div className="docs-person-picker" ref={ref}>
+      <button
+        type="button"
+        className="docs-chip docs-chip--add"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={onToggle}
+      >
+        <Plus size={11} strokeWidth={1.5} aria-hidden="true" />
+        Filter by person
+      </button>
+
+      {open ? (
+        <div className="docs-person-menu" role="menu">
+          {owners.length === 0 ? (
+            <p className="docs-person-menu-empty">
+              Nobody else owns a document in this view.
+            </p>
+          ) : (
+            owners.map((owner) => (
+              <button
+                key={owner}
+                type="button"
+                className="docs-person-menu-item"
+                role="menuitem"
+                onClick={() => onPick(owner)}
+              >
+                {capitalizeFirst(owner)}
+              </button>
+            ))
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DocumentRowItem({
+  row,
+  onOpen,
+}: {
+  row: DocumentRow;
+  onOpen: () => void;
+}) {
+  return (
+    <button type="button" className="docs-list-item" onClick={onOpen}>
+      <span
+        className={`docs-list-item-icon${row.urgent ? " docs-list-item-icon--urgent" : ""}`}
+        aria-hidden="true"
+      >
+        <FileText size={16} strokeWidth={1.4} />
+      </span>
+
+      <span className="docs-list-item-body">
+        <span className="docs-list-item-name">{row.name}</span>
+        <span className="docs-list-item-meta">{row.meta}</span>
+      </span>
+
+      <span className={`docs-pill docs-pill--${toneOf(row)}`}>
+        {row.statusLabel}
+      </span>
+    </button>
+  );
+}
+
+/** Coral for work owed, green for settled, quiet grey for everything else. */
+function toneOf(row: DocumentRow): "review" | "approved" | "waiting" {
+  if (row.status === "needs_your_review" || row.status === "ready_to_publish") {
+    return "review";
+  }
+  return row.status === "current" ? "approved" : "waiting";
+}
+
+function DocumentSkeletonRows({ count }: { count: number }) {
+  return (
+    <>
+      {Array.from({ length: count }, (_, index) => (
+        <div className="docs-list-item docs-list-item--skeleton" key={index}>
+          <span className="docs-list-item-icon" />
+          <span className="docs-skeleton-lines">
+            <span className="docs-skeleton-line docs-skeleton-line--wide" />
+            <span className="docs-skeleton-line docs-skeleton-line--short" />
+          </span>
+        </div>
+      ))}
+    </>
   );
 }

--- a/apps/app/documentsView.test.ts
+++ b/apps/app/documentsView.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from "bun:test";
+
+import type { WorkspaceDocumentSummary } from "./api";
+import {
+  applyPersonFilter,
+  buildDocumentRow,
+  buildDocumentRows,
+  buildDocumentsUrl,
+  collectOwners,
+  describeDocumentCount,
+  parseDocumentsViewState,
+  resolveDocumentRowStatus,
+  toSearchParams,
+} from "./documentsView";
+
+const NOW = new Date("2026-08-22T12:00:00Z").getTime();
+
+function reviewer(
+  login: string,
+  status: "awaiting" | "approved" | "changes_requested" | "commented",
+  stale = false,
+) {
+  return {
+    login,
+    fullName: "",
+    avatarUrl: "",
+    status,
+    reviewedAt: "",
+    stale,
+    requested: true,
+  };
+}
+
+function change(
+  overrides: Partial<WorkspaceDocumentSummary["pendingPRs"][number]> = {},
+): WorkspaceDocumentSummary["pendingPRs"][number] {
+  return {
+    id: 1,
+    number: 1,
+    title: "",
+    state: "open",
+    created: "2026-08-22T10:00:00Z",
+    created_at: "2026-08-22T10:00:00Z",
+    updated_at: "2026-08-22T10:00:00Z",
+    branchName: "upload/v2",
+    approvalCount: 0,
+    requiredApprovals: 1,
+    isApproved: false,
+    isRejected: false,
+    reviewers: [],
+    assignee: null,
+    approvalState: "in_review",
+    user: { login: "maya" },
+    ...overrides,
+  };
+}
+
+function doc(
+  overrides: {
+    name?: string;
+    owner?: string;
+    updatedAt?: string;
+    version?: number | null;
+    tagCreated?: string;
+    pendingPRs?: WorkspaceDocumentSummary["pendingPRs"];
+  } = {},
+): WorkspaceDocumentSummary {
+  const version = overrides.version === undefined ? 3 : overrides.version;
+  return {
+    repo: {
+      id: 1,
+      name: overrides.name ?? "vendor-agreement",
+      full_name: `${overrides.owner ?? "jack"}/${overrides.name ?? "vendor-agreement"}`,
+      description: "",
+      updated_at: overrides.updatedAt ?? "2026-08-22T10:00:00Z",
+      owner: { login: overrides.owner ?? "jack" },
+    },
+    latestTag:
+      version === null
+        ? null
+        : {
+            name: `v${version}`,
+            version,
+            sha: "abc",
+            created: overrides.tagCreated ?? "2026-08-19T09:00:00Z",
+          },
+    pendingPRs: overrides.pendingPRs ?? [],
+    error: null,
+  };
+}
+
+describe("parseDocumentsViewState", () => {
+  it("defaults to the documents the reader contributes to", () => {
+    expect(parseDocumentsViewState("", "dana")).toEqual({
+      view: "contributing",
+      people: [],
+      freeText: "",
+    });
+  });
+
+  it("reads a saved view and person chips out of the URL", () => {
+    expect(
+      parseDocumentsViewState("?view=owned&person=jack,priya", "dana"),
+    ).toEqual({ view: "owned", people: ["jack", "priya"], freeText: "" });
+  });
+
+  it("ignores a view it does not recognise", () => {
+    expect(parseDocumentsViewState("?view=nonsense", "dana").view).toBe(
+      "contributing",
+    );
+  });
+
+  it("maps the owner:@me power query onto the 'I own' chip", () => {
+    const state = parseDocumentsViewState("?q=owner:@me", "dana");
+    expect(state.view).toBe("owned");
+    expect(state.people).toEqual([]);
+  });
+
+  it("maps contributed-by:@me onto the default chip", () => {
+    expect(
+      parseDocumentsViewState("?q=contributed-by:@dana", "dana").view,
+    ).toBe("contributing");
+  });
+
+  it("turns owner:@someone-else into a person chip over everything", () => {
+    const state = parseDocumentsViewState("?q=owner:@jack", "dana");
+    expect(state).toEqual({
+      view: "everything",
+      people: ["jack"],
+      freeText: "",
+    });
+  });
+
+  it("keeps the plain words alongside a filter", () => {
+    expect(
+      parseDocumentsViewState("?q=owner:@me retention", "dana").freeText,
+    ).toBe("retention");
+  });
+
+  it("does not repeat a person named twice", () => {
+    expect(
+      parseDocumentsViewState("?q=owner:@jack&person=Jack", "dana").people,
+    ).toEqual(["jack"]);
+  });
+});
+
+describe("buildDocumentsUrl", () => {
+  it("gives the default view the plainest URL", () => {
+    expect(
+      buildDocumentsUrl({ view: "contributing", people: [], freeText: "" }),
+    ).toBe("/documents");
+  });
+
+  it("carries view, people and search", () => {
+    expect(
+      buildDocumentsUrl({
+        view: "everything",
+        people: ["jack", "priya"],
+        freeText: "retention policy",
+      }),
+    ).toBe("/documents?view=everything&person=jack%2Cpriya&q=retention+policy");
+  });
+
+  it("round-trips through the parser", () => {
+    const state = {
+      view: "owned" as const,
+      people: ["jack"],
+      freeText: "nda",
+    };
+    const url = buildDocumentsUrl(state);
+    expect(parseDocumentsViewState(url.split("?")[1] ?? "", "dana")).toEqual(
+      state,
+    );
+  });
+});
+
+describe("toSearchParams", () => {
+  it("asks for the reader's own documents", () => {
+    expect(
+      toSearchParams({ view: "owned", people: [], freeText: "" }, "dana"),
+    ).toEqual({ ownerUsername: "dana", freeText: undefined });
+  });
+
+  it("asks for membership on the default view", () => {
+    expect(
+      toSearchParams(
+        { view: "contributing", people: [], freeText: "" },
+        "dana",
+      ),
+    ).toEqual({ memberUsername: "dana", freeText: undefined });
+  });
+
+  it("asks for nothing at all when the scope is everything", () => {
+    expect(
+      toSearchParams({ view: "everything", people: [], freeText: "" }, "dana"),
+    ).toBeUndefined();
+  });
+
+  it("sends plain words on any scope", () => {
+    expect(
+      toSearchParams({ view: "everything", people: [], freeText: "nda" }, "d"),
+    ).toEqual({ freeText: "nda" });
+  });
+
+  it("leaves the person filter to the client", () => {
+    expect(
+      toSearchParams({ view: "owned", people: ["jack"], freeText: "" }, "dana"),
+    ).toEqual({ ownerUsername: "dana", freeText: undefined });
+  });
+});
+
+describe("applyPersonFilter", () => {
+  const documents = [
+    doc({ owner: "jack" }),
+    doc({ owner: "priya", name: "employee-handbook" }),
+    doc({ owner: "dana", name: "mutual-nda" }),
+  ];
+
+  it("passes everything through when nobody is named", () => {
+    expect(applyPersonFilter(documents, [])).toHaveLength(3);
+  });
+
+  it("keeps only the named owners, case-insensitively", () => {
+    const filtered = applyPersonFilter(documents, ["Jack", "priya"]);
+    expect(filtered.map((d) => d.repo.owner.login)).toEqual(["jack", "priya"]);
+  });
+});
+
+describe("collectOwners", () => {
+  it("lists each owner once, in order", () => {
+    expect(
+      collectOwners([
+        doc({ owner: "priya" }),
+        doc({ owner: "jack", name: "a" }),
+        doc({ owner: "priya", name: "b" }),
+      ]),
+    ).toEqual(["jack", "priya"]);
+  });
+});
+
+describe("resolveDocumentRowStatus", () => {
+  it("calls a document with nothing open and a version Current", () => {
+    expect(resolveDocumentRowStatus(doc(), "dana")).toBe("current");
+  });
+
+  it("calls a document with no version at all a Draft", () => {
+    expect(resolveDocumentRowStatus(doc({ version: null }), "dana")).toBe(
+      "draft",
+    );
+  });
+
+  it("says a review is owed when the reader is still awaited", () => {
+    const document = doc({
+      pendingPRs: [change({ reviewers: [reviewer("dana", "awaiting")] })],
+    });
+    expect(resolveDocumentRowStatus(document, "dana")).toBe(
+      "needs_your_review",
+    );
+  });
+
+  it("counts a stale approval as a review still owed", () => {
+    const document = doc({
+      pendingPRs: [change({ reviewers: [reviewer("dana", "approved", true)] })],
+    });
+    expect(resolveDocumentRowStatus(document, "dana")).toBe(
+      "needs_your_review",
+    );
+  });
+
+  it("never asks the reader to review their own submission", () => {
+    const document = doc({
+      pendingPRs: [
+        change({
+          user: { login: "dana" },
+          reviewers: [reviewer("dana", "awaiting")],
+        }),
+      ],
+    });
+    expect(resolveDocumentRowStatus(document, "dana")).toBe("in_review");
+  });
+
+  it("reports a fully approved change as ready to publish", () => {
+    const document = doc({
+      pendingPRs: [change({ approvalCount: 1, requiredApprovals: 1 })],
+    });
+    expect(resolveDocumentRowStatus(document, "dana")).toBe("ready_to_publish");
+  });
+
+  it("does not call a rejected change ready", () => {
+    const document = doc({
+      pendingPRs: [
+        change({ approvalCount: 1, requiredApprovals: 1, isRejected: true }),
+      ],
+    });
+    expect(resolveDocumentRowStatus(document, "dana")).toBe("in_review");
+  });
+
+  it("puts the reader's own review ahead of a change that is ready", () => {
+    const document = doc({
+      pendingPRs: [
+        change({ number: 1, approvalCount: 1, requiredApprovals: 1 }),
+        change({ number: 2, reviewers: [reviewer("dana", "awaiting")] }),
+      ],
+    });
+    expect(resolveDocumentRowStatus(document, "dana")).toBe(
+      "needs_your_review",
+    );
+  });
+});
+
+describe("buildDocumentRow", () => {
+  it("writes the meta line the mockup shows for someone else's document", () => {
+    const document = doc({
+      owner: "jack",
+      updatedAt: "2026-08-22T10:00:00Z",
+      pendingPRs: [
+        change({ number: 1, reviewers: [reviewer("dana", "awaiting")] }),
+        change({ number: 2 }),
+      ],
+    });
+
+    const row = buildDocumentRow(document, "dana", NOW);
+    expect(row.name).toBe("Vendor Agreement");
+    expect(row.meta).toBe("Jack owns · v3 · 2 open changes · updated 2h ago");
+    expect(row.statusLabel).toBe("Needs your review");
+    expect(row.urgent).toBe(true);
+  });
+
+  it("names the reader's own proposal rather than counting it", () => {
+    const document = doc({
+      owner: "dana",
+      name: "q3-compliance-policy",
+      updatedAt: "2026-08-21T09:00:00Z",
+      pendingPRs: [change({ user: { login: "dana" } })],
+    });
+
+    expect(buildDocumentRow(document, "dana", NOW).meta).toBe(
+      "You own · v3 · your v4 proposal in review · updated yesterday",
+    );
+  });
+
+  it("says when a single change is ready to publish", () => {
+    const document = doc({
+      owner: "dana",
+      name: "data-retention-policy",
+      version: 1,
+      updatedAt: "2026-08-22T09:00:00Z",
+      pendingPRs: [
+        change({
+          user: { login: "dana" },
+          approvalCount: 2,
+          requiredApprovals: 2,
+        }),
+      ],
+    });
+
+    const row = buildDocumentRow(document, "dana", NOW);
+    expect(row.meta).toBe(
+      "You own · v1 · 1 open change, ready to publish · updated 3h ago",
+    );
+    expect(row.statusLabel).toBe("Ready to publish");
+  });
+
+  it("dates a settled document by its approval, not its last touch", () => {
+    const document = doc({
+      owner: "priya",
+      name: "employee-handbook",
+      version: 6,
+      tagCreated: "2026-08-19T09:00:00Z",
+    });
+
+    const row = buildDocumentRow(document, "dana", NOW);
+    expect(row.meta).toBe(
+      "Priya owns · v6 · no open changes · approved Aug 19",
+    );
+    expect(row.statusLabel).toBe("Current");
+    expect(row.urgent).toBe(false);
+  });
+
+  it("admits when nothing has been published yet", () => {
+    const document = doc({ owner: "dana", version: null });
+    expect(buildDocumentRow(document, "dana", NOW).meta).toContain(
+      "You own · no version published yet · no open changes",
+    );
+  });
+});
+
+describe("buildDocumentRows", () => {
+  it("puts the most recently moved document first", () => {
+    const rows = buildDocumentRows(
+      [
+        doc({ name: "old-one", updatedAt: "2026-08-01T09:00:00Z" }),
+        doc({ name: "new-one", updatedAt: "2026-08-22T09:00:00Z" }),
+      ],
+      "dana",
+      NOW,
+    );
+    expect(rows.map((row) => row.repo)).toEqual(["new-one", "old-one"]);
+  });
+});
+
+describe("describeDocumentCount", () => {
+  it("names the scope", () => {
+    expect(describeDocumentCount("contributing", 6, 6)).toBe(
+      "6 documents you contribute to",
+    );
+    expect(describeDocumentCount("owned", 1, 1)).toBe("1 document you own");
+  });
+
+  it("says how much was filtered away", () => {
+    expect(describeDocumentCount("everything", 2, 6)).toBe(
+      "2 of 6 documents you can see",
+    );
+  });
+});

--- a/apps/app/documentsView.ts
+++ b/apps/app/documentsView.ts
@@ -1,0 +1,370 @@
+import type { WorkspaceDocumentSummary } from "./api";
+import { capitalizeFirst, formatDocumentName } from "./documentDisplay";
+import type { DocumentSearchParams } from "./documentSearch";
+import { parseDocumentSearchQuery } from "./documentSearch";
+import { formatDecisionDate, formatWhen } from "./homeChanges";
+
+/**
+ * The library page, decided here so the component only renders.
+ *
+ * Documents is the one screen that answers "what is in here?", and the shape
+ * of that answer is a scope ("mine", "everyone's") narrowed by people. Both
+ * live in the URL so a view can be linked and reloaded, and both are read back
+ * out of it here — including the `owner:@me` query syntax the page used to put
+ * in its placeholder, which still works for anyone who learned it.
+ */
+
+/** The three saved scopes, as chips across the top of the list. */
+export type SavedView = "contributing" | "owned" | "everything";
+
+export interface DocumentsViewState {
+  view: SavedView;
+  /** Owners the list is narrowed to. Empty means every owner in the scope. */
+  people: string[];
+  /** Plain words typed into the search box, if any. */
+  freeText: string;
+}
+
+const VIEW_LABELS: Record<SavedView, string> = {
+  contributing: "I contribute to",
+  owned: "I own",
+  everything: "Everything I can see",
+};
+
+export const SAVED_VIEWS: SavedView[] = ["contributing", "owned", "everything"];
+
+export function getSavedViewLabel(view: SavedView): string {
+  return VIEW_LABELS[view];
+}
+
+function isSavedView(value: string): value is SavedView {
+  return (SAVED_VIEWS as string[]).includes(value);
+}
+
+function normalizeLogin(login: string): string {
+  return login.trim().replace(/^@/, "").toLowerCase();
+}
+
+function uniqueLogins(logins: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const login of logins) {
+    const normalized = normalizeLogin(login);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+/**
+ * Read the page's state out of a query string.
+ *
+ * The `q` parameter carries two things at once: plain words, and the
+ * `owner:@someone` / `contributed-by:@someone` filters. A filter naming the
+ * reader picks the matching chip; a filter naming anyone else becomes a person
+ * chip, which is the same thing said in a way people can undo by clicking.
+ */
+export function parseDocumentsViewState(
+  search: string,
+  currentUsername: string,
+): DocumentsViewState {
+  const params = new URLSearchParams(search);
+  const me = normalizeLogin(currentUsername);
+
+  const rawQuery = params.get("q") ?? "";
+  const parsed = parseDocumentSearchQuery(rawQuery, currentUsername);
+
+  const viewParam = params.get("view") ?? "";
+  let view: SavedView = isSavedView(viewParam) ? viewParam : "contributing";
+  const people: string[] = [];
+
+  if (parsed.ownerUsername) {
+    const owner = normalizeLogin(parsed.ownerUsername);
+    if (owner === me) {
+      view = "owned";
+    } else {
+      // A filter on someone else says nothing about the reader's own scope, so
+      // widen to everything they can see and let the chip do the narrowing.
+      if (!isSavedView(viewParam)) view = "everything";
+      people.push(owner);
+    }
+  }
+
+  if (parsed.memberUsername) {
+    const member = normalizeLogin(parsed.memberUsername);
+    if (member === me) {
+      view = "contributing";
+    } else if (!isSavedView(viewParam)) {
+      view = "everything";
+    }
+  }
+
+  people.push(...(params.get("person") ?? "").split(",").filter(Boolean));
+
+  return {
+    view,
+    people: uniqueLogins(people),
+    freeText: (parsed.freeText ?? "").trim(),
+  };
+}
+
+/** The address for a state. The default view has the plainest URL there is. */
+export function buildDocumentsUrl(state: DocumentsViewState): string {
+  const params = new URLSearchParams();
+
+  if (state.view !== "contributing") params.set("view", state.view);
+  if (state.people.length > 0) params.set("person", state.people.join(","));
+  if (state.freeText) params.set("q", state.freeText);
+
+  const query = params.toString();
+  return query ? `/documents?${query}` : "/documents";
+}
+
+/**
+ * What to ask the server for.
+ *
+ * Only the scope is a server concern: Gitea's repo search takes one user id,
+ * so a person filter on top of a scope cannot be expressed in the same call.
+ * The scope is the wider of the two, so it is the one that travels.
+ */
+export function toSearchParams(
+  state: DocumentsViewState,
+  currentUsername: string,
+): DocumentSearchParams | undefined {
+  const freeText = state.freeText || undefined;
+
+  switch (state.view) {
+    case "owned":
+      return { ownerUsername: currentUsername, freeText };
+    case "contributing":
+      return { memberUsername: currentUsername, freeText };
+    default:
+      return freeText ? { freeText } : undefined;
+  }
+}
+
+/** Narrow a fetched list to the people the reader picked. */
+export function applyPersonFilter(
+  documents: WorkspaceDocumentSummary[],
+  people: string[],
+): WorkspaceDocumentSummary[] {
+  if (people.length === 0) return documents;
+  const wanted = new Set(people.map(normalizeLogin));
+  return documents.filter((document) =>
+    wanted.has(normalizeLogin(document.repo.owner.login)),
+  );
+}
+
+/** Every owner present in a list, for the "filter by person" picker. */
+export function collectOwners(documents: WorkspaceDocumentSummary[]): string[] {
+  return uniqueLogins(
+    documents.map((document) => document.repo.owner.login),
+  ).sort();
+}
+
+/** What the pill on a row says. The vocabulary is fixed by the design spec. */
+export type DocumentRowStatus =
+  "needs_your_review" | "ready_to_publish" | "in_review" | "current" | "draft";
+
+const STATUS_LABELS: Record<DocumentRowStatus, string> = {
+  needs_your_review: "Needs your review",
+  ready_to_publish: "Ready to publish",
+  in_review: "In review",
+  current: "Current",
+  draft: "Draft",
+};
+
+export function getDocumentRowStatusLabel(status: DocumentRowStatus): string {
+  return STATUS_LABELS[status];
+}
+
+export interface DocumentRow {
+  key: string;
+  owner: string;
+  repo: string;
+  /** "Vendor Agreement". */
+  name: string;
+  /** "Jack owns · v3 · 2 open changes · updated 2h ago". */
+  meta: string;
+  status: DocumentRowStatus;
+  statusLabel: string;
+  /** The row is the reader's next action, and is allowed to wear coral. */
+  urgent: boolean;
+  updatedAt: number;
+}
+
+type OpenChange = WorkspaceDocumentSummary["pendingPRs"][number];
+
+function isReady(change: OpenChange): boolean {
+  return (
+    !change.isRejected &&
+    change.requiredApprovals > 0 &&
+    change.approvalCount >= change.requiredApprovals
+  );
+}
+
+/** A stale approval is a review still owed: the version under it moved on. */
+function awaits(change: OpenChange, username: string): boolean {
+  return change.reviewers.some(
+    (reviewer) =>
+      normalizeLogin(reviewer.login) === normalizeLogin(username) &&
+      (reviewer.status === "awaiting" || reviewer.stale),
+  );
+}
+
+/**
+ * The one word for where a document stands, worst news first.
+ *
+ * "Needs your review" outranks everything because it is the only status that
+ * is about the reader; below it, work that can be finished outranks work that
+ * cannot, and both outrank a document with nothing open.
+ */
+export function resolveDocumentRowStatus(
+  document: WorkspaceDocumentSummary,
+  username: string,
+): DocumentRowStatus {
+  const open = document.pendingPRs;
+
+  if (
+    open.some(
+      (change) =>
+        normalizeLogin(change.user?.login ?? "") !== normalizeLogin(username) &&
+        awaits(change, username),
+    )
+  ) {
+    return "needs_your_review";
+  }
+
+  if (open.some(isReady)) return "ready_to_publish";
+  if (open.length > 0) return "in_review";
+  return document.latestTag ? "current" : "draft";
+}
+
+function describeOwner(ownerLogin: string, username: string): string {
+  return normalizeLogin(ownerLogin) === normalizeLogin(username)
+    ? "You own"
+    : `${capitalizeFirst(ownerLogin)} owns`;
+}
+
+function describeVersion(document: WorkspaceDocumentSummary): string {
+  const version = document.latestTag?.version;
+  return version === undefined ? "no version published yet" : `v${version}`;
+}
+
+/**
+ * The change clause: how much is in flight, in the fewest words that say it.
+ *
+ * A single change is described rather than counted — "1 open change" and
+ * "your v4 proposal in review" are the same fact, and only one of them tells
+ * the reader whose move it is.
+ */
+function describeOpenChanges(
+  document: WorkspaceDocumentSummary,
+  username: string,
+): string {
+  const open = document.pendingPRs;
+  if (open.length === 0) return "no open changes";
+
+  if (open.length === 1) {
+    const change = open[0]!;
+    if (isReady(change)) return "1 open change, ready to publish";
+    if (normalizeLogin(change.user?.login ?? "") === normalizeLogin(username)) {
+      return `your v${(document.latestTag?.version ?? 0) + 1} proposal in review`;
+    }
+    return "1 open change";
+  }
+
+  const ready = open.filter(isReady).length;
+  return ready > 0
+    ? `${open.length} open changes, ${ready} ready to publish`
+    : `${open.length} open changes`;
+}
+
+/**
+ * The last clause: the most recent thing that actually happened.
+ *
+ * A document with nothing open is best described by its approval — that is
+ * the date a reader cares about — while anything in flight is described by
+ * when it last moved.
+ */
+function describeRecency(
+  document: WorkspaceDocumentSummary,
+  now: number,
+): string {
+  if (document.pendingPRs.length === 0 && document.latestTag) {
+    const approved = formatDecisionDate(document.latestTag.created);
+    if (approved) return `approved ${approved}`;
+  }
+  return `updated ${formatWhen(document.repo.updated_at, now)}`;
+}
+
+function toTime(timestamp: string): number {
+  const parsed = new Date(timestamp).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/** One document, as a row: a name, one sentence, and one pill. */
+export function buildDocumentRow(
+  document: WorkspaceDocumentSummary,
+  username: string,
+  now: number = Date.now(),
+): DocumentRow {
+  const owner = document.repo.owner.login;
+  const status = resolveDocumentRowStatus(document, username);
+
+  return {
+    key: `${owner}/${document.repo.name}`,
+    owner,
+    repo: document.repo.name,
+    name: formatDocumentName(document.repo.name),
+    meta: [
+      describeOwner(owner, username),
+      describeVersion(document),
+      describeOpenChanges(document, username),
+      describeRecency(document, now),
+    ].join(" · "),
+    status,
+    statusLabel: STATUS_LABELS[status],
+    urgent: status === "needs_your_review",
+    updatedAt: toTime(document.repo.updated_at),
+  };
+}
+
+/** Every row, last moved first — the only order the page offers. */
+export function buildDocumentRows(
+  documents: WorkspaceDocumentSummary[],
+  username: string,
+  now: number = Date.now(),
+): DocumentRow[] {
+  return documents
+    .map((document) => buildDocumentRow(document, username, now))
+    .sort((left, right) => right.updatedAt - left.updatedAt);
+}
+
+const COUNT_SUFFIXES: Record<SavedView, string> = {
+  contributing: "you contribute to",
+  owned: "you own",
+  everything: "you can see",
+};
+
+/**
+ * The line under the list. It names the scope, because "6 documents" on a
+ * filtered page is a number without a question.
+ */
+export function describeDocumentCount(
+  view: SavedView,
+  shown: number,
+  total: number,
+): string {
+  const noun = total === 1 ? "document" : "documents";
+  const scope = `${noun} ${COUNT_SUFFIXES[view]}`;
+  return shown === total
+    ? `${total} ${scope}`
+    : `${shown} of ${total} ${scope}`;
+}
+
+/** "Owned by Jack" — the label on a person chip. */
+export function describePersonChip(login: string): string {
+  return capitalizeFirst(login);
+}

--- a/tests/document-collaborators.pw.ts
+++ b/tests/document-collaborators.pw.ts
@@ -164,9 +164,9 @@ async function reopenDocumentFromWorkspace(page: Page): Promise<void> {
     timeout: 10_000,
   });
 
-  // Switch to "My Documents" (owner:@me) so we only see documents this user owns.
-  // The default "My Contributions" scope may include documents from other tests.
-  await page.locator(".docs-scope-tab", { hasText: "My Documents" }).click();
+  // Switch to the "I own" saved view so we only see documents this user owns.
+  // The default "I contribute to" scope may include documents from other tests.
+  await page.locator(".docs-chip", { hasText: "I own" }).click();
   await expect(page.locator(".docs-list-item")).toHaveCount(1, {
     timeout: 10_000,
   });


### PR DESCRIPTION
Phase 2 of the approved workspace redesign (`docs/design/workspace-redesign-spec.md`), built against `docs/design/mockups/Documents.dc.html` as the visual source of truth. Follows #338 (phase 1: shell + task-first Home).

## What changed

**The library page.** Lora title, then saved views as chips — **I contribute to** (default) / **I own** / **Everything I can see** — followed by removable "Owned by *Jack* ×" person chips and a dashed "+ Filter by person" affordance. One card of rows: file icon, name, one meta sentence, one status pill. "Sorted by last updated" is stated, not chosen. Under the card, the count names its scope: "6 documents you contribute to".

The meta sentence is the mockup's, verbatim in shape:

- `Jack owns · v3 · 2 open changes · updated 2h ago`
- `You own · v3 · your v4 proposal in review · updated yesterday`
- `You own · v1 · 1 open change, ready to publish · updated 3h ago`
- `Priya owns · v6 · no open changes · approved Aug 19`

A document with nothing open is dated by its approval; anything in flight is dated by when it last moved. A single change is described rather than counted, because "1 open change" and "your v4 proposal in review" are the same fact and only one of them says whose move it is.

Pills use the spec's fixed vocabulary — `Needs your review`, `Ready to publish`, `In review`, `Current`, `Draft` — resolved worst-news-first. Coral appears twice at most and only on work owed: the pill, plus the icon tint on a row that needs the reader's review. Green stays on `Current`.

**Removed**, per the cross-cutting rules: the hero search bar whose placeholder taught `owner:@me` syntax, the four-way sort select, the `GitPullRequest`/`Users`/`Tag` git icons, and the `owner/repo` path in the meta line.

**Search now lives in one place.** The nav search box has been chrome since phase 1; it now searches, submitting to `/documents?q=…`, with `/` to focus and Escape to clear. The `owner:@me` / `contributed-by:@someone` syntax still parses and resolves onto the matching chip — a filter naming someone else becomes a person chip, which is the same statement in a form people can undo by clicking.

## Architecture

Presentation only, as the spec requires. No BFF, Gitea, or schema change:

- Scope maps onto the existing `owner` / `member` parameters on `GET /api/app/documents`.
- The person filter is applied client-side, because Gitea's repo search takes a single user id and cannot express "documents I contribute to, owned by Jack" in one call. Scope is the wider of the two, so scope is what travels.
- All view state lives in the URL (`?view=`, `?person=`, `?q=`), which is what makes a saved view saveable and back/forward the way out of one.

Every sentence, pill, and count is derived in `apps/app/documentsView.ts` so the component only renders.

## Verification

- `bun run test` — 336 pass, 0 fail (35 new tests in `apps/app/documentsView.test.ts`, asserting the mockup's own copy).
- `bun run format:check` — clean.
- Playwright against the local stack: `document-collaborators`, `smoke`, `topnav-new-document`, `new-document-nav` all pass. The collaborators spec's scope-tab selector moved to the new chip.
- Driven by hand in the browser as two seeded users: view switching, person filter add/remove, nav search, and the count line all behave, with no console errors beyond the pre-auth 401s.

`packages/editor/` is untouched — no `sync-demo` needed.

## Not in this PR

Phases 3 (document workspace, four tabs) and 4 (change review) per the spec's build order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)