### PR TITLE
fix: serve the approval count to every reviewer, not just admins

### DIFF
--- a/apps/app/components/ApprovalMeter.tsx
+++ b/apps/app/components/ApprovalMeter.tsx
@@ -43,8 +43,8 @@ export function ApprovalMeter({
   if (!standing) return null;
 
   const Icon = TONE_ICONS[standing.tone];
-  const showPips =
-    change.requiredApprovals > 0 && change.requiredApprovals <= MAX_PIPS;
+  const required = change.requiredApprovals ?? 0;
+  const showPips = required > 0 && required <= MAX_PIPS;
 
   return (
     <span
@@ -56,7 +56,7 @@ export function ApprovalMeter({
       ) : null}
       {showPips ? (
         <span className="approval-meter-pips" aria-hidden="true">
-          {Array.from({ length: change.requiredApprovals }, (_, index) => (
+          {Array.from({ length: required }, (_, index) => (
             <span
               key={index}
               className={`approval-meter-pip${

--- a/apps/app/components/DocumentChangeDetail.tsx
+++ b/apps/app/components/DocumentChangeDetail.tsx
@@ -118,14 +118,14 @@ function canUserMerge(
  * says it exactly. Who is holding it up is the reviewers row's job, right
  * below — it names people, which a meter never can.
  *
- * `requiredApprovals` comes from the repo's branch protection, and Gitea only
- * serves that to an admin — so a write collaborator, which is to say most
- * reviewers, receives 0 and there is no count to draw. They still need to know
- * their approval registered, so the state badge stands in. Rendering nothing
- * would leave the reviewer who just signed off with no sign anything happened.
+ * A document can demand no approvals at all, and the server can fail to read
+ * the policy — both leave nothing to draw. The reviewer who just signed off
+ * still needs to see that it registered, so the state badge stands in rather
+ * than rendering nothing.
  */
 function ApprovalBars({ change }: { change: ChangeRecord }) {
-  if (change.requiredApprovals <= 0) {
+  const required = change.requiredApprovals ?? 0;
+  if (required <= 0) {
     return (
       <div className="rev-approvals">
         <span className={getChangeStateBadgeClass(change)}>
@@ -135,14 +135,14 @@ function ApprovalBars({ change }: { change: ChangeRecord }) {
     );
   }
 
-  const filled = Math.min(change.approvalCount, change.requiredApprovals);
-  const showBars = change.requiredApprovals <= MAX_APPROVAL_BARS;
+  const filled = Math.min(change.approvalCount, required);
+  const showBars = required <= MAX_APPROVAL_BARS;
 
   return (
     <div className="rev-approvals">
       {showBars ? (
         <div className="rev-approval-bars" aria-hidden="true">
-          {Array.from({ length: change.requiredApprovals }, (_, index) => (
+          {Array.from({ length: required }, (_, index) => (
             <span
               key={index}
               className={`rev-approval-bar${
@@ -153,7 +153,7 @@ function ApprovalBars({ change }: { change: ChangeRecord }) {
         </div>
       ) : null}
       <span className="rev-approval-count">
-        {change.approvalCount} of {change.requiredApprovals} approvals
+        {change.approvalCount} of {required} approvals
       </span>
     </div>
   );

--- a/apps/app/documentDisplay.test.ts
+++ b/apps/app/documentDisplay.test.ts
@@ -237,7 +237,9 @@ test("a change with no assignments still becomes a record", () => {
   expect(change.assignee).toBeNull();
   expect(change.reviewers).toEqual([]);
   expect(change.approvalCount).toBe(0);
-  expect(change.requiredApprovals).toBe(0);
+  // Absent, not zero: a change that arrives without a policy has an unknown
+  // requirement, which is not the same as a document demanding none.
+  expect(change.requiredApprovals).toBeNull();
 });
 
 test("approval progress counts sign-offs instead of saying 'awaiting'", () => {
@@ -260,6 +262,18 @@ test("a document that demands no approvals gets no counter", () => {
   expect(hasEnoughApprovals({ approvalCount: 0, requiredApprovals: 0 })).toBe(
     false,
   );
+});
+
+test("an unknown approval requirement is not a requirement of none", () => {
+  // A reader who cannot be told the denominator gets the badge, same as a
+  // document that demands nothing — but the two arrive as different values, so
+  // nothing downstream can mistake "unknown" for "nothing left to collect".
+  expect(
+    describeApprovalProgress({ approvalCount: 1, requiredApprovals: null }),
+  ).toBeNull();
+  expect(
+    hasEnoughApprovals({ approvalCount: 3, requiredApprovals: null }),
+  ).toBe(false);
 });
 
 test("an unresolved thread outranks the reviewer's own approval", () => {

--- a/apps/app/documentDisplay.ts
+++ b/apps/app/documentDisplay.ts
@@ -255,8 +255,13 @@ export interface ChangeRecord {
   reviewers: ChangeReviewer[];
   /** Approvals that still count. */
   approvalCount: number;
-  /** How many this document demands before anything can publish. */
-  requiredApprovals: number;
+  /**
+   * How many approvals this document demands before anything can publish, or
+   * null when the server could not read the policy. A document that demands
+   * none reports 0 — the two are different answers and only one of them means
+   * "nothing left to collect".
+   */
+  requiredApprovals: number | null;
 }
 
 export type ChangeOutcome = "published" | "declined" | "withdrawn";
@@ -310,7 +315,7 @@ export function toChangeRecord(pullRequest: {
   reviewers?: ChangeReviewer[];
   assignee?: ChangeUser | null;
   approvalCount?: number;
-  requiredApprovals?: number;
+  requiredApprovals?: number | null;
   user?: { login: string } | null;
 }): ChangeRecord {
   const submittedBy = pullRequest.user?.login ?? "";
@@ -331,7 +336,7 @@ export function toChangeRecord(pullRequest: {
     assignee: pullRequest.assignee ?? null,
     reviewers: pullRequest.reviewers ?? [],
     approvalCount: pullRequest.approvalCount ?? 0,
-    requiredApprovals: pullRequest.requiredApprovals ?? 0,
+    requiredApprovals: pullRequest.requiredApprovals ?? null,
   };
 }
 
@@ -349,7 +354,7 @@ export function closedChangeToRecord(change: {
   reviewers?: ChangeReviewer[];
   assignee?: ChangeUser | null;
   approvalCount?: number;
-  requiredApprovals?: number;
+  requiredApprovals?: number | null;
 }): ChangeRecord {
   return {
     number: change.number,
@@ -368,7 +373,7 @@ export function closedChangeToRecord(change: {
     assignee: change.assignee ?? null,
     reviewers: change.reviewers ?? [],
     approvalCount: change.approvalCount ?? 0,
-    requiredApprovals: change.requiredApprovals ?? 0,
+    requiredApprovals: change.requiredApprovals ?? null,
   };
 }
 
@@ -411,7 +416,7 @@ export function publishedVersionToRecord(version: {
     assignee: null,
     reviewers: [],
     approvalCount: 0,
-    requiredApprovals: 0,
+    requiredApprovals: null,
   };
 }
 
@@ -467,25 +472,25 @@ export function getReviewerDisplayName(reviewer: {
  *
  * "Awaiting review" says a decision is outstanding without saying how much is
  * outstanding — one more sign-off and three more are the same badge. Returns
- * null when the document demands no approvals, because "0 of 0" is noise.
+ * null when the document demands no approvals, because "0 of 0" is noise, and
+ * when the requirement is unknown, because a denominator is the whole point.
  */
 export function describeApprovalProgress(change: {
   approvalCount: number;
-  requiredApprovals: number;
+  requiredApprovals: number | null;
 }): string | null {
-  if (change.requiredApprovals <= 0) return null;
-  return `${change.approvalCount} of ${change.requiredApprovals} approvals`;
+  const required = change.requiredApprovals;
+  if (required === null || required <= 0) return null;
+  return `${change.approvalCount} of ${required} approvals`;
 }
 
 /** True once a change has collected every approval it needs. */
 export function hasEnoughApprovals(change: {
   approvalCount: number;
-  requiredApprovals: number;
+  requiredApprovals: number | null;
 }): boolean {
-  return (
-    change.requiredApprovals > 0 &&
-    change.approvalCount >= change.requiredApprovals
-  );
+  const required = change.requiredApprovals;
+  return required !== null && required > 0 && change.approvalCount >= required;
 }
 
 /**
@@ -523,14 +528,9 @@ function joinNames(reviewers: { login: string; fullName: string }[]): string {
  * a blocker outranks a full count, because a full count cannot publish past it.
  *
  * Returns null for a closed change (its outcome is the whole story) and for a
- * document that demands no approvals and has no blocker, where there is simply
- * nothing to report. The caller falls back to the state badge in that case.
- *
- * That second case is more common than it looks: `requiredApprovals` comes from
- * the repo's branch protection, and Gitea only serves that to an admin. A write
- * collaborator — which is to say most reviewers — receives 0 and therefore sees
- * the badge rather than the count. They are the people the count is *for*, so
- * this is worth fixing at the source rather than papering over here.
+ * document that demands no approvals — or whose policy could not be read — and
+ * has no blocker, where there is simply nothing to report. The caller falls
+ * back to the state badge in that case.
  */
 export function describeChangeStanding(
   change: ChangeRecord,
@@ -570,7 +570,7 @@ export function describeChangeStanding(
 
   if (progress === null) return null;
 
-  const missing = change.requiredApprovals - change.approvalCount;
+  const missing = (change.requiredApprovals ?? 0) - change.approvalCount;
   const waiting = change.reviewers.filter(
     (reviewer) => standingOf(reviewer) === "awaiting",
   );

--- a/apps/app/documentWorkspace.ts
+++ b/apps/app/documentWorkspace.ts
@@ -84,7 +84,7 @@ export function buildPendingDecisionRows(
       formatWhen(pullRequest.created_at ?? "", now),
       describeApprovalProgress({
         approvalCount: pullRequest.approvalCount ?? 0,
-        requiredApprovals: pullRequest.requiredApprovals ?? 0,
+        requiredApprovals: pullRequest.requiredApprovals ?? null,
       }) ?? "no approvals needed",
     ];
 

--- a/apps/app/documentsView.ts
+++ b/apps/app/documentsView.ts
@@ -1,5 +1,9 @@
 import type { WorkspaceDocumentSummary } from "./api";
-import { capitalizeFirst, formatDocumentName } from "./documentDisplay";
+import {
+  capitalizeFirst,
+  formatDocumentName,
+  hasEnoughApprovals,
+} from "./documentDisplay";
 import type { DocumentSearchParams } from "./documentSearch";
 import { parseDocumentSearchQuery } from "./documentSearch";
 import { formatDecisionDate, formatWhen } from "./homeChanges";
@@ -197,11 +201,7 @@ export interface DocumentRow {
 type OpenChange = WorkspaceDocumentSummary["pendingPRs"][number];
 
 function isReady(change: OpenChange): boolean {
-  return (
-    !change.isRejected &&
-    change.requiredApprovals > 0 &&
-    change.approvalCount >= change.requiredApprovals
-  );
+  return !change.isRejected && hasEnoughApprovals(change);
 }
 
 /** A stale approval is a review still owed: the version under it moved on. */

--- a/packages/api-client/model/documentDetailPayloadOpenPullRequestsItem.ts
+++ b/packages/api-client/model/documentDetailPayloadOpenPullRequestsItem.ts
@@ -20,7 +20,8 @@ export type DocumentDetailPayloadOpenPullRequestsItem = {
   updated_at?: string;
   branchName: string;
   approvalCount: number;
-  requiredApprovals: number;
+  /** @nullable */
+  requiredApprovals: number | null;
   isApproved: boolean;
   isRejected: boolean;
   reviewers: DocumentDetailPayloadOpenPullRequestsItemReviewersItem[];

--- a/packages/api-client/model/documentDetailPayloadUploadPullRequestsItem.ts
+++ b/packages/api-client/model/documentDetailPayloadUploadPullRequestsItem.ts
@@ -20,7 +20,8 @@ export type DocumentDetailPayloadUploadPullRequestsItem = {
   updated_at?: string;
   branchName: string;
   approvalCount: number;
-  requiredApprovals: number;
+  /** @nullable */
+  requiredApprovals: number | null;
   isApproved: boolean;
   isRejected: boolean;
   reviewers: DocumentDetailPayloadUploadPullRequestsItemReviewersItem[];

--- a/packages/api-client/model/getClosedChanges200ChangesItem.ts
+++ b/packages/api-client/model/getClosedChanges200ChangesItem.ts
@@ -28,5 +28,6 @@ export type GetClosedChanges200ChangesItem = {
   /** @nullable */
   assignee: GetClosedChanges200ChangesItemAssignee;
   approvalCount: number;
-  requiredApprovals: number;
+  /** @nullable */
+  requiredApprovals: number | null;
 };

--- a/packages/api-client/model/getDocumentDetail200OpenPullRequestsItem.ts
+++ b/packages/api-client/model/getDocumentDetail200OpenPullRequestsItem.ts
@@ -20,7 +20,8 @@ export type GetDocumentDetail200OpenPullRequestsItem = {
   updated_at?: string;
   branchName: string;
   approvalCount: number;
-  requiredApprovals: number;
+  /** @nullable */
+  requiredApprovals: number | null;
   isApproved: boolean;
   isRejected: boolean;
   reviewers: GetDocumentDetail200OpenPullRequestsItemReviewersItem[];

--- a/packages/api-client/model/getDocumentDetail200UploadPullRequestsItem.ts
+++ b/packages/api-client/model/getDocumentDetail200UploadPullRequestsItem.ts
@@ -20,7 +20,8 @@ export type GetDocumentDetail200UploadPullRequestsItem = {
   updated_at?: string;
   branchName: string;
   approvalCount: number;
-  requiredApprovals: number;
+  /** @nullable */
+  requiredApprovals: number | null;
   isApproved: boolean;
   isRejected: boolean;
   reviewers: GetDocumentDetail200UploadPullRequestsItemReviewersItem[];

--- a/packages/api-client/model/listDocuments200DocumentsItemPendingPRsItem.ts
+++ b/packages/api-client/model/listDocuments200DocumentsItemPendingPRsItem.ts
@@ -20,7 +20,8 @@ export type ListDocuments200DocumentsItemPendingPRsItem = {
   updated_at?: string;
   branchName: string;
   approvalCount: number;
-  requiredApprovals: number;
+  /** @nullable */
+  requiredApprovals: number | null;
   isApproved: boolean;
   isRejected: boolean;
   reviewers: ListDocuments200DocumentsItemPendingPRsItemReviewersItem[];

--- a/packages/api-client/model/updateChangeAssignments200.ts
+++ b/packages/api-client/model/updateChangeAssignments200.ts
@@ -12,5 +12,6 @@ export type UpdateChangeAssignments200 = {
   assignee: UpdateChangeAssignments200Assignee;
   reviewers: UpdateChangeAssignments200ReviewersItem[];
   approvalCount: number;
-  requiredApprovals: number;
+  /** @nullable */
+  requiredApprovals: number | null;
 };

--- a/packages/api-client/model/workspaceDocumentSummaryPendingPRsItem.ts
+++ b/packages/api-client/model/workspaceDocumentSummaryPendingPRsItem.ts
@@ -20,7 +20,8 @@ export type WorkspaceDocumentSummaryPendingPRsItem = {
   updated_at?: string;
   branchName: string;
   approvalCount: number;
-  requiredApprovals: number;
+  /** @nullable */
+  requiredApprovals: number | null;
   isApproved: boolean;
   isRejected: boolean;
   reviewers: WorkspaceDocumentSummaryPendingPRsItemReviewersItem[];

--- a/packages/api-schema/openapi.json
+++ b/packages/api-schema/openapi.json
@@ -184,7 +184,8 @@
                   "type": "number"
                 },
                 "requiredApprovals": {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 "isApproved": {
                   "type": "boolean"
@@ -496,7 +497,8 @@
                   "type": "number"
                 },
                 "requiredApprovals": {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 "isApproved": {
                   "type": "boolean"
@@ -704,7 +706,8 @@
                   "type": "number"
                 },
                 "requiredApprovals": {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 "isApproved": {
                   "type": "boolean"
@@ -2391,7 +2394,8 @@
                                   "type": "number"
                                 },
                                 "requiredApprovals": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "nullable": true
                                 },
                                 "isApproved": {
                                   "type": "boolean"
@@ -2868,7 +2872,8 @@
                             "type": "number"
                           },
                           "requiredApprovals": {
-                            "type": "number"
+                            "type": "number",
+                            "nullable": true
                           },
                           "isApproved": {
                             "type": "boolean"
@@ -3076,7 +3081,8 @@
                             "type": "number"
                           },
                           "requiredApprovals": {
-                            "type": "number"
+                            "type": "number",
+                            "nullable": true
                           },
                           "isApproved": {
                             "type": "boolean"
@@ -3803,7 +3809,8 @@
                             "type": "number"
                           },
                           "requiredApprovals": {
-                            "type": "number"
+                            "type": "number",
+                            "nullable": true
                           }
                         },
                         "required": [
@@ -4933,7 +4940,8 @@
                       "type": "number"
                     },
                     "requiredApprovals": {
-                      "type": "number"
+                      "type": "number",
+                      "nullable": true
                     }
                   },
                   "required": [

--- a/packages/api-schema/schemas/documents.ts
+++ b/packages/api-schema/schemas/documents.ts
@@ -153,7 +153,12 @@ export const PullRequestWithApprovalStateSchema = z.object({
   branchName: z.string(),
   /** Approvals that still count, against the number the document demands. */
   approvalCount: z.number(),
-  requiredApprovals: z.number(),
+  /**
+   * How many approvals the document demands, or null when the policy could not
+   * be read. 0 means the document genuinely demands none — the two are not the
+   * same answer and the UI renders them differently.
+   */
+  requiredApprovals: z.number().nullable(),
   isApproved: z.boolean(),
   isRejected: z.boolean(),
   /** Who is on the hook to review, and where each of them stands. */
@@ -350,7 +355,8 @@ export const ClosedChangeSchema = z.object({
   reviewers: z.array(ChangeReviewerSchema),
   assignee: ChangeUserSchema.nullable(),
   approvalCount: z.number(),
-  requiredApprovals: z.number(),
+  /** As on an open change: null means unknown, 0 means none required. */
+  requiredApprovals: z.number().nullable(),
 });
 export type ClosedChange = z.infer<typeof ClosedChangeSchema>;
 
@@ -414,6 +420,7 @@ export const ChangeAssignmentsSchema = z.object({
   assignee: ChangeUserSchema.nullable(),
   reviewers: z.array(ChangeReviewerSchema),
   approvalCount: z.number(),
-  requiredApprovals: z.number(),
+  /** As on an open change: null means unknown, 0 means none required. */
+  requiredApprovals: z.number().nullable(),
 });
 export type ChangeAssignments = z.infer<typeof ChangeAssignmentsSchema>;

--- a/services/api/change-assignments.route.test.ts
+++ b/services/api/change-assignments.route.test.ts
@@ -26,6 +26,10 @@ type GiteaUser = { login: string; full_name: string; avatar_url: string };
 const originalFetch = globalThis.fetch;
 const originalApiPort = config.apiPort;
 const originalSessionsDbPath = config.sessionsDbPath;
+const originalServiceToken = config.giteaServiceToken;
+
+/** The token the BFF holds; the only one Gitea serves branch protection to. */
+const SERVICE_TOKEN = "gitea_service_token";
 
 let giteaUsersByLogin = new Map<string, { login: string; email: string }>();
 let giteaLoginsByToken = new Map<string, string>();
@@ -34,6 +38,8 @@ let assignees: GiteaUser[] = [];
 let reviewerCalls: { method: string; reviewers: string[] }[] = [];
 let assigneeCalls: string[][] = [];
 let requiredApprovals = 2;
+/** False when Gitea refuses the rule to everyone, service account included. */
+let protectionReadable = true;
 
 function person(login: string): GiteaUser {
   return {
@@ -52,6 +58,7 @@ function json(data: unknown, status = 200): Response {
 
 beforeEach(() => {
   config.apiPort = 0;
+  config.giteaServiceToken = SERVICE_TOKEN;
   config.sessionsDbPath = `/tmp/bindersnap-assign-test-${randomUUID()}.sqlite`;
   resetStripeClientForTests();
 
@@ -71,6 +78,7 @@ beforeEach(() => {
   reviewerCalls = [];
   assigneeCalls = [];
   requiredApprovals = 2;
+  protectionReadable = true;
 
   globalThis.fetch = (async (input, init) => {
     const requestUrl =
@@ -153,6 +161,20 @@ beforeEach(() => {
       /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/branch_protections$/,
     );
     if (protectionMatch && method === "GET") {
+      // Gitea serves this to an owner or an admin collaborator and nobody
+      // else, which is the whole reason the BFF reads it as the service
+      // account. A caller's own token gets the 403 a reviewer would get.
+      const auth = headers.get("Authorization") ?? "";
+      const token = auth.startsWith("token ") ? auth.slice(6) : "";
+      if (!protectionReadable || token !== SERVICE_TOKEN) {
+        return json(
+          {
+            message:
+              "user should be an owner or a collaborator with admin write of a repository",
+          },
+          403,
+        );
+      }
       return json([
         { rule_name: "main", required_approvals: requiredApprovals },
       ]);
@@ -200,6 +222,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  config.giteaServiceToken = originalServiceToken;
   config.apiPort = originalApiPort;
   config.sessionsDbPath = originalSessionsDbPath;
 });
@@ -317,7 +340,7 @@ describe("change assignment route", () => {
     const payload = (await response.json()) as {
       reviewers: { login: string; status: string; requested: boolean }[];
       approvalCount: number;
-      requiredApprovals: number;
+      requiredApprovals: number | null;
     };
 
     expect(payload.approvalCount).toBe(1);
@@ -329,6 +352,39 @@ describe("change assignment route", () => {
       ["lee", "awaiting"],
       ["dana", "approved"],
     ]);
+  });
+
+  test("a write collaborator is told what publishing needs", async () => {
+    const server = createApiServer();
+    // Bob's own Gitea token is refused the branch protection rule; the count
+    // comes back anyway, because the BFF reads it as the service account.
+    const session = await seedSession("carol");
+
+    const response = await server.fetch(
+      request({ reviewers: ["dana"] }, session),
+    );
+    const payload = (await response.json()) as {
+      requiredApprovals: number | null;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.requiredApprovals).toBe(2);
+  });
+
+  test("reports an unreadable policy as unknown rather than none", async () => {
+    protectionReadable = false;
+    const server = createApiServer();
+    const session = await seedSession("alice");
+
+    const response = await server.fetch(
+      request({ reviewers: ["dana"] }, session),
+    );
+    const payload = (await response.json()) as {
+      requiredApprovals: number | null;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.requiredApprovals).toBeNull();
   });
 
   test("rejects a request that changes nothing", async () => {

--- a/services/api/document-detail.route.test.ts
+++ b/services/api/document-detail.route.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "crypto";
+
+import { config } from "./config";
+import { createApiServer } from "./server";
+import { SessionStore, sessionStore } from "./sessions";
+import { resetStripeClientForTests } from "./stripe/client";
+import {
+  SubscriptionStore,
+  subscriptionStore,
+  WebhookEventStore,
+  webhookEventStore,
+} from "./subscriptions";
+
+/**
+ * What a reviewer who is not a repo admin is told about a change.
+ *
+ * Gitea serves branch protection only to an owner or a collaborator with admin
+ * write. Reading it as the caller therefore handed every write collaborator a
+ * 403, which the BFF turned into `requiredApprovals: 0` — no denominator, no
+ * count, for exactly the people the count exists for. The service account
+ * reads it now, and these tests hold the line on both halves of that: the
+ * number reaches a non-admin, and the whitelists on the same Gitea object,
+ * which name individual people, still do not.
+ */
+
+const originalFetch = globalThis.fetch;
+const originalApiPort = config.apiPort;
+const originalSessionsDbPath = config.sessionsDbPath;
+const originalServiceToken = config.giteaServiceToken;
+
+/** The BFF's own token — the only one this Gitea admits to the rule. */
+const SERVICE_TOKEN = "gitea_service_token";
+
+const WHITELISTED = "carol";
+
+let giteaLoginsByToken = new Map<string, string>();
+let requiredApprovals = 2;
+/** What the caller's own token is allowed to do with the repo. */
+let callerIsAdmin = false;
+/** False when even the service account cannot read the rule. */
+let protectionReadable = true;
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function person(login: string) {
+  return {
+    login,
+    full_name: `${login[0]?.toUpperCase()}${login.slice(1)} Reyes`,
+    avatar_url: `https://gitea.test/${login}.png`,
+  };
+}
+
+function pullRequest(number: number, state: "open" | "closed") {
+  return {
+    id: number,
+    number,
+    title: `Change ${number}`,
+    body: "Adds the 2026 retention clause.",
+    state,
+    created_at: "2026-02-01T00:00:00Z",
+    updated_at: "2026-02-02T00:00:00Z",
+    head: { ref: `upload/v${number}` },
+    base: { ref: "main" },
+    user: person("bob"),
+    assignees: [],
+    requested_reviewers: [person("dana")],
+    merged: state === "closed",
+    merge_commit_sha: state === "closed" ? "sha-closed" : undefined,
+  };
+}
+
+beforeEach(() => {
+  config.apiPort = 0;
+  config.sessionsDbPath = `/tmp/bindersnap-detail-test-${randomUUID()}.sqlite`;
+  config.giteaServiceToken = SERVICE_TOKEN;
+  resetStripeClientForTests();
+
+  (sessionStore as unknown as { _store: SessionStore | null })._store =
+    new SessionStore(config.sessionsDbPath);
+  (
+    subscriptionStore as unknown as { _store: SubscriptionStore | null }
+  )._store = new SubscriptionStore(config.sessionsDbPath);
+  (
+    webhookEventStore as unknown as { _store: WebhookEventStore | null }
+  )._store = new WebhookEventStore(config.sessionsDbPath);
+
+  giteaLoginsByToken = new Map();
+  requiredApprovals = 2;
+  callerIsAdmin = false;
+  protectionReadable = true;
+
+  globalThis.fetch = (async (input, init) => {
+    const requestUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const url = new URL(requestUrl);
+    const headers =
+      input instanceof Request ? input.headers : new Headers(init?.headers);
+    const method =
+      input instanceof Request ? input.method : (init?.method ?? "GET");
+    const path = url.pathname;
+    const auth = headers.get("Authorization") ?? "";
+    const token = auth.startsWith("token ") ? auth.slice(6) : "";
+
+    if (path === "/api/v1/user") {
+      const login = giteaLoginsByToken.get(token);
+      if (!login) return json({ message: "Not found" }, 404);
+      return json({
+        login,
+        email: `${login}@test.local`,
+        full_name: "",
+        is_admin: false,
+      });
+    }
+
+    if (/^\/api\/v1\/repos\/[^/]+\/[^/]+\/branch_protections$/.test(path)) {
+      // The 403 a write collaborator actually receives, verbatim.
+      if (!protectionReadable || (token !== SERVICE_TOKEN && !callerIsAdmin)) {
+        return json(
+          {
+            message:
+              "user should be an owner or a collaborator with admin write of a repository",
+          },
+          403,
+        );
+      }
+      return json([
+        {
+          rule_name: "main",
+          required_approvals: requiredApprovals,
+          enable_approvals_whitelist: true,
+          approvals_whitelist_username: [WHITELISTED],
+          approvals_whitelist_teams: ["legal"],
+          enable_merge_whitelist: true,
+          merge_whitelist_usernames: [WHITELISTED],
+          merge_whitelist_teams: ["legal"],
+        },
+      ]);
+    }
+
+    if (/^\/api\/v1\/repos\/[^/]+\/[^/]+\/tags$/.test(path)) {
+      return json([]);
+    }
+
+    const pullsMatch = path.match(/^\/api\/v1\/repos\/[^/]+\/[^/]+\/pulls$/);
+    if (pullsMatch && method === "GET") {
+      const state =
+        url.searchParams.get("state") === "closed" ? "closed" : "open";
+      return json([pullRequest(3, state)]);
+    }
+
+    if (/^\/api\/v1\/repos\/[^/]+\/[^/]+\/pulls\/\d+\/reviews$/.test(path)) {
+      return json([
+        {
+          id: 11,
+          state: "APPROVED",
+          body: "",
+          submitted_at: "2026-02-02T00:00:00Z",
+          user: person("dana"),
+        },
+      ]);
+    }
+
+    const repoMatch = path.match(/^\/api\/v1\/repos\/([^/]+)\/([^/]+)$/);
+    if (repoMatch && method === "GET") {
+      return json({
+        id: 1,
+        name: repoMatch[2],
+        full_name: `${repoMatch[1]}/${repoMatch[2]}`,
+        private: true,
+        owner: person(repoMatch[1]!),
+        permissions: {
+          admin: token === SERVICE_TOKEN ? true : callerIsAdmin,
+          push: true,
+          pull: true,
+        },
+      });
+    }
+
+    // Everything else on a document's page — the canonical file, the
+    // collaborator lookup, the review settings — is read behind a catch and
+    // has no bearing on the approval count.
+    return json({ message: "Not found" }, 404);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  config.giteaServiceToken = originalServiceToken;
+  config.apiPort = originalApiPort;
+  config.sessionsDbPath = originalSessionsDbPath;
+});
+
+async function seedSession(username: string): Promise<string> {
+  const sessionId = `sess_${randomUUID()}`;
+  const giteaToken = `gitea_${randomUUID()}`;
+  giteaLoginsByToken.set(giteaToken, username);
+  await sessionStore.put({
+    id: sessionId,
+    username,
+    giteaToken,
+    giteaTokenName: "detail-test-token",
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  });
+  await subscriptionStore.upsert({
+    username,
+    stripeCustomerId: `cus_${randomUUID()}`,
+    stripeSubscriptionId: `sub_${randomUUID()}`,
+    status: "active",
+    currentPeriodEnd: Math.floor(Date.now() / 1000) + 86_400,
+    cancelAtPeriodEnd: false,
+    cancelAt: null,
+    updatedAt: Date.now(),
+  });
+  return sessionId;
+}
+
+function get(path: string, sessionId: string) {
+  return new Request(`http://localhost${path}`, {
+    headers: {
+      Origin: config.appOrigin,
+      Cookie: `${config.sessionCookieName}=${sessionId}`,
+    },
+  });
+}
+
+const DETAIL = "/api/app/documents/alice/quarterly-report";
+const CLOSED = "/api/app/documents/alice/quarterly-report/changes/closed";
+
+interface DetailPayload {
+  openPullRequests: { requiredApprovals: number | null }[];
+  branchProtection: { approvalsWhitelistUsernames: string[] } | null;
+}
+
+describe("document detail approval policy", () => {
+  test("a write collaborator sees the count the owner sees", async () => {
+    const server = createApiServer();
+    const session = await seedSession("bob");
+
+    const response = await server.fetch(get(DETAIL, session));
+    const payload = (await response.json()) as DetailPayload;
+
+    expect(response.status).toBe(200);
+    // Bob's own token is refused the rule; the service account is not, and the
+    // number it reads is the number Bob is served.
+    expect(payload.openPullRequests[0]?.requiredApprovals).toBe(2);
+  });
+
+  test("the whitelists stay admin-only", async () => {
+    const server = createApiServer();
+    const session = await seedSession("bob");
+
+    const response = await server.fetch(get(DETAIL, session));
+    const body = await response.text();
+    const payload = JSON.parse(body) as DetailPayload;
+
+    // The count is policy every reviewer is entitled to. Who is on the
+    // approval or merge whitelist is policy about named people, and reaching
+    // it still requires admin on the repo.
+    expect(payload.branchProtection).toBeNull();
+    expect(body).not.toContain(WHITELISTED);
+    expect(body).not.toContain("approvalsWhitelistUsernames");
+  });
+
+  test("an admin still receives the whole rule", async () => {
+    callerIsAdmin = true;
+    const server = createApiServer();
+    const session = await seedSession("alice");
+
+    const response = await server.fetch(get(DETAIL, session));
+    const payload = (await response.json()) as DetailPayload;
+
+    expect(payload.openPullRequests[0]?.requiredApprovals).toBe(2);
+    expect(payload.branchProtection?.approvalsWhitelistUsernames).toEqual([
+      WHITELISTED,
+    ]);
+  });
+
+  test("a document that demands no approvals reports zero, not unknown", async () => {
+    requiredApprovals = 0;
+    const server = createApiServer();
+    const session = await seedSession("bob");
+
+    const response = await server.fetch(get(DETAIL, session));
+    const payload = (await response.json()) as DetailPayload;
+
+    expect(payload.openPullRequests[0]?.requiredApprovals).toBe(0);
+  });
+
+  test("a policy that cannot be read reports null, not zero", async () => {
+    // Gitea refusing even the service account is the one case where nobody
+    // can read the rule. It has to stay distinguishable from a document that
+    // demands nothing, or the UI reports "nothing left to collect" when what
+    // it means is "we do not know".
+    protectionReadable = false;
+    const server = createApiServer();
+    const session = await seedSession("bob");
+
+    const response = await server.fetch(get(DETAIL, session));
+    const payload = (await response.json()) as DetailPayload;
+
+    expect(payload.openPullRequests[0]?.requiredApprovals).toBeNull();
+  });
+
+  test("closed changes carry the same count", async () => {
+    const server = createApiServer();
+    const session = await seedSession("bob");
+
+    const response = await server.fetch(get(CLOSED, session));
+    const payload = (await response.json()) as {
+      changes: { requiredApprovals: number | null }[];
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.changes[0]?.requiredApprovals).toBe(2);
+  });
+});

--- a/services/api/document-history.ts
+++ b/services/api/document-history.ts
@@ -147,7 +147,8 @@ export function buildVersionRecords(
 export function buildClosedChanges(
   entries: PullRequestWithReviews[],
   tags: DocTag[],
-  requiredApprovals = 0,
+  /** null when the approval policy could not be read. See ClosedChange. */
+  requiredApprovals: number | null = null,
 ): ClosedChange[] {
   const versionByMergeSha = new Map<string, number>();
   for (const tag of tags) {

--- a/services/api/gitea-client/client.ts
+++ b/services/api/gitea-client/client.ts
@@ -15,6 +15,28 @@ export function createGiteaClient(baseUrl: string, token: string) {
   });
 }
 
+/**
+ * The same client, authenticated as a Gitea user rather than by token.
+ *
+ * Dev and test stacks bring Gitea up with admin credentials and no service
+ * token to mint one from, so the BFF's privileged reads have always fallen
+ * back to basic auth there. This is that fallback, for the reads that go
+ * through the typed client instead of raw fetch.
+ */
+export function createGiteaBasicAuthClient(
+  baseUrl: string,
+  username: string,
+  password: string,
+) {
+  return createClient<paths>({
+    baseUrl: `${baseUrl}/api/v1`,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+    },
+  });
+}
+
 export class GiteaApiError extends Error {
   constructor(
     public status: number,

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -19,6 +19,7 @@ import {
   reconcileStripeCustomerByCustomerId,
 } from "./stripe/reconcile";
 import {
+  createGiteaBasicAuthClient,
   createGiteaClient,
   GiteaApiError,
   unwrap,
@@ -580,6 +581,75 @@ function createSessionGiteaClient(session: SessionRecord): GiteaClient {
 
 function createServiceGiteaClient(): GiteaClient {
   return createGiteaClient(config.giteaUrl, config.giteaServiceToken);
+}
+
+/**
+ * A client that can read what the caller is not allowed to, or null.
+ *
+ * The service token is the real answer. Dev and test stacks come up without
+ * one, so they fall back to the admin credentials the BFF already holds —
+ * the same fallback `buildGiteaPrivilegedHeaders` makes for the raw-fetch
+ * calls, kept in one shape so the two cannot drift apart.
+ */
+function createPrivilegedGiteaClient(): GiteaClient | null {
+  if (config.giteaServiceToken) {
+    return createServiceGiteaClient();
+  }
+
+  if (
+    !config.isProduction &&
+    config.giteaAdminUsername &&
+    config.giteaAdminPassword
+  ) {
+    return createGiteaBasicAuthClient(
+      config.giteaUrl,
+      config.giteaAdminUsername,
+      config.giteaAdminPassword,
+    );
+  }
+
+  return null;
+}
+
+/**
+ * How many approvals a document demands before anything can publish.
+ *
+ * Gitea serves branch protection only to an owner or a collaborator with admin
+ * write, so reading it as the caller hands every write collaborator a 403 — and
+ * the reviewers who need the count most are precisely the ones who never see
+ * it. The service account reads it instead, and only the number comes back:
+ * the whitelists on the same object name individual people and stay as
+ * admin-only as they are today.
+ *
+ * Returns 0 for a repo with no protection rule, and null when the read fails,
+ * so "this document needs no approvals" stays distinguishable from "we could
+ * not find out how many it needs".
+ */
+async function readRequiredApprovals(
+  owner: string,
+  repo: string,
+  branch = "main",
+): Promise<number | null> {
+  const client = createPrivilegedGiteaClient();
+  if (!client) return null;
+
+  try {
+    const protection = await getRepoBranchProtection(
+      client,
+      owner,
+      repo,
+      branch,
+    );
+    return protection?.requiredApprovals ?? 0;
+  } catch (err) {
+    logger.error("Failed to read required approvals", {
+      owner,
+      repo,
+      branch,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
 }
 
 interface DocumentAccessContext {
@@ -1977,7 +2047,7 @@ async function handleDocuments(
     const documents = await Promise.all(
       repos.map(async (repo) => {
         try {
-          const [latestTag, openWithReviews, branchProtection] =
+          const [latestTag, openWithReviews, requiredApprovals] =
             await Promise.all([
               getLatestDocTag(client, repo.owner.login, repo.name),
               listPullRequestsWithReviews({
@@ -1986,17 +2056,10 @@ async function handleDocuments(
                 repo: repo.name,
                 state: "open",
               }),
-              getRepoBranchProtection(
-                client,
-                repo.owner.login,
-                repo.name,
-                "main",
-                // A row is worth showing without its approval policy; it is
-                // not worth failing the whole list for.
-              ).catch(() => null),
+              // A row is worth showing without its approval policy; it is not
+              // worth failing the whole list for.
+              readRequiredApprovals(repo.owner.login, repo.name),
             ]);
-
-          const requiredApprovals = branchProtection?.requiredApprovals ?? 0;
           const pendingPRs = openWithReviews
             .filter((entry) =>
               (entry.pullRequest.head?.ref ?? "").startsWith("upload/"),
@@ -2241,25 +2304,32 @@ async function handleDocumentDetail(
       },
     );
 
-    const [tags, openWithReviews, branchProtection, reviewSettings] =
-      await Promise.all([
-        listDocTags(client, owner, repo),
-        listPullRequestsWithReviews({
-          client,
-          owner,
-          repo,
-          state: "open",
-        }),
-        getRepoBranchProtection(client, owner, repo, "main").catch(() => null),
-        getReviewSettings({ client, owner, repo }).catch(() => null),
-      ]);
+    const [
+      tags,
+      openWithReviews,
+      branchProtection,
+      requiredApprovals,
+      reviewSettings,
+    ] = await Promise.all([
+      listDocTags(client, owner, repo),
+      listPullRequestsWithReviews({
+        client,
+        owner,
+        repo,
+        state: "open",
+      }),
+      // The whole rule, whitelists and all, is admin-only and stays that way:
+      // a non-admin gets null here and the count below regardless.
+      getRepoBranchProtection(client, owner, repo, "main").catch(() => null),
+      readRequiredApprovals(owner, repo),
+      getReviewSettings({ client, owner, repo }).catch(() => null),
+    ]);
 
     // The reviews come back with the pull requests anyway, and a change's page
     // reads as a log of what happened — an approval is part of that log, so it
     // travels with the change rather than costing a second round trip. The
     // reviewer list is the same reviews read a different way: not what happened,
     // but who the change is still waiting on.
-    const requiredApprovals = branchProtection?.requiredApprovals ?? 0;
     const openPullRequests = openWithReviews.map((entry) => ({
       ...entry.pullRequest,
       reviews: toVersionReviews(entry.reviews),
@@ -2436,7 +2506,7 @@ async function handleClosedChanges(
   const { client } = access;
 
   try {
-    const [tags, closedPullRequests, branchProtection] = await Promise.all([
+    const [tags, closedPullRequests, requiredApprovals] = await Promise.all([
       listDocTags(client, owner, repo),
       listPullRequestsWithReviews({
         client,
@@ -2444,7 +2514,7 @@ async function handleClosedChanges(
         repo,
         state: "closed",
       }),
-      getRepoBranchProtection(client, owner, repo, "main").catch(() => null),
+      readRequiredApprovals(owner, repo),
     ]);
 
     return json(
@@ -2453,7 +2523,7 @@ async function handleClosedChanges(
         changes: buildClosedChanges(
           closedPullRequests,
           tags,
-          branchProtection?.requiredApprovals ?? 0,
+          requiredApprovals,
         ),
       },
       baseHeaders,
@@ -2787,14 +2857,14 @@ async function handleUpdateChangeAssignments(
       });
     }
 
-    const [after, branchProtection] = await Promise.all([
+    const [after, requiredApprovals] = await Promise.all([
       getPullRequestWithReviews({
         client,
         owner,
         repo,
         pullNumber: prNumber,
       }),
-      getRepoBranchProtection(client, owner, repo, "main").catch(() => null),
+      readRequiredApprovals(owner, repo),
     ]);
 
     return json(
@@ -2807,7 +2877,7 @@ async function handleUpdateChangeAssignments(
           submittedBy: after.pullRequest.user?.login ?? submittedBy,
         }),
         approvalCount: countApprovals(after.reviews),
-        requiredApprovals: branchProtection?.requiredApprovals ?? 0,
+        requiredApprovals,
       },
       baseHeaders,
     );

--- a/tests/merge-conflict-resolution.pw.ts
+++ b/tests/merge-conflict-resolution.pw.ts
@@ -141,13 +141,13 @@ test.describe("Merge conflict resolution on publish", () => {
     });
     await page.getByRole("button", { name: "Confirm Approval" }).click();
 
-    // Bob is a write collaborator, not an admin, so Gitea refuses him the
-    // branch protection read and the change arrives with requiredApprovals 0.
-    // With no count to show, the standing pill cannot render and the state
-    // badge is what he gets. See the note in documentDisplay.
-    await expect(page.locator(".vault-status-approved")).toBeVisible({
-      timeout: 30_000,
-    });
+    // Bob is a write collaborator, not an admin, but the BFF reads the
+    // approval policy with the service account — so he gets the count, and
+    // the count is what says his approval landed.
+    await expect(page.locator(".change-detail .rev-approval-count")).toHaveText(
+      "1 of 1 approvals",
+      { timeout: 30_000 },
+    );
 
     // Switch back to Alice to publish v1
     await signInAsAlice(page);
@@ -237,11 +237,10 @@ test.describe("Merge conflict resolution on publish", () => {
       timeout: 5_000,
     });
     await page.getByRole("button", { name: "Confirm Approval" }).click();
-    await expect(
-      page.locator(".change-detail .vault-status-approved"),
-    ).toBeVisible({
-      timeout: 30_000,
-    });
+    await expect(page.locator(".change-detail .rev-approval-count")).toHaveText(
+      "1 of 1 approvals",
+      { timeout: 30_000 },
+    );
 
     // --- Alice publishes v2 ---
     // Both changes are still open and only v2 is approved, so open the same
@@ -282,11 +281,10 @@ test.describe("Merge conflict resolution on publish", () => {
       timeout: 5_000,
     });
     await page.getByRole("button", { name: "Confirm Approval" }).click();
-    await expect(
-      page.locator(".change-detail .vault-status-approved"),
-    ).toBeVisible({
-      timeout: 30_000,
-    });
+    await expect(page.locator(".change-detail .rev-approval-count")).toHaveText(
+      "1 of 1 approvals",
+      { timeout: 30_000 },
+    );
 
     // --- Alice publishes v3 (conflict resolution path) ---
     await signInAsAlice(page);


### PR DESCRIPTION
## Summary

Closes #334.

`requiredApprovals` came from a branch-protection read made with the **caller's** Gitea client. Gitea serves `GET /repos/{owner}/{repo}/branch_protections` only to an owner or a collaborator with admin write, so every write collaborator got a 403, the BFF swallowed it, and the change was served with `requiredApprovals: 0`. No denominator, no count — for exactly the people the count exists for.

The four change-serving call sites now read the rule with the service account and take **only the number** from it:

- `handleDocuments` (workspace list)
- `handleDocumentDetail`
- `handleClosedChanges`
- `handleUpdateChangeAssignments`

**The whitelists are not widened.** `handleDocumentDetail` still reads the whole `branchProtection` object with the caller's client, so `approvalsWhitelistUsernames` / `approvalsWhitelistTeams` and the merge whitelists reach admins only, exactly as before. A test asserts the non-admin payload contains neither the field nor the whitelisted username.

**An unreadable policy is now `null`, not `0`.** A document that genuinely demands no approvals reports `0`; a policy nobody could read reports `null`. Both render as the state badge, but nothing downstream can mistake "nothing left to collect" for "we do not know". This widens `requiredApprovals` to `number | null` on the three change-carrying schemas (open PRs, closed changes, assignments) and regenerates the OpenAPI spec and client.

Two things beyond the issue's letter, both load-bearing:

1. **Dev and test stacks have no service token.** `BINDERSNAP_GITEA_SERVICE_TOKEN` is only set in `docker-compose.prod.yml`, so without a fallback the fix is inert locally and the integration assertions below could never pass. `createPrivilegedGiteaClient()` falls back to the admin credentials the BFF already holds outside production — the same fallback `buildGiteaPrivilegedHeaders` already makes for the raw-fetch calls.
2. **The Playwright assertions moved to `.rev-approval-count`, not `.approval-meter--ready`.** The issue named the latter, but `ApprovalMeter` renders on the Changes tab list; the change-detail page those three assertions sit on renders `ApprovalBars`. They now assert `.change-detail .rev-approval-count` reads `"1 of 1 approvals"` — same intent, correct selector for that page.

The note at `apps/app/documentDisplay.ts:464` explaining why Bob had no count is gone with the bug.

## Scope Check

- [x] Changes are focused on one issue/task
- [x] No unrelated refactors or formatting-only churn included

## Validation

- [x] Local validation/tests run (list commands below)
- Commands run:
  - `bun run test:app` — 219 pass
  - `bun run test:ops` — 358 pass (includes the new `services/api/document-detail.route.test.ts`, 6 tests, and 2 added cases on the assignment route)
  - `bun run format:check` — clean
  - `bunx playwright test tests/merge-conflict-resolution.pw.ts` — 2 passed
  - `bun run test:integration` — 40 passed. `smoke.pw.ts` and `gitea-services.pw.ts` fail on a 10s `beforeAll` seed timeout in my working directory; `main` fails identically there and both pass on a clean worktree, so it is accumulated local `data/gitea`, not this change.

New tests:
- `services/api/document-detail.route.test.ts` — a write collaborator sees the owner's count; the whitelists stay admin-only; an admin still receives the whole rule; a document demanding none reports `0`; an unreadable policy reports `null`; closed changes carry the same count.
- `change-assignments.route.test.ts` — the mocked Gitea now returns the real 403 to any non-service token, so every existing assertion in that file exercises the fixed path.
- `documentDisplay.test.ts` — an unknown requirement is not a requirement of none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
