### PR TITLE
fix: quiet the top nav's "New document" button

### DIFF
--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -4109,25 +4109,11 @@ input {
   flex-shrink: 1;
 }
 
-.app-topnav-new-btn {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 9px var(--brand-space-4);
-  background: var(--brand-coral);
-  color: #fff;
-  font-size: 13px;
-  font-weight: var(--brand-weight-semibold);
-  border-radius: var(--brand-radius-md);
-  border: none;
-  cursor: pointer;
-  transition: none;
-  white-space: nowrap;
+/* The nav's create action is a convenience, not a headline: every page owns a
+   primary action of its own, so this one keeps the quiet icon-button styling
+   it shares with the bell and leaves coral to the page. */
+.app-topnav-new-btn svg {
   flex-shrink: 0;
-}
-
-.app-topnav-new-btn:hover {
-  background: var(--brand-coral-dark);
 }
 
 .app-topnav-divider {
@@ -4921,22 +4907,6 @@ input {
      you are, and Home/Documents are the only way to move. */
   .app-topnav-wordmark {
     display: none;
-  }
-
-  /* New Document: icon-only square */
-  .app-topnav-new-btn {
-    width: var(--brand-space-8);
-    height: var(--brand-space-8);
-    padding: 0;
-    justify-content: center;
-    font-size: 0;
-    gap: 0;
-  }
-
-  .app-topnav-new-btn svg {
-    width: 14px;
-    height: 14px;
-    flex-shrink: 0;
   }
 
   .app-nav-search {

--- a/apps/app/components/AnonymousDocumentShell.tsx
+++ b/apps/app/components/AnonymousDocumentShell.tsx
@@ -43,7 +43,7 @@ export function AnonymousDocumentShell({
           </button>
           <button
             type="button"
-            className="bs-btn bs-btn-primary app-topnav-new-btn"
+            className="bs-btn bs-btn-primary"
             onClick={() => onNavigate({ kind: "signup" })}
           >
             Sign up

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -1,13 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Bell,
-  FileText,
-  LogOut,
-  Moon,
-  Plus,
-  Search,
-  Shield,
-} from "lucide-react";
+import { Bell, FileText, LogOut, Moon, Search, Shield } from "lucide-react";
 import type { SessionUser } from "../api";
 import { buildDocumentsUrl, parseDocumentsViewState } from "../documentsView";
 import type { AppRoute } from "../routes";
@@ -18,6 +10,7 @@ import { CreateDocumentModal } from "./CreateDocumentModal";
 import { DocumentDetail } from "./DocumentDetail";
 import { DocumentsPage } from "./DocumentsPage";
 import { HomePage } from "./HomePage";
+import { NewDocumentButton } from "./NewDocumentButton";
 
 interface AppShellProps {
   user: SessionUser | null;
@@ -219,16 +212,8 @@ export function AppShell({
             </span>
           </form>
 
-          {/* Create document */}
-          <button
-            className="app-topnav-new-btn"
-            type="button"
-            id="topnav-new-doc-btn"
-            onClick={openCreateDocumentModal}
-          >
-            <Plus size={12} strokeWidth={2} aria-hidden="true" />
-            New document
-          </button>
+          {/* Create document — a convenience, not the page's headline action */}
+          <NewDocumentButton onClick={openCreateDocumentModal} />
 
           {/* Notifications */}
           <button

--- a/apps/app/components/NewDocumentButton.test.ts
+++ b/apps/app/components/NewDocumentButton.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { createElement } from "react";
+import type { ReactElement } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { JSDOM } from "jsdom";
+
+import { NewDocumentButton } from "./NewDocumentButton";
+
+/**
+ * The nav's create action, rendered.
+ *
+ * The point of this button is restraint: it has to stay reachable and named
+ * for a screen reader while giving up the coral that belongs to whatever the
+ * page itself is asking for.
+ */
+
+const DOM_KEYS = [
+  "window",
+  "document",
+  "navigator",
+  "HTMLElement",
+  "Element",
+  "Node",
+  "MutationObserver",
+  "Event",
+] as const;
+
+let originals: Record<string, unknown> = {};
+
+beforeEach(() => {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "https://bindersnap.com/",
+  });
+
+  const values: Record<string, unknown> = {
+    window: dom.window,
+    document: dom.window.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Element: dom.window.Element,
+    Node: dom.window.Node,
+    MutationObserver: dom.window.MutationObserver,
+    Event: dom.window.Event,
+  };
+
+  originals = {};
+  for (const key of DOM_KEYS) {
+    originals[key] = (globalThis as Record<string, unknown>)[key];
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value: values[key],
+    });
+  }
+});
+
+afterEach(async () => {
+  // React's scheduler reads `window` from a callback of its own; pulling the
+  // DOM out from under it mid-flight fails the next test, not this one.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  for (const key of DOM_KEYS) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value: originals[key],
+    });
+  }
+});
+
+function render(element: ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  flushSync(() => root.render(element));
+
+  return {
+    container,
+    unmount: () => {
+      flushSync(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+test("the button is named for a screen reader and on hover", () => {
+  const { container, unmount } = render(
+    createElement(NewDocumentButton, { onClick: () => {} }),
+  );
+
+  const button = container.querySelector("button");
+  expect(button).not.toBeNull();
+  expect(button?.getAttribute("aria-label")).toBe("New document");
+  expect(button?.getAttribute("title")).toBe("New document");
+  expect(button?.getAttribute("type")).toBe("button");
+
+  unmount();
+});
+
+test("the button stays quiet — no visible label, no coral styling", () => {
+  const { container, unmount } = render(
+    createElement(NewDocumentButton, { onClick: () => {} }),
+  );
+
+  const button = container.querySelector("button");
+  // Icon only: nothing in the button reads as a word on screen.
+  expect(button?.textContent?.trim()).toBe("");
+  expect(container.querySelector("svg")).not.toBeNull();
+  // It borrows the nav's plain icon-button styling rather than a coral CTA.
+  expect(button?.className.split(/\s+/)).toContain("app-topnav-icon-btn");
+
+  unmount();
+});
+
+test("clicking it asks for a new document", () => {
+  let clicks = 0;
+  const { container, unmount } = render(
+    createElement(NewDocumentButton, {
+      onClick: () => {
+        clicks += 1;
+      },
+    }),
+  );
+
+  const button = container.querySelector("button");
+  flushSync(() => {
+    button?.dispatchEvent(new window.Event("click", { bubbles: true }));
+  });
+
+  expect(clicks).toBe(1);
+
+  unmount();
+});

--- a/apps/app/components/NewDocumentButton.tsx
+++ b/apps/app/components/NewDocumentButton.tsx
@@ -1,0 +1,29 @@
+import { Plus } from "lucide-react";
+
+interface NewDocumentButtonProps {
+  onClick: () => void;
+}
+
+/**
+ * "New document", in the top nav.
+ *
+ * Every page already carries its own primary action, so the nav's copy of this
+ * one stays quiet: a plain plus that sits with the notification bell rather
+ * than a coral button competing with the action the page actually wants. The
+ * label lives in `aria-label` and `title` — read by a screen reader, shown on
+ * hover, and never shouted in coral.
+ */
+export function NewDocumentButton({ onClick }: NewDocumentButtonProps) {
+  return (
+    <button
+      className="app-topnav-icon-btn app-topnav-new-btn"
+      type="button"
+      id="topnav-new-doc-btn"
+      title="New document"
+      aria-label="New document"
+      onClick={onClick}
+    >
+      <Plus size={16} strokeWidth={1.5} aria-hidden="true" />
+    </button>
+  );
+}

--- a/tests/new-document-nav.pw.ts
+++ b/tests/new-document-nav.pw.ts
@@ -11,8 +11,13 @@ test.describe("top nav new document button", () => {
     await page.locator(".app-topnav-link", { hasText: "Documents" }).click();
     await expect(page.locator(".docs-page")).toBeVisible();
 
-    await expect(page.locator("#topnav-new-doc-btn")).toBeVisible();
-    await page.locator("#topnav-new-doc-btn").click();
+    // Subtle by design: the nav's create action is an icon with an accessible
+    // name, not a coral button competing with the page's own primary action.
+    const newDocButton = page.locator("#topnav-new-doc-btn");
+    await expect(newDocButton).toBeVisible();
+    await expect(newDocButton).toHaveAccessibleName("New document");
+    await expect(newDocButton).toHaveText("");
+    await newDocButton.click();
 
     await expect(
       page.getByRole("heading", { name: "Create workspace document" }),


### PR DESCRIPTION
Closes #330

## The change

The top nav's coral `+ New document` button was a second primary action on
every page, fighting the one the page itself is asking for. It is now a plain
plus that sits with the notification bell — same quiet `app-topnav-icon-btn`
styling, same `#topnav-new-doc-btn` hook, same modal. The label moves to
`aria-label` and `title`, so it is still announced by a screen reader and still
shown on hover.

The markup moved into its own `NewDocumentButton` component so it can be tested
on its own.

- `.app-topnav-new-btn` is no longer a coral CTA, and the ≤960px media query
  that squashed it into an icon-only square is gone — it is always icon-only now.
- `AnonymousDocumentShell`'s "Sign up" button dropped the `app-topnav-new-btn`
  class it was borrowing for coral; it keeps `bs-btn-primary`, which is where
  its coral actually comes from. Sign up is that page's primary action, so it
  stays coral.

## Tests

- New `apps/app/components/NewDocumentButton.test.ts` — accessible name and
  title, no visible label, no coral class, and the click reaches the handler.
- `tests/new-document-nav.pw.ts` now also asserts the accessible name and the
  empty visible text.
- `bun run test` — 358 pass, 0 fail. `bun run build` clean.

## Verified in the app

Signed in against the local stack: the nav renders a plain `+`, clicking it
opens the create-document modal, the button computes to a transparent 32×32
with secondary text color in dark theme, and it stays a correctly sized square
at mobile width.

No `packages/editor/` visuals changed, so no `bun run sync-demo` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)