### PR TITLE
feat: workspace redesign phase 3 — document workspace

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -27,6 +27,7 @@ import { usePaymentRequiredHandler } from "./paymentRequired";
 import {
   asShellRoute,
   getRoute,
+  isLegacyDocumentTabPath,
   isLegacyInboxPath,
   isProtectedAppRoute,
   routeToPath,
@@ -363,6 +364,12 @@ export function App() {
   useEffect(() => {
     if (isLegacyInboxPath(window.location.pathname)) {
       navigateTo({ kind: "workspace" }, true);
+      return;
+    }
+
+    // Same for the document's old Team and Settings tabs, now one page.
+    if (isLegacyDocumentTabPath(window.location.pathname)) {
+      navigateTo(route, true);
     }
   }, [route]);
 

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -677,120 +677,131 @@ input {
   align-content: start;
 }
 
-/* Header — the one part of the page that never changes as you move
-   between tabs, so you always know which document you are looking at.
-   It sits on the page rather than inside a card: a floating box that
-   resizes under you is the thing this page was accused of. */
-.doc-header {
+/* ── Document workspace ─────────────────────────────────────────────
+   The page is 1080px of content on paper, not a stack of cards. The header
+   never changes as you move between tabs, so you always know which document
+   you are looking at. */
+.docw-page {
+  width: 100%;
+  /* 1080px of content, plus the gutter that keeps it off the edge. */
+  max-width: calc(1080px + var(--brand-space-8) * 2);
+  margin: 0 auto;
+  padding: var(--brand-space-8) var(--brand-space-8) var(--brand-space-16);
+  box-sizing: border-box;
   display: grid;
   gap: var(--brand-space-5);
+  align-content: start;
+}
+
+.doc-header {
+  display: grid;
+  gap: var(--brand-space-6);
   padding: 0;
   background: none;
   border: none;
   border-bottom: 1px solid var(--bs-rule);
   border-radius: 0;
+  margin-bottom: var(--brand-space-2);
 }
 
 .doc-header-top {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: var(--brand-space-6);
+  gap: var(--brand-space-5);
   flex-wrap: wrap;
 }
 
 .doc-header-identity {
   display: grid;
-  gap: var(--brand-space-2);
+  gap: 6px;
   min-width: 0;
-}
-
-.doc-header-back {
-  justify-self: start;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--brand-space-1);
-  margin-bottom: var(--brand-space-1);
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--bs-text-muted);
-  cursor: pointer;
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-label);
-  letter-spacing: var(--brand-tracking-wide);
-  text-transform: uppercase;
-  transition: color var(--brand-transition-base);
-}
-
-.doc-header-back:hover,
-.doc-header-back:focus-visible {
-  color: var(--bs-text-primary);
-}
-
-.doc-header-path {
-  margin: 0;
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-label);
-  letter-spacing: var(--brand-tracking-wide);
-  color: var(--bs-text-faint);
-  overflow-wrap: anywhere;
+  flex: 1;
 }
 
 .doc-header-title {
-  margin: 0;
   font-family: var(--brand-font-serif);
-  font-size: var(--brand-text-h2);
-  line-height: var(--brand-leading-tight);
-  overflow-wrap: anywhere;
+  font-size: 26px;
+  font-weight: var(--brand-weight-semibold);
+  letter-spacing: var(--brand-tracking-snug);
+  color: var(--bs-text-primary);
+  margin: 0;
 }
 
 .doc-header-facts {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: var(--brand-space-2) var(--brand-space-3);
-  margin-top: var(--brand-space-1);
+  flex-wrap: wrap;
+  gap: var(--brand-space-3);
 }
 
 .doc-header-fact {
-  font-size: var(--brand-text-sm);
+  font-size: 12.5px;
   color: var(--bs-text-muted);
 }
 
 .doc-header-file {
   font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
+  font-size: 11.5px;
 }
 
-.doc-header-actions {
-  display: flex;
-  gap: var(--brand-space-3);
-  align-items: center;
-}
-
-/* Official version — a fact, not a status. "Published" and "In review" are
-   both true at once whenever a new version is under review, so the header
-   states the version on record and leaves the verdicts to the Changes tab. */
+/* The version on record. Green means it is the record; nothing published
+   yet is a quiet grey statement of fact, not a warning. */
 .doc-version-pill {
   display: inline-flex;
   align-items: center;
-  padding: var(--brand-space-1) var(--brand-space-3);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-sm);
-  background: var(--bs-surface-2);
-  color: var(--bs-text-secondary);
+  gap: 5px;
   font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
+  font-size: var(--brand-text-label);
   font-weight: var(--brand-weight-medium);
-  letter-spacing: var(--brand-tracking-wide);
+  letter-spacing: 0.04em;
+  border-radius: var(--brand-radius-full);
+  padding: 3px 10px;
+  white-space: nowrap;
 }
 
-/* Tabs — GitHub's repo bar, in Bindersnap's voice. */
+.doc-version-pill--current {
+  background: var(--bs-green-dim);
+  color: var(--brand-green);
+}
+
+.doc-version-pill--none {
+  background: var(--bs-surface-2);
+  color: var(--bs-text-muted);
+}
+
+/* The one coral element on the page: the next action. */
+.doc-header-submit {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  background: var(--brand-coral);
+  color: #ffffff;
+  border: none;
+  border-radius: var(--brand-radius-md);
+  padding: 9px var(--brand-space-4);
+  font-family: var(--brand-font-sans);
+  font-size: 13px;
+  font-weight: var(--brand-weight-semibold);
+  cursor: pointer;
+  transition: background var(--brand-transition-base);
+}
+
+.doc-header-submit:hover {
+  background: var(--brand-coral-dark);
+}
+
+.doc-header-submit:focus-visible {
+  outline: 2px solid var(--brand-coral);
+  outline-offset: 2px;
+}
+
+/* Tabs — four of them, sitting on the header's own rule. */
 .doc-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--brand-space-1);
+  gap: var(--brand-space-6);
   margin: 0 0 -1px;
   padding: 0;
 }
@@ -799,8 +810,8 @@ input {
   appearance: none;
   display: inline-flex;
   align-items: center;
-  gap: var(--brand-space-2);
-  padding: var(--brand-space-3) var(--brand-space-3);
+  gap: 6px;
+  padding: 10px 2px;
   border: none;
   border-bottom: 2px solid transparent;
   background: none;
@@ -825,18 +836,16 @@ input {
   border-bottom-color: var(--brand-coral);
 }
 
+/* A count, not an alarm: the bubble stays quiet even on the active tab.
+   History has none at all — a number of versions is not a number of things
+   to deal with. */
 .doc-tab-count {
-  padding: 1px var(--brand-space-2);
-  border-radius: var(--brand-radius-sm);
+  padding: 1px 7px;
+  border-radius: var(--brand-radius-full);
   background: var(--bs-surface-2);
   color: var(--bs-text-muted);
   font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-}
-
-.doc-tab--active .doc-tab-count {
-  background: var(--bs-coral-dim);
-  color: var(--brand-coral-dark);
+  font-size: 10.5px;
 }
 
 .document-detail-tab-panel {
@@ -844,11 +853,11 @@ input {
   gap: var(--brand-space-5);
 }
 
-/* Document tab — the file, with a summary rail beside it. */
+/* Document tab — the file, with a slim rail beside it. */
 .doc-workspace {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
-  gap: var(--brand-space-5);
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 28px;
   align-items: start;
 }
 
@@ -872,22 +881,27 @@ input {
   font-size: var(--brand-text-sm);
 }
 
+/* The document itself: one white sheet, big radius, room to read. The
+   toolbar is the only chrome on it — a preview you cannot download is a
+   picture of a document. */
 .doc-preview {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   background: var(--bs-surface-1);
   border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-md);
+  border-radius: var(--brand-radius-xl);
   overflow: hidden;
+  min-height: 540px;
 }
 
+/* Slim chrome on a white sheet: the file it is, and the way to keep it. */
 .doc-preview-toolbar {
   display: flex;
   align-items: center;
   gap: var(--brand-space-3);
-  padding: var(--brand-space-3) var(--brand-space-4);
-  background: var(--bs-surface-2);
-  border-bottom: 1px solid var(--bs-rule);
+  padding: var(--brand-space-3) var(--brand-space-5);
+  background: none;
+  border-bottom: 1px solid var(--bs-rule-warm);
 }
 
 .doc-preview-filename {
@@ -922,9 +936,10 @@ input {
    no scrollbox inside a scrollbox. */
 .doc-preview-body {
   display: grid;
+  align-content: start;
   gap: var(--brand-space-3);
-  padding: var(--brand-space-5);
-  background: var(--bs-page-bg);
+  padding: var(--brand-space-12) 56px;
+  background: var(--bs-surface-1);
   min-height: 320px;
 }
 
@@ -1008,11 +1023,12 @@ input {
 }
 
 /* The sheet — the document reads like paper, not like a form field. */
+/* The sheet is already inside the card, so it carries no frame of its own —
+   it just holds the measure the document is read at. */
 .doc-preview-sheet {
-  padding: var(--brand-space-8);
-  background: var(--bs-surface-1);
-  border: 1px solid var(--bs-rule-warm);
-  border-radius: var(--brand-radius-sm);
+  width: 100%;
+  max-width: 620px;
+  margin: 0 auto;
   color: var(--bs-text-secondary);
 }
 
@@ -1154,122 +1170,213 @@ input {
   height: auto;
 }
 
-/* Summary rail — stays in view while a long document scrolls past it.
-   One column with rules between its sections, not a stack of cards: four
-   bordered boxes in a 300px gutter is four times the frame and none of the
-   information. */
+/* Summary rail — three sections, stated in the order they matter: what
+   somebody still has to decide, what is already on the record, and who is
+   here. Section titles are mono labels on the paper; only the cards under
+   them are white. */
 .doc-rail {
   display: grid;
   align-content: start;
+  gap: var(--brand-space-6);
   position: sticky;
   top: var(--brand-space-4);
-  padding: var(--brand-space-1) var(--brand-space-5);
-  border-left: 1px solid var(--bs-rule);
 }
 
-.doc-rail-card {
+.doc-rail-section {
   display: grid;
-  gap: var(--brand-space-3);
-  padding: var(--brand-space-5) 0;
-}
-
-.doc-rail-card + .doc-rail-card {
-  border-top: 1px solid var(--bs-rule-warm);
+  gap: 10px;
+  align-content: start;
 }
 
 .doc-rail-title {
-  display: flex;
-  align-items: center;
-  gap: var(--brand-space-2);
-  margin: 0;
   font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-label);
+  font-size: 11px;
   font-weight: var(--brand-weight-medium);
-  letter-spacing: var(--brand-tracking-wide);
+  letter-spacing: var(--brand-tracking-wider);
   text-transform: uppercase;
   color: var(--bs-text-muted);
+  margin: 0;
+}
+
+/* The rail's one coral element, and the page's second: what is unfinished. */
+.doc-rail-title--urgent {
+  color: var(--brand-coral-dark);
+}
+
+.doc-rail-card {
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-xl);
+  padding: 14px var(--brand-space-4);
+}
+
+.doc-rail-card--quiet {
+  background: none;
+  border-style: dashed;
+}
+
+.doc-rail-card--rows {
+  padding: 6px var(--brand-space-4);
+}
+
+.doc-rail-card-title {
+  margin: 0;
+  font-size: 13.5px;
+  font-weight: var(--brand-weight-medium);
+  color: var(--bs-text-primary);
+}
+
+.doc-rail-card-meta {
+  margin: 3px 0 var(--brand-space-2);
+  font-size: 12.5px;
+  color: var(--bs-text-muted);
+}
+
+.doc-rail-card-link,
+.doc-rail-more,
+.doc-team-manage {
+  appearance: none;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--brand-coral-dark);
+  cursor: pointer;
+  font-family: var(--brand-font-sans);
+  text-align: left;
+}
+
+.doc-rail-card-link {
+  font-size: 13px;
+  font-weight: var(--brand-weight-semibold);
+}
+
+.doc-rail-more,
+.doc-team-manage {
+  font-size: 12.5px;
+  font-weight: var(--brand-weight-medium);
+}
+
+.doc-rail-card-link:hover,
+.doc-rail-more:hover,
+.doc-team-manage:hover {
+  color: var(--brand-coral);
 }
 
 .doc-rail-note {
   margin: 0;
-  font-size: var(--brand-text-sm);
-  line-height: var(--brand-leading-normal);
+  font-size: 12.5px;
   color: var(--bs-text-muted);
 }
 
-.doc-rail-facts {
-  display: grid;
-  gap: var(--brand-space-2);
-  margin: 0;
-}
-
-.doc-rail-facts > div {
+/* Versions: hairline-separated rows inside one card, not one card each. */
+.doc-rail-row {
+  appearance: none;
   display: flex;
-  justify-content: space-between;
-  gap: var(--brand-space-3);
-  padding-top: var(--brand-space-2);
-  border-top: 1px solid var(--bs-rule-warm);
-}
-
-.doc-rail-facts dt {
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-  text-transform: uppercase;
-  letter-spacing: var(--brand-tracking-wide);
-  color: var(--bs-text-faint);
-}
-
-.doc-rail-facts dd {
-  margin: 0;
-  font-size: var(--brand-text-sm);
-  color: var(--bs-text-secondary);
-}
-
-.doc-rail-list {
-  display: grid;
-  gap: var(--brand-space-1);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.doc-rail-link {
-  display: grid;
-  gap: 2px;
+  align-items: center;
+  gap: 10px;
   width: 100%;
-  padding: var(--brand-space-2) var(--brand-space-3);
-  border: 1px solid transparent;
-  border-radius: var(--brand-radius-md);
+  padding: 9px 0;
+  border: none;
+  border-top: 1px solid var(--bs-rule-warm);
   background: none;
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--brand-transition-base);
-}
-
-.doc-rail-link:hover,
-.doc-rail-link:focus-visible {
-  background: var(--bs-surface-2);
-  outline: none;
-}
-
-.doc-rail-link-title {
-  font-size: var(--brand-text-sm);
   color: var(--bs-text-secondary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-family: var(--brand-font-sans);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
 }
 
-.doc-rail-link-sub {
+.doc-rail-row:first-child {
+  border-top: none;
+}
+
+.doc-rail-row:hover .doc-rail-row-date {
+  color: var(--bs-text-primary);
+}
+
+.doc-rail-row:focus-visible {
+  outline: 2px solid var(--brand-coral);
+  outline-offset: -2px;
+}
+
+.doc-rail-version {
+  display: inline-flex;
+  align-items: center;
   font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-  color: var(--bs-text-faint);
+  font-size: var(--brand-text-label);
+  font-weight: var(--brand-weight-medium);
+  letter-spacing: 0.04em;
+  border-radius: var(--brand-radius-full);
+  padding: 3px 10px;
+  background: var(--bs-surface-2);
+  color: var(--bs-text-muted);
 }
 
-.doc-rail-actions {
+.doc-rail-version--current {
+  background: var(--bs-green-dim);
+  color: var(--brand-green);
+}
+
+.doc-rail-row-date {
+  flex: 1;
+}
+
+.doc-rail-row-note {
+  font-size: 12.5px;
+  color: var(--bs-text-muted);
+}
+
+/* Team: faces, then the way to the page that lists them properly. */
+.doc-team {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: var(--brand-space-2);
+  flex-wrap: wrap;
+}
+
+.doc-team-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--brand-radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: var(--bs-surface-2);
+  color: var(--bs-text-secondary);
+  font-size: 11px;
+  font-weight: var(--brand-weight-semibold);
+}
+
+.doc-team-avatar--more {
+  background: none;
+  border: 1px dashed var(--bs-rule);
+  color: var(--bs-text-muted);
+}
+
+.doc-team-manage {
+  margin-left: var(--brand-space-1);
+}
+
+/* Access & approvals — who is on the document, then what has to happen
+   before anything lands. One page, because it is one question. */
+.doc-access {
+  display: grid;
+  gap: var(--brand-space-10);
+}
+
+.doc-access-section {
+  display: grid;
+  gap: var(--brand-space-4);
+}
+
+.doc-access-heading {
+  font-family: var(--brand-font-serif);
+  font-size: 18px;
+  font-weight: var(--brand-weight-semibold);
+  letter-spacing: var(--brand-tracking-snug);
+  color: var(--bs-text-primary);
+  margin: 0;
 }
 
 /* Changes tab — every change this document has seen, open ones first.
@@ -2224,6 +2331,10 @@ input {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .docw-page {
+    padding: var(--brand-space-5) var(--brand-space-5) var(--brand-space-12);
+  }
+
   .doc-rail {
     position: static;
   }
@@ -2235,12 +2346,9 @@ input {
     flex-wrap: nowrap;
   }
 
-  .doc-header-actions {
+  .doc-header-submit {
     width: 100%;
-  }
-
-  .doc-header-actions .bs-btn {
-    width: 100%;
+    justify-content: center;
   }
 
   .doc-history-row {
@@ -2256,11 +2364,7 @@ input {
   }
 
   .doc-preview-body {
-    padding: var(--brand-space-3);
-  }
-
-  .doc-preview-sheet {
-    padding: var(--brand-space-5);
+    padding: var(--brand-space-5) var(--brand-space-4);
   }
 }
 

--- a/apps/app/components/AnonymousDocumentShell.tsx
+++ b/apps/app/components/AnonymousDocumentShell.tsx
@@ -58,13 +58,9 @@ export function AnonymousDocumentShell({
               owner={route.owner}
               repo={route.repo}
               uploaderSlug={null}
-              // Signed-out readers get the record, not the controls: team and
-              // settings fall back to the document itself.
-              activeView={
-                route.tab === "permissions" || route.tab === "collaborators"
-                  ? "overview"
-                  : route.tab
-              }
+              // Signed-out readers get the record, not the controls:
+              // access and approvals falls back to the document itself.
+              activeView={route.tab === "access" ? "overview" : route.tab}
               activeChangeNumber={route.changeNumber ?? null}
               activeChangeView={route.changeView ?? "discussion"}
               onTabChange={(tab) =>

--- a/apps/app/components/DocumentAccess.tsx
+++ b/apps/app/components/DocumentAccess.tsx
@@ -1,0 +1,45 @@
+import { DocumentCollaborators } from "./DocumentCollaborators";
+import { DocumentPermissions } from "./DocumentPermissions";
+
+interface DocumentAccessProps {
+  owner: string;
+  repo: string;
+  currentUsername: string;
+}
+
+/**
+ * Access & approvals — one page, because it was always one question.
+ *
+ * "Team" said who could see the document and "Settings" said how many of them
+ * had to sign off before it published. Splitting those across two tabs meant
+ * adding an approver and requiring their approval were two different errands.
+ * They are the same errand, so this is the page that answers it: who is on
+ * this document, then what has to happen before anything lands.
+ */
+export function DocumentAccess({
+  owner,
+  repo,
+  currentUsername,
+}: DocumentAccessProps) {
+  return (
+    <div className="doc-access">
+      <section className="doc-access-section" aria-label="Who has access">
+        <h2 className="doc-access-heading">Who has access</h2>
+        <DocumentCollaborators
+          owner={owner}
+          repo={repo}
+          currentUsername={currentUsername}
+        />
+      </section>
+
+      <section className="doc-access-section" aria-label="Approval rules">
+        <h2 className="doc-access-heading">Approval rules</h2>
+        <DocumentPermissions
+          owner={owner}
+          repo={repo}
+          currentUsername={currentUsername}
+        />
+      </section>
+    </div>
+  );
+}

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from "react";
-import { Clock, GitPullRequest, Users } from "lucide-react";
 
 import type {
   PullRequestWithApprovalState,
@@ -9,25 +8,31 @@ import type {
   ReviewSettings,
   UploadResult,
 } from "../api";
-import { downloadDocument, getClosedChanges, getDocumentDetail } from "../api";
+import {
+  downloadDocument,
+  getClosedChanges,
+  getDocumentDetail,
+  listDocumentCollaborators,
+} from "../api";
 import type { DocumentChangeView, DocumentTab } from "../routes";
 import { describeFileKind } from "../documentFile";
 import type { ChangeRecord } from "../documentDisplay";
 import {
-  capitalizeFirst,
   closedChangeToRecord,
-  formatDate,
   formatDocumentName,
-  getApprovalStateLabel,
-  parseSubmissionSummary,
   toChangeRecord,
 } from "../documentDisplay";
+import {
+  buildDocumentHeaderFacts,
+  buildPendingDecisionRows,
+  buildTeamAvatars,
+  buildVersionRailRows,
+} from "../documentWorkspace";
+import { DocumentAccess } from "./DocumentAccess";
 import { DocumentChangeDetail } from "./DocumentChangeDetail";
 import type { ChangeFilter } from "./DocumentChanges";
 import { DocumentChanges } from "./DocumentChanges";
-import { DocumentCollaborators } from "./DocumentCollaborators";
 import { DocumentHistory } from "./DocumentHistory";
-import { DocumentPermissions } from "./DocumentPermissions";
 import { DocumentPreview } from "./DocumentPreview";
 import { UploadModal } from "./UploadModal";
 
@@ -70,10 +75,10 @@ function triggerBrowserDownload(blob: Blob, fileName: string): void {
 /**
  * The document workspace.
  *
- * One document, five views: what it says now, what is waiting on a decision,
- * how it got here, who can see it, and how it gets approved. The header names
- * the document and the version on record, and holds still at the same width on
- * every tab — it is a page, not a stack of boxes that resize under you.
+ * One document, four views: what it says now, what is waiting on a decision,
+ * how it got here, and who can approve it. The header names the document and
+ * the version on record, and holds still at the same width on every tab — it
+ * is a page, not a stack of boxes that resize under you.
  */
 export function DocumentDetail({
   owner,
@@ -116,6 +121,11 @@ export function DocumentDetail({
     loading: boolean;
     error: string | null;
   }>({ loading: false, error: null });
+  // Faces for the rail. Purely presentational, so a refusal costs nothing but
+  // an empty row — the Access & approvals tab is where this is really asked.
+  const [collaborators, setCollaborators] = useState<
+    RepoCollaboratorPermissionSummary[]
+  >([]);
 
   const loadDocumentData = useCallback(async () => {
     setIsLoading(true);
@@ -170,10 +180,27 @@ export function DocumentDetail({
     setChangeFilter("open");
   }, [loadDocumentData]);
 
+  useEffect(() => {
+    if (uploaderSlug === null) return;
+
+    let cancelled = false;
+    listDocumentCollaborators(owner, repo, 1, 12)
+      .then((payload) => {
+        if (!cancelled) setCollaborators(payload.collaborators);
+      })
+      .catch(() => {
+        if (!cancelled) setCollaborators([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [owner, repo, uploaderSlug]);
+
   const isAnonymous = uploaderSlug === null;
   const currentUser = uploaderSlug ?? "";
   const documentName = formatDocumentName(repo);
-  const latestTag = tags.length > 0 ? tags[0] : null;
+  const latestTag = tags[0] ?? null;
   const nextVersion = (latestTag?.version ?? 0) + 1;
 
   // Assigning a change is a write to the pull request, so it takes the same
@@ -258,9 +285,8 @@ export function DocumentDetail({
 
   if (isLoading) {
     return (
-      <div className="vault-detail app-page-shell">
+      <div className="docw-page">
         <div className="doc-panel vault-empty-state">
-          <div className="bs-eyebrow">Loading</div>
           <h2>Loading document details…</h2>
           <p>Fetching version history and pending approvals.</p>
         </div>
@@ -270,9 +296,8 @@ export function DocumentDetail({
 
   if (error) {
     return (
-      <div className="vault-detail app-page-shell">
+      <div className="docw-page">
         <div className="doc-panel vault-error-state">
-          <div className="bs-eyebrow">Error</div>
           <h2>Unable to load document</h2>
           <p>{error}</p>
           <button
@@ -290,60 +315,64 @@ export function DocumentDetail({
   const viewingRef = viewedVersion?.tagName ?? "main";
   const isViewingLatest = viewedVersion === null;
 
+  // History carries no count on purpose: a version count is not a number of
+  // things to deal with, and a bubble beside it reads like one.
   const tabs: { id: DocumentTab; label: string; count?: number }[] = [
     { id: "overview", label: "Document" },
     { id: "changes", label: "Changes", count: openPRs.length },
-    { id: "history", label: "History", count: tags.length },
+    { id: "history", label: "History" },
     ...(isAnonymous
       ? []
-      : ([
-          { id: "collaborators", label: "Team" },
-          { id: "permissions", label: "Settings" },
-        ] as const)),
+      : ([{ id: "access", label: "Access & approvals" }] as const)),
   ];
 
+  const headerFacts = buildDocumentHeaderFacts({
+    latestTag,
+    fileName: canonicalFileInfo?.downloadFileName ?? null,
+  });
+  const pendingRows = buildPendingDecisionRows(openPRs);
+  const versionRows = buildVersionRailRows(tags);
+  const teamAvatars = buildTeamAvatars(collaborators, owner);
+
   return (
-    <div className="vault-detail app-page-shell">
+    <div className="docw-page">
       <header className="doc-header">
         <div className="doc-header-top">
           <div className="doc-header-identity">
-            <p className="doc-header-path">
-              {owner} / {repo}
-            </p>
+            {/* No owner/repo path. Nobody thinks of their contract as
+                "alice / vendor-agreement" — it is the Vendor Agreement. */}
             <h1 className="doc-header-title">{documentName}</h1>
             <div className="doc-header-facts">
               {/* The official version, not a status. A document can have v3
                   published and v4 in review at the same time, so a single
                   status word here was always going to be a lie. */}
-              <span className="doc-version-pill">
-                {latestTag ? `v${latestTag.version}` : "No version yet"}
+              <span
+                className={`doc-version-pill doc-version-pill--${headerFacts.tone}`}
+              >
+                {headerFacts.versionLabel}
               </span>
-              {latestTag ? (
-                <span className="doc-header-fact">
-                  Approved {formatDate(latestTag.created)}
-                </span>
-              ) : (
-                <span className="doc-header-fact">Nothing published yet</span>
-              )}
-              {canonicalFileInfo ? (
-                <span className="doc-header-fact doc-header-file">
-                  {canonicalFileInfo.downloadFileName} ·{" "}
-                  {describeFileKind(canonicalFileInfo.downloadFileName)}
+              <span className="doc-header-fact">
+                {headerFacts.approvedLine}
+              </span>
+              {headerFacts.fileName ? (
+                <span
+                  className="doc-header-fact doc-header-file"
+                  title={describeFileKind(headerFacts.fileName)}
+                >
+                  {headerFacts.fileName}
                 </span>
               ) : null}
             </div>
           </div>
 
           {!isAnonymous ? (
-            <div className="doc-header-actions">
-              <button
-                className="bs-btn bs-btn-primary"
-                type="button"
-                onClick={() => setShowUploadModal(true)}
-              >
-                Submit New Version
-              </button>
-            </div>
+            <button
+              className="doc-header-submit"
+              type="button"
+              onClick={() => setShowUploadModal(true)}
+            >
+              Submit new version
+            </button>
           ) : null}
         </div>
 
@@ -376,17 +405,9 @@ export function DocumentDetail({
         </p>
       ) : null}
 
-      {activeView === "collaborators" && !isAnonymous ? (
+      {activeView === "access" && !isAnonymous ? (
         <div className="document-detail-tab-panel">
-          <DocumentCollaborators
-            owner={owner}
-            repo={repo}
-            currentUsername={currentUser}
-          />
-        </div>
-      ) : activeView === "permissions" && !isAnonymous ? (
-        <div className="document-detail-tab-panel">
-          <DocumentPermissions
+          <DocumentAccess
             owner={owner}
             repo={repo}
             currentUsername={currentUser}
@@ -522,150 +543,105 @@ export function DocumentDetail({
           </div>
 
           <aside className="doc-rail" aria-label="Document summary">
-            <section className="doc-rail-card">
-              <h2 className="doc-rail-title">
-                {latestTag
-                  ? `Official version — v${latestTag.version}`
-                  : "No approved version yet"}
-              </h2>
-              {/* When there is no version, the page itself already says so in
-                  full. The rail does not need to say it twice. */}
-              {latestTag ? (
-                <p className="doc-rail-note">
-                  Approved on {formatDate(latestTag.created)}. Approved versions
-                  are locked — a change means a new version and a new review.
-                </p>
-              ) : null}
-              <dl className="doc-rail-facts">
-                <div>
-                  <dt>Owner</dt>
-                  <dd>{capitalizeFirst(owner)}</dd>
-                </div>
-                <div>
-                  <dt>Versions</dt>
-                  <dd>{tags.length}</dd>
-                </div>
-                <div>
-                  <dt>Open changes</dt>
-                  <dd>{openPRs.length}</dd>
-                </div>
-              </dl>
-            </section>
-
-            <section className="doc-rail-card">
-              <h2 className="doc-rail-title">
-                <GitPullRequest
-                  size={14}
-                  strokeWidth={1.5}
-                  aria-hidden="true"
-                />
+            {/* The one coral thing on the page: what somebody still has to
+                decide. Everything below it is reference. */}
+            <section className="doc-rail-section">
+              <h2 className="doc-rail-title doc-rail-title--urgent">
                 Waiting on a decision
               </h2>
-              {openPRs.length === 0 ? (
-                <p className="doc-rail-note">
-                  Nothing is pending. The approved version above is the current
-                  record.
-                </p>
+              {pendingRows.length === 0 ? (
+                <div className="doc-rail-card doc-rail-card--quiet">
+                  <p className="doc-rail-note">
+                    Nothing is pending. The version above is the record.
+                  </p>
+                </div>
               ) : (
-                <>
-                  <ul className="doc-rail-list">
-                    {openPRs.slice(0, 3).map((pr) => (
-                      <li key={pr.number}>
-                        <button
-                          className="doc-rail-link"
-                          type="button"
-                          onClick={() => onOpenChange(pr.number ?? null)}
-                        >
-                          <span className="doc-rail-link-title">
-                            {parseSubmissionSummary(pr.body) ??
-                              `Submitted by ${capitalizeFirst(pr.user?.login ?? "someone")}`}
-                          </span>
-                          <span className="doc-rail-link-sub">
-                            {getApprovalStateLabel(pr.approvalState)}
-                            {pr.created_at
-                              ? ` · ${formatDate(pr.created_at)}`
-                              : ""}
-                          </span>
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                  <button
-                    className="bs-btn bs-btn-secondary"
-                    type="button"
-                    onClick={() => onTabChange("changes")}
-                  >
-                    Review {openPRs.length} change
-                    {openPRs.length === 1 ? "" : "s"}
-                  </button>
-                </>
+                pendingRows.map((row) => (
+                  <div className="doc-rail-card" key={row.key}>
+                    <p className="doc-rail-card-title">{row.title}</p>
+                    <p className="doc-rail-card-meta">{row.meta}</p>
+                    <button
+                      className="doc-rail-card-link"
+                      type="button"
+                      onClick={() => onOpenChange(row.number)}
+                    >
+                      Review →
+                    </button>
+                  </div>
+                ))
               )}
             </section>
 
-            <section className="doc-rail-card">
-              <h2 className="doc-rail-title">
-                <Clock size={14} strokeWidth={1.5} aria-hidden="true" />
-                Recent versions
-              </h2>
-              {tags.length === 0 ? (
-                <p className="doc-rail-note">No published versions yet.</p>
+            <section className="doc-rail-section">
+              <h2 className="doc-rail-title">Versions</h2>
+              {versionRows.length === 0 ? (
+                <div className="doc-rail-card doc-rail-card--quiet">
+                  <p className="doc-rail-note">Nothing published yet.</p>
+                </div>
               ) : (
-                <>
-                  <ul className="doc-rail-list">
-                    {tags.slice(0, 4).map((tag) => (
-                      <li key={tag.name}>
-                        <button
-                          className="doc-rail-link"
-                          type="button"
-                          onClick={() => onTabChange("history")}
-                        >
-                          <span className="doc-rail-link-title">
-                            <span className="vault-version-badge">
-                              v{tag.version}
-                            </span>
-                          </span>
-                          <span className="doc-rail-link-sub">
-                            {formatDate(tag.created)}
-                          </span>
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                  <button
-                    className="bs-btn bs-btn-secondary"
-                    type="button"
-                    onClick={() => onTabChange("history")}
-                  >
-                    View full history
-                  </button>
-                </>
+                <div className="doc-rail-card doc-rail-card--rows">
+                  {versionRows.map((row) => (
+                    <button
+                      className="doc-rail-row"
+                      type="button"
+                      key={row.key}
+                      onClick={() => {
+                        setViewedVersion(
+                          row.current
+                            ? null
+                            : { tagName: row.tagName, version: row.version },
+                        );
+                        onTabChange("overview");
+                      }}
+                    >
+                      <span
+                        className={`doc-rail-version${row.current ? " doc-rail-version--current" : ""}`}
+                      >
+                        {row.label}
+                      </span>
+                      <span className="doc-rail-row-date">{row.date}</span>
+                      {row.current ? (
+                        <span className="doc-rail-row-note">Current</span>
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
               )}
+              {tags.length > versionRows.length ? (
+                <button
+                  className="doc-rail-more"
+                  type="button"
+                  onClick={() => onTabChange("history")}
+                >
+                  Full history →
+                </button>
+              ) : null}
             </section>
 
             {!isAnonymous ? (
-              <section className="doc-rail-card">
-                <h2 className="doc-rail-title">
-                  <Users size={14} strokeWidth={1.5} aria-hidden="true" />
-                  Access
-                </h2>
-                <p className="doc-rail-note">
-                  Manage who can read this document and who has to sign off
-                  before it publishes.
-                </p>
-                <div className="doc-rail-actions">
+              <section className="doc-rail-section">
+                <h2 className="doc-rail-title">Team</h2>
+                <div className="doc-team">
+                  {teamAvatars.slice(0, 5).map((person) => (
+                    <span
+                      className="doc-team-avatar"
+                      key={person.key}
+                      title={person.name}
+                    >
+                      {person.initials}
+                    </span>
+                  ))}
+                  {teamAvatars.length > 5 ? (
+                    <span className="doc-team-avatar doc-team-avatar--more">
+                      +{teamAvatars.length - 5}
+                    </span>
+                  ) : null}
                   <button
-                    className="bs-btn bs-btn-secondary"
+                    className="doc-team-manage"
                     type="button"
-                    onClick={() => onTabChange("collaborators")}
+                    onClick={() => onTabChange("access")}
                   >
-                    Team
-                  </button>
-                  <button
-                    className="bs-btn bs-btn-secondary"
-                    type="button"
-                    onClick={() => onTabChange("permissions")}
-                  >
-                    Settings
+                    Manage
                   </button>
                 </div>
               </section>

--- a/apps/app/components/DocumentPermissions.tsx
+++ b/apps/app/components/DocumentPermissions.tsx
@@ -282,7 +282,6 @@ export function DocumentPermissions({
     return (
       <div className="perms-page">
         <div className="perms-notice perms-notice--error">
-          <div className="bs-eyebrow">Error</div>
           <p>{loadError}</p>
         </div>
       </div>
@@ -451,7 +450,6 @@ export function DocumentPermissions({
 
           {isInternal ? (
             <div className="perms-notice">
-              <div className="bs-eyebrow">Internal (Gitea)</div>
               <p>
                 This document uses <strong>Internal</strong> visibility —
                 accessible to all logged-in Gitea users but not listed on your

--- a/apps/app/documentWorkspace.test.ts
+++ b/apps/app/documentWorkspace.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "bun:test";
+
+import type {
+  DocTag,
+  PullRequestWithApprovalState,
+  RepoCollaboratorPermissionSummary,
+} from "./api";
+import {
+  buildDocumentHeaderFacts,
+  buildPendingDecisionRows,
+  buildTeamAvatars,
+  buildVersionRailRows,
+} from "./documentWorkspace";
+
+function tag(version: number, created: string): DocTag {
+  return { name: `v${version}`, version, sha: `sha-${version}`, created };
+}
+
+function pullRequest(
+  overrides: Partial<PullRequestWithApprovalState> = {},
+): PullRequestWithApprovalState {
+  return {
+    id: 1,
+    number: 4,
+    title: "Updated liability clause",
+    state: "open",
+    created: "2026-08-22T08:00:00Z",
+    created_at: "2026-08-22T08:00:00Z",
+    branchName: "upload/v4",
+    approvalCount: 2,
+    requiredApprovals: 3,
+    isApproved: false,
+    isRejected: false,
+    reviewers: [],
+    assignee: null,
+    body: "Updated liability clause",
+    approvalState: "in_review",
+    user: { login: "maya" },
+    ...overrides,
+  };
+}
+
+test("the header states the version on record, the date, and the file", () => {
+  expect(
+    buildDocumentHeaderFacts({
+      latestTag: tag(3, "2026-01-12T00:00:00Z"),
+      fileName: "vendor-agreement.docx",
+    }),
+  ).toEqual({
+    versionLabel: "v3 · Current",
+    tone: "current",
+    approvedLine: "Approved Jan 12, 2026",
+    fileName: "vendor-agreement.docx",
+  });
+});
+
+test("a document with nothing published says so instead of showing a version", () => {
+  const facts = buildDocumentHeaderFacts({ latestTag: null, fileName: null });
+
+  expect(facts.versionLabel).toBe("No version yet");
+  // Green is approval. Nothing has been approved, so nothing is green.
+  expect(facts.tone).toBe("none");
+  expect(facts.approvedLine).toBe("Nothing published yet");
+});
+
+test("a pending change reads as one sentence: who, when, how far along", () => {
+  const now = new Date("2026-08-22T10:00:00Z").getTime();
+
+  expect(buildPendingDecisionRows([pullRequest()], now)).toEqual([
+    {
+      key: "change-4",
+      number: 4,
+      title: "Updated liability clause",
+      meta: "Maya · 2h ago · 2 of 3 approvals",
+    },
+  ]);
+});
+
+test("a change on a document that demands no approvals still says where it stands", () => {
+  const now = new Date("2026-08-22T10:00:00Z").getTime();
+  const rows = buildPendingDecisionRows(
+    [pullRequest({ approvalCount: 0, requiredApprovals: 0 })],
+    now,
+  );
+
+  expect(rows[0]?.meta).toBe("Maya · 2h ago · no approvals needed");
+});
+
+test("the rail never grows past three pending changes", () => {
+  const changes = [1, 2, 3, 4, 5].map((number) => pullRequest({ number }));
+
+  expect(buildPendingDecisionRows(changes)).toHaveLength(3);
+});
+
+test("the newest version is the current one and the rest are history", () => {
+  const rows = buildVersionRailRows([
+    tag(3, "2026-01-12T00:00:00Z"),
+    tag(2, "2025-11-03T00:00:00Z"),
+    tag(1, "2025-09-22T00:00:00Z"),
+  ]);
+
+  expect(rows.map((row) => row.label)).toEqual(["v3", "v2", "v1"]);
+  expect(rows.map((row) => row.current)).toEqual([true, false, false]);
+  expect(rows[0]?.date).toBe("Jan 12, 2026");
+});
+
+test("the version rail stops at four rows", () => {
+  const tags = [5, 4, 3, 2, 1].map((version) =>
+    tag(version, "2026-01-12T00:00:00Z"),
+  );
+
+  expect(buildVersionRailRows(tags)).toHaveLength(4);
+});
+
+function collaborator(
+  login: string,
+  fullName: string,
+): RepoCollaboratorPermissionSummary {
+  return {
+    permission: "write",
+    access: "write",
+    permissionLabel: "Can edit",
+    roleName: "Editor",
+    user: {
+      id: 1,
+      login,
+      full_name: fullName,
+      email: `${login}@example.com`,
+      avatar_url: "",
+    },
+  };
+}
+
+test("the team row puts the owner first and never repeats a person", () => {
+  const avatars = buildTeamAvatars(
+    [
+      collaborator("maya", "Maya Kaur"),
+      collaborator("Alice", ""),
+      collaborator("priya", "Priya Shah"),
+    ],
+    "alice",
+  );
+
+  expect(avatars.map((person) => person.key)).toEqual([
+    "alice",
+    "maya",
+    "priya",
+  ]);
+  expect(avatars.map((person) => person.initials)).toEqual(["AL", "MK", "PS"]);
+  expect(avatars[0]?.name).toBe("Alice");
+});

--- a/apps/app/documentWorkspace.ts
+++ b/apps/app/documentWorkspace.ts
@@ -1,0 +1,165 @@
+import type {
+  DocTag,
+  PullRequestWithApprovalState,
+  RepoCollaboratorPermissionSummary,
+} from "./api";
+import {
+  capitalizeFirst,
+  describeApprovalProgress,
+  formatShortDate,
+  getInitials,
+  parseChangeTitle,
+} from "./documentDisplay";
+import { formatWhen } from "./homeChanges";
+
+/**
+ * Everything the document workspace header and rail say, derived here.
+ *
+ * The page itself only renders. What a version pill reads, which three
+ * changes the rail is willing to show, and the one meta sentence under each
+ * of them are decisions — so they are made in one place and tested without a
+ * browser.
+ */
+
+/** The version on record, as the header states it. */
+export interface DocumentHeaderFacts {
+  /** "v3 · Current", or "No version yet" before anything is published. */
+  versionLabel: string;
+  /** Green only once something is actually on the record. */
+  tone: "current" | "none";
+  /** "Approved Jan 12, 2026", or why there is no such date. */
+  approvedLine: string;
+  /** The file the document is, in mono. Null when it cannot be resolved. */
+  fileName: string | null;
+}
+
+export function buildDocumentHeaderFacts(params: {
+  latestTag: Pick<DocTag, "version" | "created"> | null;
+  fileName: string | null;
+}): DocumentHeaderFacts {
+  const { latestTag, fileName } = params;
+
+  if (!latestTag) {
+    return {
+      versionLabel: "No version yet",
+      tone: "none",
+      approvedLine: "Nothing published yet",
+      fileName,
+    };
+  }
+
+  return {
+    versionLabel: `v${latestTag.version} · Current`,
+    tone: "current",
+    approvedLine: `Approved ${formatShortDate(latestTag.created)}`,
+    fileName,
+  };
+}
+
+/** One open change, as the rail states it. */
+export interface PendingDecisionRow {
+  key: string;
+  number: number;
+  /** What the change is called. */
+  title: string;
+  /** "Maya · 2h ago · 2 of 3 approvals" — one sentence, three facts. */
+  meta: string;
+}
+
+/**
+ * The changes still waiting on somebody, newest first.
+ *
+ * The rail is 280px wide and sits beside the document itself; it is a nudge,
+ * not the Changes tab. Three is as many as it will ever show.
+ */
+export function buildPendingDecisionRows(
+  openPullRequests: PullRequestWithApprovalState[],
+  now: number = Date.now(),
+  limit = 3,
+): PendingDecisionRow[] {
+  return openPullRequests.slice(0, limit).map((pullRequest) => {
+    const submittedBy = pullRequest.user?.login ?? "";
+    const facts = [
+      capitalizeFirst(submittedBy) || "Someone",
+      formatWhen(pullRequest.created_at ?? "", now),
+      describeApprovalProgress({
+        approvalCount: pullRequest.approvalCount ?? 0,
+        requiredApprovals: pullRequest.requiredApprovals ?? 0,
+      }) ?? "no approvals needed",
+    ];
+
+    return {
+      key: `change-${pullRequest.number}`,
+      number: pullRequest.number,
+      title: parseChangeTitle(pullRequest.body, submittedBy),
+      meta: facts.join(" · "),
+    };
+  });
+}
+
+/** One published version, as the rail lists it. */
+export interface VersionRailRow {
+  key: string;
+  tagName: string;
+  version: number;
+  /** "v3" — the pill on the left of the row. */
+  label: string;
+  /** "Jan 12, 2026". */
+  date: string;
+  /** The one row that is the document as it stands. */
+  current: boolean;
+}
+
+export function buildVersionRailRows(
+  tags: DocTag[],
+  limit = 4,
+): VersionRailRow[] {
+  return tags.slice(0, limit).map((tag, index) => ({
+    key: tag.name,
+    tagName: tag.name,
+    version: tag.version,
+    label: `v${tag.version}`,
+    date: formatShortDate(tag.created),
+    // The list arrives newest first, so the first row is the record.
+    current: index === 0,
+  }));
+}
+
+/** One face in the rail's team row. */
+export interface TeamAvatar {
+  key: string;
+  /** "MK". */
+  initials: string;
+  /** The tooltip and the screen-reader name. */
+  name: string;
+}
+
+/**
+ * Who is on this document, owner first.
+ *
+ * The rail shows faces, not a table — the table is one click away under
+ * Access & approvals. Anything past the fifth face becomes a "+N" the row
+ * renders itself, so this hands back everyone and lets the page cut.
+ */
+export function buildTeamAvatars(
+  collaborators: RepoCollaboratorPermissionSummary[],
+  owner: string,
+): TeamAvatar[] {
+  const seen = new Set<string>();
+  const avatars: TeamAvatar[] = [];
+
+  const push = (login: string, fullName: string) => {
+    const key = login.toLowerCase();
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    const name = fullName.trim() || capitalizeFirst(login);
+    avatars.push({ key: login, initials: getInitials(name), name });
+  };
+
+  push(owner, "");
+  for (const collaborator of collaborators) {
+    push(collaborator.user.login, collaborator.user.full_name);
+  }
+
+  return avatars;
+}

--- a/apps/app/routes.test.ts
+++ b/apps/app/routes.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import {
   asShellRoute,
   getRoute,
+  isLegacyDocumentTabPath,
   isLegacyInboxPath,
   isProtectedAppRoute,
   routeToPath,
@@ -29,19 +30,38 @@ test("getRoute preserves document detail routes", () => {
     tab: "overview",
   });
 
+  expect(getRoute("/docs/alice/quarterly-report/access")).toEqual({
+    kind: "document",
+    owner: "alice",
+    repo: "quarterly-report",
+    tab: "access",
+  });
+});
+
+// Team and Settings became one tab. Links that were already sent still land
+// on the page that answers them.
+test("getRoute resolves the retired Team and Settings tabs to Access", () => {
   expect(getRoute("/docs/alice/quarterly-report/collaborators")).toEqual({
     kind: "document",
     owner: "alice",
     repo: "quarterly-report",
-    tab: "collaborators",
+    tab: "access",
   });
 
   expect(getRoute("/docs/alice/quarterly-report/permissions")).toEqual({
     kind: "document",
     owner: "alice",
     repo: "quarterly-report",
-    tab: "permissions",
+    tab: "access",
   });
+
+  expect(
+    isLegacyDocumentTabPath("/docs/alice/quarterly-report/permissions"),
+  ).toBe(true);
+  expect(isLegacyDocumentTabPath("/docs/alice/quarterly-report/access")).toBe(
+    false,
+  );
+  expect(isLegacyDocumentTabPath("/docs/alice/quarterly-report")).toBe(false);
 });
 
 test("getRoute maps the changes and history tabs", () => {
@@ -122,13 +142,7 @@ test("getRoute falls back to home for an unknown document tab", () => {
 });
 
 test("routeToPath round-trips every document tab", () => {
-  const tabs = [
-    "overview",
-    "changes",
-    "history",
-    "collaborators",
-    "permissions",
-  ] as const;
+  const tabs = ["overview", "changes", "history", "access"] as const;
 
   for (const tab of tabs) {
     const route = {
@@ -141,12 +155,12 @@ test("routeToPath round-trips every document tab", () => {
   }
 });
 
-test("getRoute maps permissions path with URL-encoded owner/repo", () => {
-  expect(getRoute("/docs/alice-org/my%20doc/permissions")).toEqual({
+test("getRoute maps the access path with URL-encoded owner/repo", () => {
+  expect(getRoute("/docs/alice-org/my%20doc/access")).toEqual({
     kind: "document",
     owner: "alice-org",
     repo: "my%20doc",
-    tab: "permissions",
+    tab: "access",
   });
 });
 

--- a/apps/app/routes.ts
+++ b/apps/app/routes.ts
@@ -30,8 +30,7 @@ export type AppRoute =
  * bare `/docs/:owner/:repo` path; every other tab is a suffix so any view can
  * be linked to, bookmarked, and reloaded.
  */
-export type DocumentTab =
-  "overview" | "changes" | "history" | "collaborators" | "permissions";
+export type DocumentTab = "overview" | "changes" | "history" | "access";
 
 /**
  * The two halves of a change's page. The decision is made in the discussion,
@@ -43,8 +42,20 @@ export type DocumentChangeView = "discussion" | "preview";
 const DOCUMENT_TAB_PATHS: Record<Exclude<DocumentTab, "overview">, string> = {
   changes: "changes",
   history: "history",
-  collaborators: "collaborators",
-  permissions: "permissions",
+  access: "access",
+};
+
+/**
+ * The two tabs that became one.
+ *
+ * "Team" listed who could see the document and "Settings" held how many of
+ * them had to sign off — two halves of the same question, so the redesign
+ * merged them into Access & approvals. Links that were sent, bookmarked, or
+ * pasted into a ticket still land on the page that answers them.
+ */
+const LEGACY_DOCUMENT_TAB_PATHS: Record<string, DocumentTab> = {
+  collaborators: "access",
+  permissions: "access",
 };
 
 function normalizePathname(pathname: string): string {
@@ -57,6 +68,20 @@ function normalizePathname(pathname: string): string {
 
 export function isHomePath(pathname: string): boolean {
   return normalizePathname(pathname) === "/";
+}
+
+/**
+ * A link to one of the two document tabs the redesign merged.
+ *
+ * `getRoute` already resolves these to Access & approvals; this is what lets
+ * the app rewrite the address bar so nobody keeps a bookmark to a tab that no
+ * longer exists.
+ */
+export function isLegacyDocumentTabPath(pathname: string): boolean {
+  const match = normalizePathname(pathname).match(
+    /^\/docs\/[^/]+\/[^/]+\/([^/]+)$/,
+  );
+  return match !== null && match[1]! in LEGACY_DOCUMENT_TAB_PATHS;
 }
 
 /** A link to the retired `/inbox` page. Its contents now live on Home. */
@@ -124,9 +149,11 @@ export function getRoute(pathname: string): AppRoute {
   );
   if (docTabMatch) {
     const segment = docTabMatch[3]!;
-    const tab = (
-      Object.keys(DOCUMENT_TAB_PATHS) as Exclude<DocumentTab, "overview">[]
-    ).find((candidate) => DOCUMENT_TAB_PATHS[candidate] === segment);
+    const tab =
+      (
+        Object.keys(DOCUMENT_TAB_PATHS) as Exclude<DocumentTab, "overview">[]
+      ).find((candidate) => DOCUMENT_TAB_PATHS[candidate] === segment) ??
+      LEGACY_DOCUMENT_TAB_PATHS[segment];
 
     if (tab) {
       return {

--- a/tests/document-collaborators.pw.ts
+++ b/tests/document-collaborators.pw.ts
@@ -129,8 +129,10 @@ async function createDocument(page: Page, fileName: string): Promise<void> {
 }
 
 async function openCollaboratorsTab(page: Page): Promise<void> {
-  // Tab is now labeled "Team" (was "Collaborators") in the new UI
-  const collaboratorsTab = page.getByRole("tab", { name: "Team" });
+  // Team and Settings merged into one tab in the redesign.
+  const collaboratorsTab = page.getByRole("tab", {
+    name: "Access & approvals",
+  });
   await expect(collaboratorsTab).toBeVisible({ timeout: 10_000 });
   await collaboratorsTab.click();
   await expect(page.getByRole("heading", { name: "Grant access" })).toBeVisible(
@@ -171,10 +173,9 @@ async function reopenDocumentFromWorkspace(page: Page): Promise<void> {
     timeout: 10_000,
   });
   await page.locator(".docs-list-item").first().click();
-  // Tab is now labeled "Team" (was "Collaborators") in the new UI
-  await expect(page.getByRole("tab", { name: "Team" })).toBeVisible({
-    timeout: 10_000,
-  });
+  await expect(
+    page.getByRole("tab", { name: "Access & approvals" }),
+  ).toBeVisible({ timeout: 10_000 });
   await openCollaboratorsTab(page);
 }
 

--- a/tests/document-collaborators.pw.ts
+++ b/tests/document-collaborators.pw.ts
@@ -107,8 +107,8 @@ async function createDocument(page: Page, fileName: string): Promise<void> {
     expectedDocumentName(fileName),
   );
 
-  // New UI shows .vault-detail when the document detail page has loaded
-  const vaultDetail = page.locator(".vault-detail");
+  // The document workspace shows .docw-page once it has loaded
+  const documentPage = page.locator(".docw-page");
   const createError = page
     .locator(".upload-validation-error, .upload-error-message")
     .first();
@@ -116,7 +116,7 @@ async function createDocument(page: Page, fileName: string): Promise<void> {
   await page.getByRole("button", { name: "Create Document" }).click();
 
   await Promise.race([
-    vaultDetail.waitFor({ state: "visible", timeout: 20_000 }),
+    documentPage.waitFor({ state: "visible", timeout: 20_000 }),
     createError
       .waitFor({ state: "visible", timeout: 20_000 })
       .then(async () => {

--- a/tests/document-creation.pw.ts
+++ b/tests/document-creation.pw.ts
@@ -42,8 +42,8 @@ test.describe("UI document creation flow", () => {
 
     await page.getByRole("button", { name: "Create Document" }).click();
 
-    // New UI shows .vault-detail when the document detail page has loaded
-    await expect(page.locator(".vault-detail")).toBeVisible({
+    // The document workspace shows .docw-page once it has loaded
+    await expect(page.locator(".docw-page")).toBeVisible({
       timeout: 30_000,
     });
     await expect(

--- a/tests/document-creation.pw.ts
+++ b/tests/document-creation.pw.ts
@@ -47,7 +47,7 @@ test.describe("UI document creation flow", () => {
       timeout: 30_000,
     });
     await expect(
-      page.getByRole("heading", { name: /No approved version yet/i }),
+      page.getByRole("heading", { name: /No official version yet/i }),
     ).toBeVisible();
     await expectOpenChangeCount(page, 1);
   });

--- a/tests/document-download.pw.ts
+++ b/tests/document-download.pw.ts
@@ -97,7 +97,7 @@ test.describe("Document download", () => {
 
     // Verify the document is in the unpublished state with 1 pending approval
     await expect(
-      page.getByRole("heading", { name: /No approved version yet/i }),
+      page.getByRole("heading", { name: /No official version yet/i }),
     ).toBeVisible();
     await expectOpenChangeCount(page, 1);
 

--- a/tests/document-download.pw.ts
+++ b/tests/document-download.pw.ts
@@ -91,7 +91,7 @@ test.describe("Document download", () => {
     await page.getByRole("button", { name: "Create Document" }).click();
 
     // Wait for navigation to document detail
-    await expect(page.locator(".vault-detail")).toBeVisible({
+    await expect(page.locator(".docw-page")).toBeVisible({
       timeout: 30_000,
     });
 

--- a/tests/document-version-upload.pw.ts
+++ b/tests/document-version-upload.pw.ts
@@ -97,7 +97,7 @@ test.describe("UI document version upload flow", () => {
     });
 
     await expect(
-      page.getByRole("heading", { name: /No approved version yet/i }),
+      page.getByRole("heading", { name: /No official version yet/i }),
     ).toBeVisible();
     await expectOpenChangeCount(page, 1);
 

--- a/tests/document-version-upload.pw.ts
+++ b/tests/document-version-upload.pw.ts
@@ -92,7 +92,7 @@ test.describe("UI document version upload flow", () => {
     await page.getByRole("button", { name: "Create Document" }).click();
 
     // Wait for navigation to document detail
-    await expect(page.locator(".vault-detail")).toBeVisible({
+    await expect(page.locator(".docw-page")).toBeVisible({
       timeout: 30_000,
     });
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -474,9 +474,11 @@ export async function expectPublishedVersion(
   version: number,
   timeout = 30_000,
 ): Promise<void> {
-  await expect(page.locator(".doc-version-pill")).toHaveText(`v${version}`, {
-    timeout,
-  });
+  // The pill states the version and that it is the record: "v3 · Current".
+  await expect(page.locator(".doc-version-pill")).toHaveText(
+    `v${version} · Current`,
+    { timeout },
+  );
 }
 
 /** Assert how many changes are waiting on a decision, per the Changes tab. */

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -598,7 +598,7 @@ export async function waitForNoPendingReviews(
  * and wait for the collaborator search input to become visible.
  */
 export async function openCollaboratorsTab(page: Page): Promise<void> {
-  await page.getByRole("tab", { name: "Team" }).click();
+  await page.getByRole("tab", { name: "Access & approvals" }).click();
   await expect(page.locator("#collaborator-search")).toBeVisible({
     timeout: 5_000,
   });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -384,7 +384,7 @@ export async function signOutCurrentUser(page: Page): Promise<void> {
  * Navigate from any app page to a document detail page.
  *
  * Navigates to the Documents list page first, then clicks the row whose
- * text matches `docName`. Waits for `.vault-detail` to confirm arrival.
+ * text matches `docName`. Waits for `.docw-page` to confirm arrival.
  *
  * Stability fix: waits for DOM content to be loaded before clicking so the
  * list is fully rendered. We intentionally avoid networkidle because the live
@@ -406,7 +406,7 @@ export async function navigateToDocument(
   await expect(card).toBeVisible({ timeout: 10_000 });
   await card.click({ force: true });
   // Confirm we reached the document detail page
-  await expect(page.locator(".vault-detail")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".docw-page")).toBeVisible({ timeout: 10_000 });
 }
 
 /** The tabs across the top of the document workspace. */

--- a/tests/merge-conflict-resolution.pw.ts
+++ b/tests/merge-conflict-resolution.pw.ts
@@ -88,7 +88,7 @@ test.describe("Merge conflict resolution on publish", () => {
       timeout: 10_000,
     });
     await expect(
-      page.getByRole("heading", { name: /No approved version yet/i }),
+      page.getByRole("heading", { name: /No official version yet/i }),
     ).toBeVisible();
     await expectOpenChangeCount(page, 1);
 

--- a/tests/merge-conflict-resolution.pw.ts
+++ b/tests/merge-conflict-resolution.pw.ts
@@ -84,7 +84,7 @@ test.describe("Merge conflict resolution on publish", () => {
     await page.getByRole("button", { name: "Create Document" }).click();
 
     // Wait for document detail page
-    await expect(page.locator(".vault-detail")).toBeVisible({
+    await expect(page.locator(".docw-page")).toBeVisible({
       timeout: 10_000,
     });
     await expect(

--- a/tests/smoke.pw.ts
+++ b/tests/smoke.pw.ts
@@ -226,7 +226,7 @@ test.describe("app shell routes", () => {
     await page.goto(`/docs/${OWNER}/${REPO}`);
 
     await expect(page).toHaveURL(new RegExp(`/docs/${OWNER}/${REPO}$`));
-    await expect(page.locator(".vault-detail")).toBeVisible();
+    await expect(page.locator(".docw-page")).toBeVisible();
     await expect(
       page.locator(".app-topnav-link", { hasText: "Documents" }),
     ).toBeVisible();


### PR DESCRIPTION
Phase 3 of the approved workspace redesign (`docs/design/workspace-redesign-spec.md`), built against `docs/design/mockups/DocumentDetail.dc.html`. Presentation layer only — no BFF, Gitea model, or `packages/editor/` changes, so no `sync-demo` needed.

## What changed

**Header.** Title in Lora 26, a `v3 · Current` pill, the approved date, and the filename in mono. The `owner / repo` path is gone. The one coral element on the page is the coral "Submit new version" button.

**Four tabs instead of five.** Team and Settings merged into **Access & approvals** — "who can see this" and "how many of them have to sign off" were always one question, and splitting them meant adding an approver and requiring their approval were two different errands. `Changes` keeps its count bubble; `History` loses one, because a number of versions is not a number of things to deal with.

**Document tab.** The file on one white sheet (radius 16, 540px min-height) beside a slim 280px rail with three sections: *Waiting on a decision* (coral mono label, per-change card with a Review link), *Versions* (hairline rows in one card, current version in green), and *Team* (28px avatar faces plus a Manage link).

**Routing.** `DocumentTab` is now `overview | changes | history | access`. `/docs/:owner/:repo/collaborators` and `/permissions` still resolve to the merged tab, and `App` rewrites the address bar to `/access` so nobody keeps a bookmark to a page that no longer exists.

**New pure module.** `apps/app/documentWorkspace.ts` derives the header facts, the pending-decision rows, the version rail, and the team avatars, with tests — same shape as `homeChanges.ts` (phase 1) and `documentsView.ts` (phase 2).

Also removed the in-app `.bs-eyebrow` marketing labels from this page's loading/error states and from `DocumentPermissions`, per the spec's cross-cutting rules.

## Two deliberate deviations from the mockup

- **The nav.** `DocumentDetail.dc.html` shows a `Bindersnap / Vendor Agreement` breadcrumb in place of the Home/Documents links. The spec's cross-cutting rule states the top nav is the same on every page, and phase 1 shipped it that way, so the nav is untouched. Happy to add the breadcrumb if you want the mockup's version instead.
- **The preview toolbar.** The mockup draws the document card as a bare sheet. A preview you cannot download is a picture of a document, so the filename + size + Download strip stays — restyled as a hairline-separated strip on white rather than the old warm band.

## Verification

- `bun run test:app` — 191 pass
- `bun run test:ops` — 336 pass
- `bunx tsc --noEmit` — no new errors (two pre-existing `apps/app/api.ts` errors remain)
- `bun run format:check` — clean
- Driven in the browser against the local stack: Document, Changes, History and Access & approvals tabs on published and unpublished documents; `/collaborators` confirmed redirecting to `/access`; all network calls 200, no console errors.

Playwright: `tests/helpers.ts` and `tests/document-collaborators.pw.ts` now click the `Access & approvals` tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)