### PR TITLE
feat: restyle the history page as a spline of change reviews

### DIFF
--- a/apps/app/App.test.ts
+++ b/apps/app/App.test.ts
@@ -46,7 +46,14 @@ const mockSignup = mock(async () => ({
 }));
 const mockStoreToken = mock(() => {});
 
+// Spread the real module rather than replacing it: `mock.module` fixes a
+// module's export names the first time it is applied, so a partial mock here
+// makes every *other* suite that imports an untouched export of `./api` fail
+// to link — in a different file, with a confusing message.
+const actualApi = await import("./api");
+
 mock.module("./api", () => ({
+  ...actualApi,
   clearToken: mockClearToken,
   createCheckoutSession: mockCreateCheckoutSession,
   createPortalSession: mockCreatePortalSession,

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -557,7 +557,6 @@ input {
   align-items: center;
 }
 
-.vault-version-badge,
 .vault-pending-badge,
 .vault-status-badge,
 .collaborator-permission-badge {
@@ -569,11 +568,6 @@ input {
   border-radius: var(--brand-radius-sm);
   text-transform: uppercase;
   letter-spacing: var(--brand-tracking-wide);
-}
-
-.vault-version-badge {
-  background: var(--bs-coral-dim);
-  color: var(--brand-coral-dark);
 }
 
 .vault-no-version {

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -2511,72 +2511,181 @@ input {
   color: var(--bs-text-muted);
 }
 
-/* History tab — the audit trail as a timeline. */
-.doc-history {
+/* ── History tab — the audit trail as a spline ─────────────────────
+   One line down the page with a knot for every published version. Each knot
+   is the change review that produced it, so the title is that review's title
+   and it links straight to it; the two people the record is about — who wrote
+   the change and who published it — sit on the line rather than inside a
+   panel nobody opens.
+   ------------------------------------------------------------------ */
+.doc-spline {
+  position: relative;
   display: grid;
-  gap: var(--brand-space-3);
+  gap: var(--brand-space-5);
   margin: 0;
-  padding: 0;
+  padding: var(--brand-space-2) 0 var(--brand-space-2) 56px;
   list-style: none;
 }
 
-.doc-history-entry {
-  background: var(--bs-surface-1);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-md);
-  overflow: hidden;
+/* The line is the page's structure, not an inner divider, so it reads at the
+   rule colour rather than the warm 6% one used inside a card. */
+.doc-spline::before {
+  content: "";
+  position: absolute;
+  left: 21px;
+  top: var(--brand-space-3);
+  bottom: var(--brand-space-3);
+  width: 1.5px;
+  background: var(--bs-rule);
 }
 
-.doc-history-entry--viewing {
-  border-color: var(--brand-coral);
+.doc-spline-entry {
+  position: relative;
 }
 
-.doc-history-row {
-  display: flex;
-  align-items: center;
-  gap: var(--brand-space-3);
-  padding: var(--brand-space-3) var(--brand-space-4);
-}
-
-.doc-history-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--brand-space-3);
-  flex: 1;
-  min-width: 0;
-  padding: 0;
-  border: none;
-  background: none;
-  color: inherit;
-  cursor: pointer;
-  text-align: left;
-}
-
-.doc-history-summary {
+/* Opaque, always: the line showing through a knot turns the version into a
+   smudge with a rule drawn across it. */
+.doc-spline-knot {
+  position: absolute;
+  left: -56px;
+  top: 0;
+  z-index: var(--brand-z-raised);
   display: grid;
-  gap: 2px;
+  place-items: center;
+  width: 44px;
+  height: 26px;
+  border-radius: var(--brand-radius-full);
+  background: var(--bs-surface-1);
+  border: 1.5px solid var(--bs-rule);
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-secondary);
+}
+
+/* The version currently open on the Document tab. Coral is the one thing on
+   this page that says "you are here". */
+.doc-spline-entry--viewing .doc-spline-knot {
+  border-color: var(--brand-coral);
+  color: var(--brand-coral-dark);
+}
+
+.doc-spline-body {
+  display: grid;
+  gap: var(--brand-space-2);
   min-width: 0;
 }
 
-.doc-history-title {
-  font-size: var(--brand-text-sm);
+.doc-spline-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--brand-space-3);
+}
+
+.doc-spline-title {
+  margin: 0;
+  min-width: 0;
+  font-family: var(--brand-font-sans);
+  font-size: var(--brand-text-body);
   font-weight: var(--brand-weight-medium);
   color: var(--bs-text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.doc-history-sub {
+.doc-spline-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--brand-transition-fast);
+}
+
+.doc-spline-link:hover,
+.doc-spline-link:focus-visible {
+  border-bottom-color: var(--brand-coral);
+}
+
+.doc-spline-actions {
+  display: flex;
+  gap: var(--brand-space-2);
+  flex-shrink: 0;
+}
+
+/* Icon only. A row of buttons that each repeat the version number reads as a
+   form; the icon plus the version on the knot says the same thing quieter.
+   Scoped to the row so it outranks `.bs-btn`'s own padding, which is set for
+   a button with words in it. */
+.doc-spline-actions .doc-spline-icon-btn {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+}
+
+/* A 15px icon in a grid cell narrower than its intrinsic width collapses to
+   nothing rather than overflowing. */
+.doc-spline-icon-btn svg {
+  flex: none;
+}
+
+.doc-spline-people {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--brand-space-3);
+}
+
+.doc-spline-person {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--brand-space-2);
+  min-width: 0;
+}
+
+.doc-spline-person-name {
+  font-size: var(--brand-text-sm);
+  font-weight: var(--brand-weight-medium);
+  color: var(--bs-text-secondary);
+}
+
+.doc-spline-person-role {
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-faint);
+}
+
+.doc-spline-meta {
+  margin: 0;
   font-family: var(--brand-font-mono);
   font-size: var(--brand-text-xs);
   color: var(--bs-text-muted);
 }
 
-.doc-history-actions {
-  display: flex;
+.doc-spline-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-self: start;
   gap: var(--brand-space-2);
-  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-xs);
+  color: var(--bs-text-muted);
+  cursor: pointer;
+}
+
+.doc-spline-toggle:hover {
+  color: var(--bs-text-secondary);
+}
+
+.doc-spline-detail {
+  display: grid;
+  gap: var(--brand-space-4);
+  margin-top: var(--brand-space-2);
+  padding: var(--brand-space-4);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-md);
+  background: var(--bs-surface-2);
 }
 
 .doc-history-btn {
@@ -2585,14 +2694,6 @@ input {
   gap: var(--brand-space-2);
   padding: var(--brand-space-2) var(--brand-space-3);
   font-size: var(--brand-text-sm);
-}
-
-.doc-history-detail {
-  display: grid;
-  gap: var(--brand-space-4);
-  padding: var(--brand-space-4);
-  border-top: 1px solid var(--bs-rule-warm);
-  background: var(--bs-surface-2);
 }
 
 .doc-history-facts {
@@ -2618,16 +2719,6 @@ input {
 
 .doc-history-facts code {
   font-family: var(--brand-font-mono);
-}
-
-.doc-history-section-title {
-  margin: 0 0 var(--brand-space-2);
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-label);
-  font-weight: var(--brand-weight-medium);
-  letter-spacing: var(--brand-tracking-wide);
-  text-transform: uppercase;
-  color: var(--bs-text-muted);
 }
 
 .doc-review-list {
@@ -2798,7 +2889,22 @@ input {
     justify-content: center;
   }
 
-  .doc-history-row {
+  /* The rail costs 56px of a 375px screen. Narrow the gutter, shrink the
+     knot, and let the head wrap rather than squeezing the title to nothing. */
+  .doc-spline {
+    padding-left: 44px;
+  }
+
+  .doc-spline::before {
+    left: 17px;
+  }
+
+  .doc-spline-knot {
+    left: -44px;
+    width: 36px;
+  }
+
+  .doc-spline-head {
     flex-wrap: wrap;
   }
 

--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -2660,65 +2660,14 @@ input {
   color: var(--bs-text-muted);
 }
 
-.doc-spline-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-self: start;
-  gap: var(--brand-space-2);
-  padding: 0;
-  border: none;
-  background: none;
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-  color: var(--bs-text-muted);
-  cursor: pointer;
-}
-
-.doc-spline-toggle:hover {
-  color: var(--bs-text-secondary);
-}
-
-.doc-spline-detail {
-  display: grid;
-  gap: var(--brand-space-4);
-  margin-top: var(--brand-space-2);
-  padding: var(--brand-space-4);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-md);
-  background: var(--bs-surface-2);
-}
-
+/* The "Back to latest" button on the Document tab, which reads an earlier
+   version. Not part of the spline. */
 .doc-history-btn {
   display: inline-flex;
   align-items: center;
   gap: var(--brand-space-2);
   padding: var(--brand-space-2) var(--brand-space-3);
   font-size: var(--brand-text-sm);
-}
-
-.doc-history-facts {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: var(--brand-space-3);
-  margin: 0;
-}
-
-.doc-history-facts dt {
-  font-family: var(--brand-font-mono);
-  font-size: var(--brand-text-xs);
-  text-transform: uppercase;
-  letter-spacing: var(--brand-tracking-wide);
-  color: var(--bs-text-faint);
-}
-
-.doc-history-facts dd {
-  margin: var(--brand-space-1) 0 0;
-  font-size: var(--brand-text-sm);
-  color: var(--bs-text-secondary);
-}
-
-.doc-history-facts code {
-  font-family: var(--brand-font-mono);
 }
 
 .doc-review-list {

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -484,6 +484,7 @@ export function DocumentDetail({
               );
               onTabChange("overview");
             }}
+            onOpenChange={(changeNumber) => onOpenChange(changeNumber)}
           />
         </div>
       ) : (

--- a/apps/app/components/DocumentHistory.test.ts
+++ b/apps/app/components/DocumentHistory.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { createElement } from "react";
+import type { ReactElement } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { JSDOM } from "jsdom";
+
+import type { DocumentHistoryPayload, DocumentVersionRecord } from "../api";
+
+/**
+ * The History tab, rendered.
+ *
+ * One line down the page, one knot per published version. What has to survive
+ * a redesign: the title is the change review and it goes there, both people
+ * are named, and the two actions are icons — the version is on the knot, so a
+ * button that repeats it is the same word twice.
+ */
+
+let payload: DocumentHistoryPayload = { versions: [], canonicalFile: null };
+
+const mockGetDocumentHistory = mock(async () => payload);
+
+mock.module("../api", () => ({
+  getDocumentHistory: mockGetDocumentHistory,
+}));
+
+// The timeline fetches the change's discussion of its own accord. This test is
+// about the spline, not what a knot unfolds into.
+mock.module("./ReviewTimeline", () => ({
+  ReviewTimeline: () => createElement("div", { "data-testid": "timeline" }),
+}));
+
+const { DocumentHistory } = await import("./DocumentHistory");
+
+const DOM_KEYS = [
+  "window",
+  "document",
+  "navigator",
+  "HTMLElement",
+  "Element",
+  "Node",
+  "MutationObserver",
+  "Event",
+] as const;
+
+let originals: Record<string, unknown> = {};
+
+beforeEach(() => {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "https://bindersnap.com/docs/alice/contract/history",
+  });
+
+  const values: Record<string, unknown> = {
+    window: dom.window,
+    document: dom.window.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Element: dom.window.Element,
+    Node: dom.window.Node,
+    MutationObserver: dom.window.MutationObserver,
+    Event: dom.window.Event,
+  };
+
+  originals = {};
+  for (const key of DOM_KEYS) {
+    originals[key] = (globalThis as Record<string, unknown>)[key];
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value: values[key],
+    });
+  }
+});
+
+afterEach(async () => {
+  // React's scheduler reads `window` from a callback of its own; pulling the
+  // DOM out from under it mid-flight fails the next test, not this one.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  for (const key of DOM_KEYS) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value: originals[key],
+    });
+  }
+});
+
+function version(
+  overrides: Partial<DocumentVersionRecord> = {},
+): DocumentVersionRecord {
+  return {
+    version: 3,
+    tagName: "v3",
+    sha: "abcdef0123456789",
+    createdAt: "2026-08-21T09:00:00Z",
+    submission: {
+      number: 12,
+      title: "Updated liability clause",
+      body: "Updated liability clause",
+      submittedBy: "maya",
+      submittedAt: "2026-08-20T08:00:00Z",
+      mergedAt: "2026-08-21T09:00:00Z",
+      mergedBy: "dana",
+    },
+    reviews: [],
+    discussionCount: 0,
+    ...overrides,
+  };
+}
+
+async function render(element: ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  flushSync(() => root.render(element));
+  // The history is fetched on mount; let the promise land before asserting.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+
+  return {
+    container,
+    unmount: () => {
+      flushSync(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function historyProps(overrides: Record<string, unknown> = {}) {
+  return {
+    owner: "alice",
+    repo: "contract",
+    viewingVersion: null,
+    hasCanonicalFile: true,
+    downloadingRef: null,
+    onDownloadVersion: () => {},
+    onViewVersion: () => {},
+    onOpenChange: () => {},
+    ...overrides,
+  };
+}
+
+test("each version is a knot on one spline", async () => {
+  payload = {
+    versions: [version(), version({ version: 2, tagName: "v2" })],
+    canonicalFile: null,
+  };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  expect(container.querySelectorAll(".doc-spline").length).toBe(1);
+  expect(container.querySelectorAll(".doc-spline-entry").length).toBe(2);
+  expect(
+    [...container.querySelectorAll(".doc-spline-knot")].map(
+      (knot) => knot.textContent,
+    ),
+  ).toEqual(["v3", "v2"]);
+
+  unmount();
+});
+
+test("the title is the change review, and it links straight to it", async () => {
+  payload = { versions: [version()], canonicalFile: null };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  const link = container.querySelector(".doc-spline-link") as HTMLAnchorElement;
+  expect(link.textContent).toBe("Updated liability clause");
+  expect(link.getAttribute("href")).toBe("/docs/alice/contract/changes/12");
+
+  unmount();
+});
+
+test("clicking the title opens the change review without reloading the page", async () => {
+  payload = { versions: [version()], canonicalFile: null };
+
+  const opened: number[] = [];
+  const { container, unmount } = await render(
+    createElement(
+      DocumentHistory,
+      historyProps({ onOpenChange: (n: number) => opened.push(n) }),
+    ),
+  );
+
+  const link = container.querySelector(".doc-spline-link") as HTMLAnchorElement;
+  const event = new window.MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+  });
+  flushSync(() => {
+    link.dispatchEvent(event);
+  });
+
+  expect(opened).toEqual([12]);
+  expect(event.defaultPrevented).toBe(true);
+
+  unmount();
+});
+
+test("the author and the publisher are both on the spline", async () => {
+  payload = { versions: [version()], canonicalFile: null };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  const names = [...container.querySelectorAll(".doc-spline-person-name")].map(
+    (name) => name.textContent,
+  );
+  const roles = [...container.querySelectorAll(".doc-spline-person-role")].map(
+    (role) => role.textContent,
+  );
+  expect(names).toEqual(["Maya", "Dana"]);
+  expect(roles).toEqual(["wrote", "published"]);
+
+  unmount();
+});
+
+test("View and Download are icons, named for a screen reader only", async () => {
+  payload = { versions: [version()], canonicalFile: null };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  const actions = [
+    ...container.querySelectorAll(".doc-spline-actions button"),
+  ] as HTMLButtonElement[];
+
+  expect(actions.length).toBe(2);
+  expect(actions.map((button) => button.textContent)).toEqual(["", ""]);
+  expect(actions.map((button) => button.getAttribute("aria-label"))).toEqual([
+    "View v3",
+    "Download v3",
+  ]);
+
+  unmount();
+});
+
+test("with no file to download, only View is offered", async () => {
+  payload = { versions: [version()], canonicalFile: null };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps({ hasCanonicalFile: false })),
+  );
+
+  const actions = [...container.querySelectorAll(".doc-spline-actions button")];
+  expect(actions.length).toBe(1);
+  expect(actions[0]?.getAttribute("aria-label")).toBe("View v3");
+
+  unmount();
+});
+
+test("the version being read is marked on the spline", async () => {
+  payload = {
+    versions: [version(), version({ version: 2, tagName: "v2" })],
+    canonicalFile: null,
+  };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps({ viewingVersion: 2 })),
+  );
+
+  const marked = [...container.querySelectorAll(".doc-spline-entry")].map(
+    (entry) => entry.className.includes("doc-spline-entry--viewing"),
+  );
+  expect(marked).toEqual([false, true]);
+
+  unmount();
+});
+
+test("a version with no surviving change review is plain text, not a dead link", async () => {
+  payload = { versions: [version({ submission: null })], canonicalFile: null };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  expect(container.querySelector(".doc-spline-link")).toBeNull();
+  expect(container.querySelector(".doc-spline-title")?.textContent).toContain(
+    "Version 3",
+  );
+
+  unmount();
+});
+
+test("nothing published yet says so instead of drawing an empty line", async () => {
+  payload = { versions: [], canonicalFile: null };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  expect(container.querySelector(".doc-spline")).toBeNull();
+  expect(container.textContent).toContain("No published versions yet");
+
+  unmount();
+});

--- a/apps/app/components/DocumentHistory.test.ts
+++ b/apps/app/components/DocumentHistory.test.ts
@@ -13,7 +13,8 @@ import type { DocumentHistoryPayload, DocumentVersionRecord } from "../api";
  * One line down the page, one knot per published version. What has to survive
  * a redesign: the title is the change review and it goes there, both people
  * are named, and the two actions are icons — the version is on the knot, so a
- * button that repeats it is the same word twice.
+ * button that repeats it is the same word twice. Nothing here unfolds into a
+ * second copy of the review record, and nothing here shows a commit hash.
  */
 
 let payload: DocumentHistoryPayload = { versions: [], canonicalFile: null };
@@ -22,12 +23,6 @@ const mockGetDocumentHistory = mock(async () => payload);
 
 mock.module("../api", () => ({
   getDocumentHistory: mockGetDocumentHistory,
-}));
-
-// The timeline fetches the change's discussion of its own accord. This test is
-// about the spline, not what a knot unfolds into.
-mock.module("./ReviewTimeline", () => ({
-  ReviewTimeline: () => createElement("div", { "data-testid": "timeline" }),
 }));
 
 const { DocumentHistory } = await import("./DocumentHistory");
@@ -283,6 +278,38 @@ test("a version with no surviving change review is plain text, not a dead link",
   expect(container.querySelector(".doc-spline-title")?.textContent).toContain(
     "Version 3",
   );
+
+  unmount();
+});
+
+test("a knot does not unfold into a second copy of the review record", async () => {
+  // The change review is the review record — it renders the approvals and the
+  // discussion threads on its own page. Repeating them here is the same log in
+  // two places. The title is the way in.
+  payload = { versions: [version()], canonicalFile: null };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  expect(container.querySelector(".doc-spline-toggle")).toBeNull();
+  expect(container.querySelector(".doc-spline-detail")).toBeNull();
+  expect(container.querySelector(".rev-timeline")).toBeNull();
+  expect(container.textContent).not.toContain("review record");
+
+  unmount();
+});
+
+test("a knot never shows a commit hash", async () => {
+  // The reader is a compliance manager. A SHA answers no question they have.
+  payload = { versions: [version()], canonicalFile: null };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  expect(container.querySelector("code")).toBeNull();
+  expect(container.textContent).not.toContain("abcdef");
 
   unmount();
 });

--- a/apps/app/components/DocumentHistory.test.ts
+++ b/apps/app/components/DocumentHistory.test.ts
@@ -300,6 +300,38 @@ test("a knot does not unfold into a second copy of the review record", async () 
   unmount();
 });
 
+test("a knot does not say who approved it", async () => {
+  // Everything on this page is published, which is to say approved. Repeating
+  // that on every knot distinguishes nothing.
+  payload = {
+    versions: [
+      version({
+        reviews: [
+          {
+            id: 1,
+            author: { login: "kit", fullName: "", avatarUrl: "" },
+            state: "approved",
+            body: "",
+            submittedAt: "2026-08-20T10:00:00Z",
+            stale: false,
+            dismissed: false,
+          },
+        ],
+      }),
+    ],
+    canonicalFile: null,
+  };
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  expect(container.textContent).not.toContain("Approved");
+  expect(container.textContent).not.toContain("Kit");
+
+  unmount();
+});
+
 test("a knot never shows a commit hash", async () => {
   // The reader is a compliance manager. A SHA answers no question they have.
   payload = { versions: [version()], canonicalFile: null };

--- a/apps/app/components/DocumentHistory.tsx
+++ b/apps/app/components/DocumentHistory.tsx
@@ -1,15 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { ChevronDown, ChevronRight, Download, Eye } from "lucide-react";
 
-import type { DocumentVersionRecord, VersionReview } from "../api";
+import type { DocumentVersionRecord } from "../api";
 import { getDocumentHistory } from "../api";
-import {
-  capitalizeFirst,
-  formatShortDate,
-  formatTimestamp,
-  parseSubmissionSummary,
-  publishedVersionToRecord,
-} from "../documentDisplay";
+import { publishedVersionToRecord } from "../documentDisplay";
+import type { HistoryEntry, HistoryPerson } from "../documentHistory";
+import { buildHistoryEntries } from "../documentHistory";
+import { PersonAvatar } from "./PersonAvatar";
 import { ReviewTimeline } from "./ReviewTimeline";
 
 interface DocumentHistoryProps {
@@ -21,28 +18,35 @@ interface DocumentHistoryProps {
   downloadingRef: string | null;
   onDownloadVersion: (tagName: string, version: number) => void;
   onViewVersion: (tagName: string, version: number) => void;
+  /** Opens the change review a version came from, in the Changes tab. */
+  onOpenChange: (changeNumber: number) => void;
 }
 
-function summarizeApprovals(reviews: VersionReview[]): string {
-  const approvers = reviews
-    .filter((review) => review.state === "approved")
-    .map((review) => review.author.fullName?.trim() || review.author.login);
-
-  const unique = [...new Set(approvers)];
-  if (unique.length === 0) return "No recorded approval";
-  if (unique.length === 1) return `Approved by ${capitalizeFirst(unique[0]!)}`;
-  return `Approved by ${capitalizeFirst(unique[0]!)} and ${unique.length - 1} other${
-    unique.length === 2 ? "" : "s"
-  }`;
+/** One name on the spline: a face, who they are, and what they did. */
+function SplinePerson({
+  person,
+  role,
+}: {
+  person: HistoryPerson;
+  role: string;
+}) {
+  return (
+    <span className="doc-spline-person">
+      <PersonAvatar person={{ login: person.login, fullName: person.name }} />
+      <span className="doc-spline-person-name">{person.name}</span>
+      <span className="doc-spline-person-role">{role}</span>
+    </span>
+  );
 }
 
 /**
- * The audit trail, as a timeline.
+ * The audit trail, as a spline.
  *
- * Each published version expands into the record that produced it: who
- * submitted it, every review that was filed, and the discussion that went with
- * it. This is the product's whole promise — "which version did we approve, and
- * who said yes?" — so it gets a first-class page instead of a list of tags.
+ * Every published version is a knot on one line, and every knot is a change
+ * review somebody argued over — so the version is titled with that review and
+ * links straight to it. The two people who matter are on the line itself: who
+ * wrote the change, and who put it on the record. Expanding a knot replays
+ * the reviews and the discussion that got it there.
  */
 export function DocumentHistory({
   owner,
@@ -52,6 +56,7 @@ export function DocumentHistory({
   downloadingRef,
   onDownloadVersion,
   onViewVersion,
+  onOpenChange,
 }: DocumentHistoryProps) {
   const [versions, setVersions] = useState<DocumentVersionRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -129,134 +134,186 @@ export function DocumentHistory({
     );
   }
 
+  const entries: HistoryEntry[] = buildHistoryEntries(versions, owner, repo);
+
   return (
-    <ol className="doc-history">
-      {versions.map((entry) => {
+    <ol className="doc-spline">
+      {entries.map((entry, index) => {
+        const record = versions[index]!;
         const isOpen = expanded.has(entry.version);
         const isViewing = viewingVersion === entry.version;
-        const submitter = entry.submission?.submittedBy
-          ? capitalizeFirst(entry.submission.submittedBy)
-          : null;
-        const summary = parseSubmissionSummary(entry.submission?.body ?? null);
 
         return (
           <li
-            className={`doc-history-entry${isViewing ? " doc-history-entry--viewing" : ""}`}
-            key={entry.tagName}
+            className={`doc-spline-entry${
+              isViewing ? " doc-spline-entry--viewing" : ""
+            }`}
+            key={entry.key}
           >
-            <div className="doc-history-row">
+            <span className="doc-spline-knot" aria-hidden="true">
+              {entry.label}
+            </span>
+
+            <div className="doc-spline-body">
+              <div className="doc-spline-head">
+                <h3 className="doc-spline-title">
+                  {entry.changeHref && entry.changeNumber !== null ? (
+                    <a
+                      className="doc-spline-link"
+                      href={entry.changeHref}
+                      onClick={(event) => {
+                        // Let a modifier click open the review in a new tab;
+                        // a plain click is a route change, not a page load.
+                        if (
+                          event.defaultPrevented ||
+                          event.metaKey ||
+                          event.ctrlKey ||
+                          event.shiftKey ||
+                          event.altKey ||
+                          event.button !== 0
+                        ) {
+                          return;
+                        }
+                        event.preventDefault();
+                        onOpenChange(entry.changeNumber!);
+                      }}
+                    >
+                      {entry.title}
+                    </a>
+                  ) : (
+                    entry.title
+                  )}
+                  {/* The knot carries the version visually; a reader who
+                      cannot see the rail still needs to hear it. */}
+                  <span className="sr-only">{entry.label}</span>
+                </h3>
+
+                <div className="doc-spline-actions">
+                  <button
+                    className="bs-btn bs-btn-secondary doc-spline-icon-btn"
+                    type="button"
+                    title={`View ${entry.label}`}
+                    aria-label={`View ${entry.label}`}
+                    onClick={() => onViewVersion(entry.tagName, entry.version)}
+                  >
+                    <Eye size={15} strokeWidth={1.5} aria-hidden="true" />
+                  </button>
+                  {hasCanonicalFile ? (
+                    <button
+                      className="bs-btn bs-btn-secondary doc-spline-icon-btn vault-version-download"
+                      type="button"
+                      disabled={downloadingRef === entry.tagName}
+                      title={
+                        downloadingRef === entry.tagName
+                          ? `Downloading ${entry.label}…`
+                          : `Download ${entry.label}`
+                      }
+                      aria-label={
+                        downloadingRef === entry.tagName
+                          ? `Downloading ${entry.label}…`
+                          : `Download ${entry.label}`
+                      }
+                      onClick={() =>
+                        onDownloadVersion(entry.tagName, entry.version)
+                      }
+                    >
+                      <Download
+                        size={15}
+                        strokeWidth={1.5}
+                        aria-hidden="true"
+                      />
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+
+              {/* The two people the record is about, on the line itself. */}
+              <div className="doc-spline-people">
+                {entry.author ? (
+                  <SplinePerson person={entry.author} role="wrote" />
+                ) : null}
+                {entry.publisher ? (
+                  <SplinePerson person={entry.publisher} role="published" />
+                ) : null}
+              </div>
+
+              <p className="doc-spline-meta">
+                <time dateTime={record.createdAt} title={entry.publishedAt}>
+                  {entry.publishedOn}
+                </time>
+                {" · "}
+                {entry.approvals}
+                {entry.comments ? ` · ${entry.comments}` : ""}
+              </p>
+
               <button
-                className="doc-history-toggle"
+                className="doc-spline-toggle"
                 type="button"
                 aria-expanded={isOpen}
                 onClick={() => toggle(entry.version)}
               >
                 {isOpen ? (
-                  <ChevronDown size={16} strokeWidth={1.5} aria-hidden="true" />
+                  <ChevronDown size={14} strokeWidth={1.5} aria-hidden="true" />
                 ) : (
                   <ChevronRight
-                    size={16}
+                    size={14}
                     strokeWidth={1.5}
                     aria-hidden="true"
                   />
                 )}
-                <span className="vault-version-badge">v{entry.version}</span>
-                <span className="doc-history-summary">
-                  <span className="doc-history-title">
-                    {summary ??
-                      (submitter
-                        ? `Submitted by ${submitter}`
-                        : `Version ${entry.version}`)}
-                  </span>
-                  <span className="doc-history-sub">
-                    {formatShortDate(entry.createdAt)} ·{" "}
-                    {summarizeApprovals(entry.reviews)}
-                    {entry.discussionCount > 0
-                      ? ` · ${entry.discussionCount} comment${
-                          entry.discussionCount === 1 ? "" : "s"
-                        }`
-                      : ""}
-                  </span>
-                </span>
+                {isOpen ? "Hide the review record" : "Show the review record"}
               </button>
 
-              <div className="doc-history-actions">
-                <button
-                  className="bs-btn bs-btn-secondary doc-history-btn"
-                  type="button"
-                  onClick={() => onViewVersion(entry.tagName, entry.version)}
-                >
-                  <Eye size={14} strokeWidth={1.5} aria-hidden="true" />
-                  View
-                </button>
-                {hasCanonicalFile ? (
-                  <button
-                    className="bs-btn bs-btn-secondary doc-history-btn vault-version-download"
-                    type="button"
-                    disabled={downloadingRef === entry.tagName}
-                    onClick={() =>
-                      onDownloadVersion(entry.tagName, entry.version)
-                    }
-                  >
-                    <Download size={14} strokeWidth={1.5} aria-hidden="true" />
-                    {downloadingRef === entry.tagName
-                      ? "Downloading…"
-                      : `Download v${entry.version}`}
-                  </button>
-                ) : null}
-              </div>
+              {isOpen ? (
+                <div className="doc-spline-detail">
+                  <dl className="doc-history-facts">
+                    <div>
+                      <dt>Published</dt>
+                      <dd>{entry.publishedAt}</dd>
+                    </div>
+                    <div>
+                      <dt>Change review</dt>
+                      <dd>
+                        {entry.changeNumber === null
+                          ? "No record kept"
+                          : `#${entry.changeNumber}`}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Commit</dt>
+                      <dd>
+                        <code>{entry.shortSha}</code>
+                      </dd>
+                    </div>
+                  </dl>
+
+                  {/* One log, not two: the reviews and the discussion are the
+                      same sequence of events, so the version shows the same
+                      timeline the change's own page shows. */}
+                  {record.submission ? (
+                    <ReviewTimeline
+                      owner={owner}
+                      repo={repo}
+                      change={publishedVersionToRecord({
+                        version: record.version,
+                        createdAt: record.createdAt,
+                        submission: record.submission,
+                        reviews: record.reviews,
+                      })}
+                      updates={[]}
+                      resetsApprovals={false}
+                      canParticipate={false}
+                      blockOnUnresolvedThreads={false}
+                      onOpenUpdate={null}
+                    />
+                  ) : (
+                    <p className="vault-pr-notice">
+                      No submission record was kept for {entry.label}.
+                    </p>
+                  )}
+                </div>
+              ) : null}
             </div>
-
-            {isOpen ? (
-              <div className="doc-history-detail">
-                <dl className="doc-history-facts">
-                  <div>
-                    <dt>Published</dt>
-                    <dd>{formatTimestamp(entry.createdAt) || "Unknown"}</dd>
-                  </div>
-                  <div>
-                    <dt>Submitted by</dt>
-                    <dd>
-                      {submitter ?? "Unknown"}
-                      {entry.submission?.submittedAt
-                        ? ` · ${formatShortDate(entry.submission.submittedAt)}`
-                        : ""}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>Commit</dt>
-                    <dd>
-                      <code>{entry.sha.slice(0, 10)}</code>
-                    </dd>
-                  </div>
-                </dl>
-
-                {/* One log, not two: the reviews and the discussion are the
-                    same sequence of events, so the version shows the same
-                    timeline the change's own page shows. */}
-                {entry.submission ? (
-                  <ReviewTimeline
-                    owner={owner}
-                    repo={repo}
-                    change={publishedVersionToRecord({
-                      version: entry.version,
-                      createdAt: entry.createdAt,
-                      submission: entry.submission,
-                      reviews: entry.reviews,
-                    })}
-                    updates={[]}
-                    resetsApprovals={false}
-                    canParticipate={false}
-                    blockOnUnresolvedThreads={false}
-                    onOpenUpdate={null}
-                  />
-                ) : (
-                  <p className="vault-pr-notice">
-                    No submission record was kept for this version.
-                  </p>
-                )}
-              </div>
-            ) : null}
           </li>
         );
       })}

--- a/apps/app/components/DocumentHistory.tsx
+++ b/apps/app/components/DocumentHistory.tsx
@@ -1,13 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
-import { ChevronDown, ChevronRight, Download, Eye } from "lucide-react";
+import { Download, Eye } from "lucide-react";
 
 import type { DocumentVersionRecord } from "../api";
 import { getDocumentHistory } from "../api";
-import { publishedVersionToRecord } from "../documentDisplay";
 import type { HistoryEntry, HistoryPerson } from "../documentHistory";
 import { buildHistoryEntries } from "../documentHistory";
 import { PersonAvatar } from "./PersonAvatar";
-import { ReviewTimeline } from "./ReviewTimeline";
 
 interface DocumentHistoryProps {
   owner: string;
@@ -45,8 +43,12 @@ function SplinePerson({
  * Every published version is a knot on one line, and every knot is a change
  * review somebody argued over — so the version is titled with that review and
  * links straight to it. The two people who matter are on the line itself: who
- * wrote the change, and who put it on the record. Expanding a knot replays
- * the reviews and the discussion that got it there.
+ * wrote the change, and who put it on the record.
+ *
+ * A knot does not unfold into the reviews and the discussion. The change
+ * review *is* the review record, and it already renders them on its own page —
+ * a second copy here is the same log in two places, drifting apart the moment
+ * one of them changes. The title is the way in.
  */
 export function DocumentHistory({
   owner,
@@ -61,7 +63,6 @@ export function DocumentHistory({
   const [versions, setVersions] = useState<DocumentVersionRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -69,9 +70,6 @@ export function DocumentHistory({
     try {
       const payload = await getDocumentHistory(owner, repo);
       setVersions(payload.versions);
-      // Open the newest version so the page never lands on a wall of rows.
-      const newest = payload.versions[0]?.version;
-      setExpanded(newest === undefined ? new Set() : new Set([newest]));
     } catch (err) {
       setError(
         err instanceof Error
@@ -88,20 +86,11 @@ export function DocumentHistory({
     void load();
   }, [load]);
 
-  function toggle(version: number) {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(version)) next.delete(version);
-      else next.add(version);
-      return next;
-    });
-  }
-
   if (isLoading) {
     return (
       <section className="doc-panel doc-empty">
         <h2>Loading version history…</h2>
-        <p>Fetching every published version and the reviews behind it.</p>
+        <p>Fetching every version that has been published.</p>
       </section>
     );
   }
@@ -138,9 +127,7 @@ export function DocumentHistory({
 
   return (
     <ol className="doc-spline">
-      {entries.map((entry, index) => {
-        const record = versions[index]!;
-        const isOpen = expanded.has(entry.version);
+      {entries.map((entry) => {
         const isViewing = viewingVersion === entry.version;
 
         return (
@@ -238,81 +225,13 @@ export function DocumentHistory({
               </div>
 
               <p className="doc-spline-meta">
-                <time dateTime={record.createdAt} title={entry.publishedAt}>
+                <time dateTime={entry.createdAt} title={entry.publishedAt}>
                   {entry.publishedOn}
                 </time>
                 {" · "}
                 {entry.approvals}
                 {entry.comments ? ` · ${entry.comments}` : ""}
               </p>
-
-              <button
-                className="doc-spline-toggle"
-                type="button"
-                aria-expanded={isOpen}
-                onClick={() => toggle(entry.version)}
-              >
-                {isOpen ? (
-                  <ChevronDown size={14} strokeWidth={1.5} aria-hidden="true" />
-                ) : (
-                  <ChevronRight
-                    size={14}
-                    strokeWidth={1.5}
-                    aria-hidden="true"
-                  />
-                )}
-                {isOpen ? "Hide the review record" : "Show the review record"}
-              </button>
-
-              {isOpen ? (
-                <div className="doc-spline-detail">
-                  <dl className="doc-history-facts">
-                    <div>
-                      <dt>Published</dt>
-                      <dd>{entry.publishedAt}</dd>
-                    </div>
-                    <div>
-                      <dt>Change review</dt>
-                      <dd>
-                        {entry.changeNumber === null
-                          ? "No record kept"
-                          : `#${entry.changeNumber}`}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Commit</dt>
-                      <dd>
-                        <code>{entry.shortSha}</code>
-                      </dd>
-                    </div>
-                  </dl>
-
-                  {/* One log, not two: the reviews and the discussion are the
-                      same sequence of events, so the version shows the same
-                      timeline the change's own page shows. */}
-                  {record.submission ? (
-                    <ReviewTimeline
-                      owner={owner}
-                      repo={repo}
-                      change={publishedVersionToRecord({
-                        version: record.version,
-                        createdAt: record.createdAt,
-                        submission: record.submission,
-                        reviews: record.reviews,
-                      })}
-                      updates={[]}
-                      resetsApprovals={false}
-                      canParticipate={false}
-                      blockOnUnresolvedThreads={false}
-                      onOpenUpdate={null}
-                    />
-                  ) : (
-                    <p className="vault-pr-notice">
-                      No submission record was kept for {entry.label}.
-                    </p>
-                  )}
-                </div>
-              ) : null}
             </div>
           </li>
         );

--- a/apps/app/components/DocumentHistory.tsx
+++ b/apps/app/components/DocumentHistory.tsx
@@ -228,8 +228,6 @@ export function DocumentHistory({
                 <time dateTime={entry.createdAt} title={entry.publishedAt}>
                   {entry.publishedOn}
                 </time>
-                {" · "}
-                {entry.approvals}
                 {entry.comments ? ` · ${entry.comments}` : ""}
               </p>
             </div>

--- a/apps/app/documentDisplay.ts
+++ b/apps/app/documentDisplay.ts
@@ -378,49 +378,6 @@ export function closedChangeToRecord(change: {
 }
 
 /**
- * A published version, read back as the change that produced it.
- *
- * The History tab and a change's own page are looking at the same events —
- * who opened it, what was said, who signed it off, when it went out — so they
- * render the same timeline rather than two components that drift apart. What
- * History has is the version record, so it is narrowed to the same shape.
- */
-export function publishedVersionToRecord(version: {
-  version: number;
-  createdAt: string;
-  submission: {
-    number: number;
-    body: string;
-    submittedBy: string;
-    submittedAt: string;
-    mergedAt: string | null;
-    mergedBy: string | null;
-  };
-  reviews?: VersionReview[];
-}): ChangeRecord {
-  const { submission } = version;
-  return {
-    number: submission.number,
-    summary: parseChangeTitle(submission.body, submission.submittedBy),
-    description: describeSubmission(submission.body),
-    reviews: version.reviews ?? [],
-    branchName: null,
-    submittedBy: submission.submittedBy,
-    submittedAt: submission.submittedAt,
-    open: false,
-    approvalState: "published",
-    outcome: "published",
-    closedAt: submission.mergedAt ?? version.createdAt,
-    decidedBy: submission.mergedBy,
-    publishedVersion: version.version,
-    assignee: null,
-    reviewers: [],
-    approvalCount: 0,
-    requiredApprovals: null,
-  };
-}
-
-/**
  * Where a reviewer stands, as the page shows it.
  *
  * The server's four states plus one it cannot see: an unresolved thread this

--- a/apps/app/documentHistory.test.ts
+++ b/apps/app/documentHistory.test.ts
@@ -1,14 +1,14 @@
 import { expect, test } from "bun:test";
 
 import type { DocumentVersionRecord, VersionReview } from "./api";
-import { buildHistoryEntries, summarizeApprovals } from "./documentHistory";
+import { buildHistoryEntries } from "./documentHistory";
 
 /**
  * What a knot on the history spline says.
  *
  * The spline is the audit trail, so the wording is the product: which change
- * review produced this version, who wrote it, who published it, and what the
- * reviews came to. Decided here, tested here.
+ * review produced this version, who wrote it, who published it, when. Decided
+ * here, tested here.
  */
 
 function review(
@@ -44,7 +44,7 @@ function version(
       mergedAt: "2026-08-21T09:00:00Z",
       mergedBy: "dana",
     },
-    reviews: [review("dana")],
+    reviews: [review("kit")],
     discussionCount: 3,
     ...overrides,
   };
@@ -129,6 +129,16 @@ test("nothing on a knot is a commit hash", () => {
   expect(JSON.stringify(entry)).not.toContain("abcdef");
 });
 
+test("a knot does not summarise who approved", () => {
+  // Every version on this page was approved — that is what published means.
+  // Naming the approver again on every knot says nothing that distinguishes
+  // one from another; the change review is where that belongs.
+  const [entry] = buildHistoryEntries([version()], "alice", "contract");
+
+  expect(JSON.stringify(entry)).not.toContain("kit");
+  expect(JSON.stringify(entry)).not.toContain("Approved");
+});
+
 test("one comment is not pluralised, and none is not mentioned", () => {
   const [one] = buildHistoryEntries(
     [version({ discussionCount: 1 })],
@@ -143,35 +153,6 @@ test("one comment is not pluralised, and none is not mentioned", () => {
 
   expect(one?.comments).toBe("1 comment");
   expect(none?.comments).toBeNull();
-});
-
-test("approvals name a person rather than counting one", () => {
-  expect(summarizeApprovals([])).toBe("No recorded approval");
-  expect(summarizeApprovals([review("dana")])).toBe("Approved by Dana");
-  expect(summarizeApprovals([review("dana"), review("sam")])).toBe(
-    "Approved by Dana and 1 other",
-  );
-  expect(
-    summarizeApprovals([review("dana"), review("sam"), review("kit")]),
-  ).toBe("Approved by Dana and 2 others");
-});
-
-test("a full name beats a login, and the same person is only counted once", () => {
-  expect(summarizeApprovals([review("dana", "approved", "dana reyes")])).toBe(
-    "Approved by Dana reyes",
-  );
-  expect(summarizeApprovals([review("dana"), review("dana")])).toBe(
-    "Approved by Dana",
-  );
-});
-
-test("a comment is not a sign-off", () => {
-  expect(
-    summarizeApprovals([
-      review("sam", "commented"),
-      review("kit", "changes_requested"),
-    ]),
-  ).toBe("No recorded approval");
 });
 
 test("every version in the payload becomes a knot, in the order given", () => {

--- a/apps/app/documentHistory.test.ts
+++ b/apps/app/documentHistory.test.ts
@@ -1,0 +1,177 @@
+import { expect, test } from "bun:test";
+
+import type { DocumentVersionRecord, VersionReview } from "./api";
+import { buildHistoryEntries, summarizeApprovals } from "./documentHistory";
+
+/**
+ * What a knot on the history spline says.
+ *
+ * The spline is the audit trail, so the wording is the product: which change
+ * review produced this version, who wrote it, who published it, and what the
+ * reviews came to. Decided here, tested here.
+ */
+
+function review(
+  login: string,
+  state: VersionReview["state"] = "approved",
+  fullName = "",
+): VersionReview {
+  return {
+    id: 1,
+    author: { login, fullName, avatarUrl: "" },
+    state,
+    body: "",
+    submittedAt: "2026-08-20T10:00:00Z",
+    stale: false,
+    dismissed: false,
+  };
+}
+
+function version(
+  overrides: Partial<DocumentVersionRecord> = {},
+): DocumentVersionRecord {
+  return {
+    version: 3,
+    tagName: "v3",
+    sha: "abcdef0123456789",
+    createdAt: "2026-08-21T09:00:00Z",
+    submission: {
+      number: 12,
+      title: "Updated liability clause",
+      body: "Updated liability clause",
+      submittedBy: "maya",
+      submittedAt: "2026-08-20T08:00:00Z",
+      mergedAt: "2026-08-21T09:00:00Z",
+      mergedBy: "dana",
+    },
+    reviews: [review("dana")],
+    discussionCount: 3,
+    ...overrides,
+  };
+}
+
+test("a version is titled with the change review that produced it, and links to it", () => {
+  const [entry] = buildHistoryEntries([version()], "alice", "contract");
+
+  expect(entry?.title).toBe("Updated liability clause");
+  expect(entry?.changeNumber).toBe(12);
+  expect(entry?.changeHref).toBe("/docs/alice/contract/changes/12");
+});
+
+test("the author and the publisher are both named on the spline", () => {
+  const [entry] = buildHistoryEntries([version()], "alice", "contract");
+
+  expect(entry?.author).toEqual({ name: "Maya", login: "maya" });
+  expect(entry?.publisher).toEqual({ name: "Dana", login: "dana" });
+});
+
+test("a version nobody published names only the author", () => {
+  const [entry] = buildHistoryEntries(
+    [
+      version({
+        submission: { ...version().submission!, mergedBy: null },
+      }),
+    ],
+    "alice",
+    "contract",
+  );
+
+  expect(entry?.author?.name).toBe("Maya");
+  expect(entry?.publisher).toBeNull();
+});
+
+test("a version whose submission record is gone still gets a knot", () => {
+  const [entry] = buildHistoryEntries(
+    [version({ submission: null, reviews: [], discussionCount: 0 })],
+    "alice",
+    "contract",
+  );
+
+  expect(entry?.title).toBe("Version 3");
+  expect(entry?.changeNumber).toBeNull();
+  expect(entry?.changeHref).toBeNull();
+  expect(entry?.author).toBeNull();
+  expect(entry?.publisher).toBeNull();
+});
+
+test("an automated upload is titled by the file it carried", () => {
+  const [entry] = buildHistoryEntries(
+    [
+      version({
+        submission: {
+          ...version().submission!,
+          body: "Automated upload from Bindersnap file vault.\nSource file: vendor-agreement.docx\nUploaded by: maya",
+        },
+      }),
+    ],
+    "alice",
+    "contract",
+  );
+
+  expect(entry?.title).toBe("New version of vendor-agreement.docx");
+});
+
+test("the knot carries the version, the date, the commit, and the comment count", () => {
+  const [entry] = buildHistoryEntries([version()], "alice", "contract");
+
+  expect(entry?.label).toBe("v3");
+  expect(entry?.tagName).toBe("v3");
+  expect(entry?.publishedOn).toBe("Aug 21, 2026");
+  expect(entry?.shortSha).toBe("abcdef0123");
+  expect(entry?.comments).toBe("3 comments");
+});
+
+test("one comment is not pluralised, and none is not mentioned", () => {
+  const [one] = buildHistoryEntries(
+    [version({ discussionCount: 1 })],
+    "alice",
+    "contract",
+  );
+  const [none] = buildHistoryEntries(
+    [version({ discussionCount: 0 })],
+    "alice",
+    "contract",
+  );
+
+  expect(one?.comments).toBe("1 comment");
+  expect(none?.comments).toBeNull();
+});
+
+test("approvals name a person rather than counting one", () => {
+  expect(summarizeApprovals([])).toBe("No recorded approval");
+  expect(summarizeApprovals([review("dana")])).toBe("Approved by Dana");
+  expect(summarizeApprovals([review("dana"), review("sam")])).toBe(
+    "Approved by Dana and 1 other",
+  );
+  expect(
+    summarizeApprovals([review("dana"), review("sam"), review("kit")]),
+  ).toBe("Approved by Dana and 2 others");
+});
+
+test("a full name beats a login, and the same person is only counted once", () => {
+  expect(summarizeApprovals([review("dana", "approved", "dana reyes")])).toBe(
+    "Approved by Dana reyes",
+  );
+  expect(summarizeApprovals([review("dana"), review("dana")])).toBe(
+    "Approved by Dana",
+  );
+});
+
+test("a comment is not a sign-off", () => {
+  expect(
+    summarizeApprovals([
+      review("sam", "commented"),
+      review("kit", "changes_requested"),
+    ]),
+  ).toBe("No recorded approval");
+});
+
+test("every version in the payload becomes a knot, in the order given", () => {
+  const entries = buildHistoryEntries(
+    [version(), version({ version: 2, tagName: "v2" })],
+    "alice",
+    "contract",
+  );
+
+  expect(entries.map((entry) => entry.label)).toEqual(["v3", "v2"]);
+});

--- a/apps/app/documentHistory.test.ts
+++ b/apps/app/documentHistory.test.ts
@@ -111,14 +111,22 @@ test("an automated upload is titled by the file it carried", () => {
   expect(entry?.title).toBe("New version of vendor-agreement.docx");
 });
 
-test("the knot carries the version, the date, the commit, and the comment count", () => {
+test("the knot carries the version, the date, and the comment count", () => {
   const [entry] = buildHistoryEntries([version()], "alice", "contract");
 
   expect(entry?.label).toBe("v3");
   expect(entry?.tagName).toBe("v3");
   expect(entry?.publishedOn).toBe("Aug 21, 2026");
-  expect(entry?.shortSha).toBe("abcdef0123");
+  expect(entry?.createdAt).toBe("2026-08-21T09:00:00Z");
   expect(entry?.comments).toBe("3 comments");
+});
+
+test("nothing on a knot is a commit hash", () => {
+  // A compliance manager does not know what a SHA is, and never needed one to
+  // answer "which version did we approve?".
+  const [entry] = buildHistoryEntries([version()], "alice", "contract");
+
+  expect(JSON.stringify(entry)).not.toContain("abcdef");
 });
 
 test("one comment is not pluralised, and none is not mentioned", () => {

--- a/apps/app/documentHistory.ts
+++ b/apps/app/documentHistory.ts
@@ -1,0 +1,127 @@
+import type { DocumentVersionRecord, VersionReview } from "./api";
+import {
+  capitalizeFirst,
+  formatShortDate,
+  formatTimestamp,
+  parseChangeTitle,
+} from "./documentDisplay";
+import { routeToPath } from "./routes";
+
+/**
+ * The History tab, decided here.
+ *
+ * History is a spline of published versions, and every one of them came from a
+ * change somebody reviewed. What a knot on that spline reads — the change's
+ * own title, who wrote it, who published it, what the reviews came to — is a
+ * set of decisions, so they are made in one place and tested without a
+ * browser. The component only draws the rail.
+ */
+
+/** One person named on the spline. */
+export interface HistoryPerson {
+  /** "Maya" — a login, made presentable. */
+  name: string;
+  /** What the avatar and the tint key off. */
+  login: string;
+}
+
+function toPerson(login: string | null | undefined): HistoryPerson | null {
+  const trimmed = (login ?? "").trim();
+  if (!trimmed) return null;
+  return { name: capitalizeFirst(trimmed), login: trimmed };
+}
+
+/** One published version, as the spline states it. */
+export interface HistoryEntry {
+  key: string;
+  version: number;
+  tagName: string;
+  /** "v3". */
+  label: string;
+  /**
+   * What the change review that produced this version was called. Falls back
+   * to the version itself when no submission record survived.
+   */
+  title: string;
+  /** The change this version came from, or null when the record is gone. */
+  changeNumber: number | null;
+  /** Where the title points. Null when there is no change to point at. */
+  changeHref: string | null;
+  /** Who submitted the change. */
+  author: HistoryPerson | null;
+  /** Who published it. Often, but not always, someone else. */
+  publisher: HistoryPerson | null;
+  /** "Jan 12, 2026". */
+  publishedOn: string;
+  /** The full stamp, for the title attribute and the expanded facts. */
+  publishedAt: string;
+  /** "Approved by Dana", or that nobody signed off. */
+  approvals: string;
+  /** "3 comments", or null when the change drew none. */
+  comments: string | null;
+  /** The commit the version points at, short. */
+  shortSha: string;
+}
+
+/**
+ * Who signed off, in the fewest words that name someone.
+ *
+ * "2 approvals" is a number; "Approved by Dana and 1 other" is a person you
+ * can go ask. Only approvals count here — a comment is not a sign-off.
+ */
+export function summarizeApprovals(reviews: VersionReview[]): string {
+  const approvers = reviews
+    .filter((review) => review.state === "approved")
+    .map((review) => review.author.fullName?.trim() || review.author.login);
+
+  const unique = [...new Set(approvers)];
+  if (unique.length === 0) return "No recorded approval";
+  if (unique.length === 1) return `Approved by ${capitalizeFirst(unique[0]!)}`;
+  return `Approved by ${capitalizeFirst(unique[0]!)} and ${unique.length - 1} other${
+    unique.length === 2 ? "" : "s"
+  }`;
+}
+
+export function buildHistoryEntries(
+  versions: DocumentVersionRecord[],
+  owner: string,
+  repo: string,
+): HistoryEntry[] {
+  return versions.map((entry) => {
+    const submission = entry.submission;
+    const changeNumber = submission?.number ?? null;
+
+    return {
+      key: entry.tagName,
+      version: entry.version,
+      tagName: entry.tagName,
+      label: `v${entry.version}`,
+      title: submission
+        ? parseChangeTitle(submission.body, submission.submittedBy)
+        : `Version ${entry.version}`,
+      changeNumber,
+      changeHref:
+        changeNumber === null
+          ? null
+          : routeToPath({
+              kind: "document",
+              owner,
+              repo,
+              tab: "changes",
+              changeNumber,
+            }),
+      author: toPerson(submission?.submittedBy),
+      publisher: toPerson(submission?.mergedBy),
+      publishedOn: formatShortDate(entry.createdAt) || "Unknown",
+      publishedAt: formatTimestamp(entry.createdAt) || "Unknown",
+      approvals: summarizeApprovals(entry.reviews),
+      comments:
+        entry.discussionCount > 0
+          ? `${entry.discussionCount} comment${
+              entry.discussionCount === 1 ? "" : "s"
+            }`
+          : null,
+      shortSha: entry.sha.slice(0, 10),
+    };
+  });
+}

--- a/apps/app/documentHistory.ts
+++ b/apps/app/documentHistory.ts
@@ -1,4 +1,4 @@
-import type { DocumentVersionRecord, VersionReview } from "./api";
+import type { DocumentVersionRecord } from "./api";
 import {
   capitalizeFirst,
   formatShortDate,
@@ -12,9 +12,9 @@ import { routeToPath } from "./routes";
  *
  * History is a spline of published versions, and every one of them came from a
  * change somebody reviewed. What a knot on that spline reads — the change's
- * own title, who wrote it, who published it, what the reviews came to — is a
- * set of decisions, so they are made in one place and tested without a
- * browser. The component only draws the rail.
+ * own title, who wrote it, who published it, when — is a set of decisions, so
+ * they are made in one place and tested without a browser. The component only
+ * draws the rail.
  */
 
 /** One person named on the spline. */
@@ -57,29 +57,8 @@ export interface HistoryEntry {
   publishedOn: string;
   /** The full stamp, for the title attribute. */
   publishedAt: string;
-  /** "Approved by Dana", or that nobody signed off. */
-  approvals: string;
   /** "3 comments", or null when the change drew none. */
   comments: string | null;
-}
-
-/**
- * Who signed off, in the fewest words that name someone.
- *
- * "2 approvals" is a number; "Approved by Dana and 1 other" is a person you
- * can go ask. Only approvals count here — a comment is not a sign-off.
- */
-export function summarizeApprovals(reviews: VersionReview[]): string {
-  const approvers = reviews
-    .filter((review) => review.state === "approved")
-    .map((review) => review.author.fullName?.trim() || review.author.login);
-
-  const unique = [...new Set(approvers)];
-  if (unique.length === 0) return "No recorded approval";
-  if (unique.length === 1) return `Approved by ${capitalizeFirst(unique[0]!)}`;
-  return `Approved by ${capitalizeFirst(unique[0]!)} and ${unique.length - 1} other${
-    unique.length === 2 ? "" : "s"
-  }`;
 }
 
 export function buildHistoryEntries(
@@ -115,7 +94,6 @@ export function buildHistoryEntries(
       createdAt: entry.createdAt,
       publishedOn: formatShortDate(entry.createdAt) || "Unknown",
       publishedAt: formatTimestamp(entry.createdAt) || "Unknown",
-      approvals: summarizeApprovals(entry.reviews),
       comments:
         entry.discussionCount > 0
           ? `${entry.discussionCount} comment${

--- a/apps/app/documentHistory.ts
+++ b/apps/app/documentHistory.ts
@@ -51,16 +51,16 @@ export interface HistoryEntry {
   author: HistoryPerson | null;
   /** Who published it. Often, but not always, someone else. */
   publisher: HistoryPerson | null;
+  /** The raw stamp, for the `datetime` attribute. */
+  createdAt: string;
   /** "Jan 12, 2026". */
   publishedOn: string;
-  /** The full stamp, for the title attribute and the expanded facts. */
+  /** The full stamp, for the title attribute. */
   publishedAt: string;
   /** "Approved by Dana", or that nobody signed off. */
   approvals: string;
   /** "3 comments", or null when the change drew none. */
   comments: string | null;
-  /** The commit the version points at, short. */
-  shortSha: string;
 }
 
 /**
@@ -112,6 +112,7 @@ export function buildHistoryEntries(
             }),
       author: toPerson(submission?.submittedBy),
       publisher: toPerson(submission?.mergedBy),
+      createdAt: entry.createdAt,
       publishedOn: formatShortDate(entry.createdAt) || "Unknown",
       publishedAt: formatTimestamp(entry.createdAt) || "Unknown",
       approvals: summarizeApprovals(entry.reviews),
@@ -121,7 +122,6 @@ export function buildHistoryEntries(
               entry.discussionCount === 1 ? "" : "s"
             }`
           : null,
-      shortSha: entry.sha.slice(0, 10),
     };
   });
 }

--- a/services/api/document-history.test.ts
+++ b/services/api/document-history.test.ts
@@ -52,6 +52,35 @@ test("joins each version to the pull request whose merge commit it tags", () => 
   });
 });
 
+test("names the publisher read from the change's own endpoint", () => {
+  // Gitea's *list* of pull requests leaves `merged_by` empty; only the single
+  // pull request endpoint fills it in. The history reads it per change and
+  // passes it here, so a version still names who put it on the record.
+  const listed = mergedPR(7, "sha-one");
+  delete (listed.pullRequest as { merged_by?: unknown }).merged_by;
+
+  const versions = buildVersionRecords(
+    [tag(1, "sha-one", "2026-01-02T00:00:00Z")],
+    [listed],
+    new Map(),
+    new Map([[7, "carol"]]),
+  );
+
+  expect(versions[0]?.submission?.mergedBy).toBe("carol");
+});
+
+test("a publisher the change's endpoint would not give up leaves the version unattributed", () => {
+  const listed = mergedPR(7, "sha-one");
+  delete (listed.pullRequest as { merged_by?: unknown }).merged_by;
+
+  const versions = buildVersionRecords(
+    [tag(1, "sha-one", "2026-01-02T00:00:00Z")],
+    [listed],
+  );
+
+  expect(versions[0]?.submission?.mergedBy).toBeNull();
+});
+
 test("orders versions newest first", () => {
   const versions = buildVersionRecords(
     [

--- a/services/api/document-history.ts
+++ b/services/api/document-history.ts
@@ -79,8 +79,17 @@ export function toVersionReviews(reviews: PullReview[]): VersionReview[] {
     .sort((left, right) => left.submittedAt.localeCompare(right.submittedAt));
 }
 
+/**
+ * Who submitted a version and who published it.
+ *
+ * `publishedBy` exists because Gitea's *list* of pull requests omits
+ * `merged_by` — it is only filled in on a single pull request's own endpoint.
+ * The history spline names the publisher, so the caller reads it per change
+ * and passes it in; without it, every version would claim nobody published it.
+ */
 export function toVersionSubmission(
   pullRequest: PullRequest,
+  publishedBy: string | null = null,
 ): VersionSubmission {
   return {
     number: pullRequest.number ?? 0,
@@ -89,7 +98,7 @@ export function toVersionSubmission(
     submittedBy: pullRequest.user?.login ?? "",
     submittedAt: pullRequest.created_at ?? "",
     mergedAt: pullRequest.merged_at ?? null,
-    mergedBy: pullRequest.merged_by?.login ?? null,
+    mergedBy: pullRequest.merged_by?.login ?? publishedBy,
   };
 }
 
@@ -106,6 +115,7 @@ export function buildVersionRecords(
   tags: DocTag[],
   pullRequests: PullRequestWithReviews[],
   discussionCounts: Map<number, number> = new Map(),
+  publishers: Map<number, string> = new Map(),
 ): DocumentVersionRecord[] {
   const byMergeSha = new Map<string, PullRequestWithReviews>();
   for (const entry of pullRequests) {
@@ -127,7 +137,12 @@ export function buildVersionRecords(
         tagName: tag.name,
         sha: tag.sha,
         createdAt: tag.created,
-        submission: match ? toVersionSubmission(match.pullRequest) : null,
+        submission: match
+          ? toVersionSubmission(
+              match.pullRequest,
+              prNumber === null ? null : (publishers.get(prNumber) ?? null),
+            )
+          : null,
         reviews: match ? toVersionReviews(match.reviews) : [],
         discussionCount:
           prNumber === null ? 0 : (discussionCounts.get(prNumber) ?? 0),

--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -2433,19 +2433,35 @@ async function handleDocumentHistory(
 
     // Comment counts are decoration, not the record — a failure here must not
     // cost the user their history.
+    //
+    // The publisher is not decoration: the spline names the person who put
+    // each version on the record. Gitea only fills `merged_by` in on a single
+    // pull request's own endpoint, never in the list, so it is read per change
+    // here. A read that fails leaves that one version unattributed rather than
+    // failing the whole history.
     const discussionCounts = new Map<number, number>();
+    const publishers = new Map<number, string>();
     await Promise.all(
       merged.map(async (entry) => {
         const pullNumber = entry.pullRequest.number;
         if (!pullNumber) return;
-        const summary = await listDiscussions({
-          client,
-          owner,
-          repo,
-          pullNumber,
-        }).catch(() => null);
+
+        const [summary, detail] = await Promise.all([
+          listDiscussions({ client, owner, repo, pullNumber }).catch(
+            () => null,
+          ),
+          getPullRequestWithReviews({ client, owner, repo, pullNumber }).catch(
+            () => null,
+          ),
+        ]);
+
         if (summary) {
           discussionCounts.set(pullNumber, summary.totalCount);
+        }
+
+        const publisher = detail?.pullRequest.merged_by?.login;
+        if (publisher) {
+          publishers.set(pullNumber, publisher);
         }
       }),
     );
@@ -2471,7 +2487,12 @@ async function handleDocumentHistory(
     return json(
       200,
       {
-        versions: buildVersionRecords(tags, merged, discussionCounts),
+        versions: buildVersionRecords(
+          tags,
+          merged,
+          discussionCounts,
+          publishers,
+        ),
         canonicalFile,
       },
       baseHeaders,

--- a/tests/document-download.pw.ts
+++ b/tests/document-download.pw.ts
@@ -297,10 +297,10 @@ test.describe("Document download", () => {
     // The History tab must list both published versions
     await openDocumentTab(page, "History");
     await expect(
-      page.locator(".vault-version-badge", { hasText: "v2" }),
+      page.locator(".doc-spline-knot", { hasText: "v2" }),
     ).toBeVisible({ timeout: 30_000 });
     await expect(
-      page.locator(".vault-version-badge", { hasText: "v1" }),
+      page.locator(".doc-spline-knot", { hasText: "v1" }),
     ).toBeVisible();
   });
 
@@ -329,10 +329,10 @@ test.describe("Document download", () => {
     await signInAsAlice(page);
     await navigateToDocument(page, cardSearchText);
 
-    // Wait for the History tab to render the v1 badge
+    // Wait for the History tab to render the v1 knot
     await openDocumentTab(page, "History");
     await expect(
-      page.locator(".vault-version-badge", { hasText: "v1" }),
+      page.locator(".doc-spline-knot", { hasText: "v1" }),
     ).toBeVisible({ timeout: 30_000 });
 
     // Intercept the download triggered by the "Download v1" history button

--- a/tests/document-version-upload.pw.ts
+++ b/tests/document-version-upload.pw.ts
@@ -281,10 +281,10 @@ test.describe("UI document version upload flow", () => {
     // The History tab should show both versions
     await openDocumentTab(page, "History");
     await expect(
-      page.locator(".vault-version-badge", { hasText: "v2" }),
+      page.locator(".doc-spline-knot", { hasText: "v2" }),
     ).toBeVisible({ timeout: 30_000 });
     await expect(
-      page.locator(".vault-version-badge", { hasText: "v1" }),
+      page.locator(".doc-spline-knot", { hasText: "v1" }),
     ).toBeVisible();
   });
 });

--- a/tests/merge-conflict-resolution.pw.ts
+++ b/tests/merge-conflict-resolution.pw.ts
@@ -313,13 +313,13 @@ test.describe("Merge conflict resolution on publish", () => {
     // The History tab should show all three versions
     await openDocumentTab(page, "History");
     await expect(
-      page.locator(".vault-version-badge", { hasText: "v3" }),
+      page.locator(".doc-spline-knot", { hasText: "v3" }),
     ).toBeVisible({ timeout: 30_000 });
     await expect(
-      page.locator(".vault-version-badge", { hasText: "v2" }),
+      page.locator(".doc-spline-knot", { hasText: "v2" }),
     ).toBeVisible();
     await expect(
-      page.locator(".vault-version-badge", { hasText: "v1" }),
+      page.locator(".doc-spline-knot", { hasText: "v1" }),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes #346.

## What changed

The History tab was a stack of cards, each titled with a generated "Submitted by Alice" line and each carrying two buttons that repeated the version number the row had already said twice. It is now one line down the page with a knot per published version.

- **Every version is titled with the change review that produced it**, and the title links straight to that review. It is a real `<a href>`, so a modifier click opens the review in a new tab and hovering shows where it goes; a plain click is a route change, not a page load.
- **The author and the publisher are both named on the line itself**, with faces — "Bob *wrote* · Alice *published*" — instead of being buried in an expanded panel.
- **View and Download are icons.** The knot carries the version, so a button that repeats it is the same word twice. Both keep an `aria-label` and a `title`, and the version is still announced via an `sr-only` span since the knot itself is decorative.

A knot reads: the change review it came from, who wrote it, who published it, the date, and the comment count. Nothing else.

## Three things the redesign removed

**The commit hash.** The reader is a compliance manager. A SHA answers no question they have, and "which version did we approve?" never needed one.

**The expanded review record.** The change review *is* the review record — it already renders the approvals and the discussion threads on its own page. A second copy on the History tab is the same log in two places, drifting apart the moment one of them changes, and it cost a `/discussions` fetch per version on every visit to the tab. The title is the way in. `publishedVersionToRecord` went with it; History was its only caller.

**"Approved by Alice."** Every version on this page is published, which is to say approved — the line was a constant rendered once per row, distinguishing no version from any other. Who signed off belongs to the change review. `summarizeApprovals` went with it.

## One bug this surfaced

Gitea only fills `merged_by` in on a single pull request's own endpoint, never in the list — so the history read it as `null` and **every version claimed nobody published it**. Since the spline names the publisher, the handler now reads it per change alongside the discussion count it was already fetching. A read that fails leaves that one version unattributed rather than failing the whole history.

## One test-infrastructure fix

`App.test.ts` mocked `./api` with a partial object. `mock.module` fixes a module's export names the first time it is applied, so that made *any other suite* importing an untouched export of `./api` fail to link — in a different file, with a message about the wrong module. It now spreads the real module before overriding. Without this, the new component test could not exist.

## Tests

- `apps/app/documentHistory.test.ts` (10) — what a knot says: the change review title and href, both people, the automated-upload title, the fallback when no submission record survived, comment pluralisation, and that a knot carries neither a commit hash nor an approver.
- `apps/app/components/DocumentHistory.test.ts` (12) — the rendered spline: one line, one knot per version, the title links to the review, a plain click opens it without a page load, both people appear, the two actions are icon-only with screen-reader names, the version being read is marked, no knot unfolds into a second copy of the review record, no commit hash, no approver, and the empty state.
- `services/api/document-history.test.ts` (2 new) — the publisher read from the change's own endpoint, and the unattributed fallback.

The three removals each have a test holding them removed, so a knot that quietly starts echoing the review record again fails.

Full suite: 604 passing, 0 failing. `bun run format:check` clean. `bun run build` clean.

## Verification

Verified against the local stack on `bob/hipaa-training-policy` (two published versions): light and dark, desktop and mobile, the title click landing on change #2, and every request on the tab returning 200 with no per-version discussions fetch.

No changes to `packages/editor/` — the landing demo embed does not need `bun run sync-demo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)