### PR TITLE
feat(app): make the version pill a dropdown onto prior versions

### DIFF
--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -764,6 +764,133 @@ input {
   color: var(--bs-text-muted);
 }
 
+/* An earlier version is open. Coral, because reading last quarter's contract
+   thinking it is this quarter's is the one mistake this page must prevent. */
+.doc-version-pill--past {
+  background: var(--bs-coral-dim);
+  color: var(--brand-coral-dark);
+  box-shadow: inset 0 0 0 1px var(--brand-coral);
+}
+
+/* The pill is also the version picker. */
+.doc-version-picker {
+  position: relative;
+  display: inline-flex;
+}
+
+.doc-version-pill--button {
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--brand-font-mono);
+  transition: filter var(--brand-transition-base);
+}
+
+.doc-version-pill--button:hover {
+  filter: brightness(0.96);
+}
+
+.doc-version-pill--button:focus-visible {
+  outline: 2px solid var(--brand-coral);
+  outline-offset: 2px;
+}
+
+.doc-version-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: var(--brand-z-raised);
+  min-width: 232px;
+  max-height: 320px;
+  overflow-y: auto;
+  display: grid;
+  gap: 2px;
+  padding: var(--brand-space-1);
+  background: var(--bs-surface-1);
+  border: 1px solid var(--bs-rule);
+  border-radius: var(--brand-radius-lg);
+  box-shadow: var(--bs-shadow-lg);
+}
+
+.doc-version-menu-item {
+  appearance: none;
+  display: grid;
+  grid-template-columns: 16px auto 1fr auto;
+  align-items: center;
+  gap: var(--brand-space-2);
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: var(--brand-radius-sm);
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--bs-text-secondary);
+  font-family: var(--brand-font-sans);
+  font-size: var(--brand-text-sm);
+  transition: background var(--brand-transition-base);
+}
+
+.doc-version-menu-item:hover,
+.doc-version-menu-item:focus-visible {
+  background: var(--bs-surface-2);
+  outline: none;
+}
+
+.doc-version-menu-item--selected {
+  color: var(--bs-text-primary);
+}
+
+.doc-version-menu-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--brand-coral);
+}
+
+.doc-version-menu-label {
+  font-family: var(--brand-font-mono);
+  font-size: var(--brand-text-label);
+  letter-spacing: 0.04em;
+}
+
+.doc-version-menu-date {
+  color: var(--bs-text-muted);
+  font-size: 12px;
+}
+
+.doc-version-menu-note {
+  font-size: 11px;
+  color: var(--bs-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* The way out of an earlier version, beside the pill that says you are in
+   one — quiet text, not a second button competing with Submit. */
+.doc-header-latest {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--brand-coral);
+  font-family: var(--brand-font-sans);
+  font-size: 12.5px;
+  font-weight: var(--brand-weight-medium);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.doc-header-latest:hover {
+  color: var(--brand-coral-dark);
+}
+
+.doc-header-latest:focus-visible {
+  outline: 2px solid var(--brand-coral);
+  outline-offset: 2px;
+}
+
 /* The one coral element on the page: the next action. */
 .doc-header-submit {
   display: inline-flex;
@@ -859,20 +986,6 @@ input {
   display: grid;
   gap: var(--brand-space-4);
   min-width: 0;
-}
-
-.doc-version-notice {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--brand-space-3);
-  padding: var(--brand-space-3) var(--brand-space-4);
-  background: var(--bs-coral-dim);
-  border: 1px solid var(--bs-rule);
-  border-radius: var(--brand-radius-sm);
-  color: var(--bs-text-secondary);
-  font-size: var(--brand-text-sm);
 }
 
 /* The document itself: one white sheet, big radius, room to read. The
@@ -1282,6 +1395,11 @@ input {
 
 .doc-rail-row:first-child {
   border-top: none;
+}
+
+/* The earlier version somebody is actually reading. */
+.doc-rail-row--viewing {
+  background: var(--bs-coral-dim);
 }
 
 .doc-rail-row:hover .doc-rail-row-date {
@@ -2673,16 +2791,6 @@ input {
   font-family: var(--brand-font-mono);
   font-size: var(--brand-text-xs);
   color: var(--bs-text-muted);
-}
-
-/* The "Back to latest" button on the Document tab, which reads an earlier
-   version. Not part of the spline. */
-.doc-history-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--brand-space-2);
-  padding: var(--brand-space-2) var(--brand-space-3);
-  font-size: var(--brand-text-sm);
 }
 
 .doc-review-list {

--- a/apps/app/components/AnonymousDocumentShell.tsx
+++ b/apps/app/components/AnonymousDocumentShell.tsx
@@ -63,12 +63,27 @@ export function AnonymousDocumentShell({
               activeView={route.tab === "access" ? "overview" : route.tab}
               activeChangeNumber={route.changeNumber ?? null}
               activeChangeView={route.changeView ?? "discussion"}
+              activeVersion={route.version ?? null}
               onTabChange={(tab) =>
                 onNavigate({
                   kind: "document",
                   owner: route.owner,
                   repo: route.repo,
                   tab,
+                  // A version lives on the Document tab; walking to another
+                  // tab leaves it behind rather than carrying it along.
+                  ...(tab === "overview" && route.version !== undefined
+                    ? { version: route.version }
+                    : {}),
+                })
+              }
+              onSelectVersion={(version) =>
+                onNavigate({
+                  kind: "document",
+                  owner: route.owner,
+                  repo: route.repo,
+                  tab: "overview",
+                  ...(version === null ? {} : { version }),
                 })
               }
               onOpenChange={(pullNumber, changeView) =>

--- a/apps/app/components/AppShell.tsx
+++ b/apps/app/components/AppShell.tsx
@@ -359,12 +359,27 @@ export function AppShell({
                 activeView={route.tab}
                 activeChangeNumber={route.changeNumber ?? null}
                 activeChangeView={route.changeView ?? "discussion"}
+                activeVersion={route.version ?? null}
                 onTabChange={(tab) =>
                   onNavigate({
                     kind: "document",
                     owner: route.owner,
                     repo: route.repo,
                     tab,
+                    // A version lives on the Document tab; walking to another
+                    // tab leaves it behind rather than carrying it along.
+                    ...(tab === "overview" && route.version !== undefined
+                      ? { version: route.version }
+                      : {}),
+                  })
+                }
+                onSelectVersion={(version) =>
+                  onNavigate({
+                    kind: "document",
+                    owner: route.owner,
+                    repo: route.repo,
+                    tab: "overview",
+                    ...(version === null ? {} : { version }),
                   })
                 }
                 onOpenChange={(pullNumber, changeView) =>

--- a/apps/app/components/DocumentDetail.test.ts
+++ b/apps/app/components/DocumentDetail.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { createElement } from "react";
+import type { ReactElement } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { JSDOM } from "jsdom";
+
+import * as api from "../api";
+import type { DocTag } from "../api";
+
+/**
+ * The document header, rendered.
+ *
+ * What has to survive a redesign: the pill says which version is on screen,
+ * it opens onto every other one, and an earlier version cannot be mistaken
+ * for the record — the pill turns coral and the way back sits beside it.
+ */
+
+let detail: Record<string, unknown> = {};
+
+const mockGetDocumentDetail = mock(async () => detail);
+
+// The children of the workspace each reach for their own slice of the API
+// client; only the four calls this page makes on mount are stubbed, and the
+// rest stay as they are so an unexpected one fails loudly.
+mock.module("../api", () => ({
+  ...api,
+  getDocumentDetail: mockGetDocumentDetail,
+  getClosedChanges: async () => ({ changes: [] }),
+  listDocumentCollaborators: async () => ({ collaborators: [] }),
+  downloadDocument: async () => new Blob(["hello"]),
+}));
+
+const { DocumentDetail } = await import("./DocumentDetail");
+
+const DOM_KEYS = [
+  "window",
+  "document",
+  "navigator",
+  "HTMLElement",
+  "Element",
+  "Node",
+  "MutationObserver",
+  "Event",
+] as const;
+
+let originals: Record<string, unknown> = {};
+
+beforeEach(() => {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "https://bindersnap.com/docs/alice/contract",
+  });
+
+  const values: Record<string, unknown> = {
+    window: dom.window,
+    document: dom.window.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Element: dom.window.Element,
+    Node: dom.window.Node,
+    MutationObserver: dom.window.MutationObserver,
+    Event: dom.window.Event,
+  };
+
+  originals = {};
+  for (const key of DOM_KEYS) {
+    originals[key] = (globalThis as Record<string, unknown>)[key];
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value: values[key],
+    });
+  }
+});
+
+afterEach(async () => {
+  // React's scheduler reads `window` from a callback of its own; pulling the
+  // DOM out from under it mid-flight fails the next test, not this one.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  for (const key of DOM_KEYS) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value: originals[key],
+    });
+  }
+});
+
+function tag(version: number, created: string): DocTag {
+  return { name: `v${version}`, version, sha: `sha-${version}`, created };
+}
+
+function documentDetail(tags: DocTag[]) {
+  return {
+    tags,
+    openPullRequests: [],
+    branchProtection: null,
+    reviewSettings: null,
+    currentUserPermission: null,
+    canonicalFile: {
+      storedFileName: "contract.md",
+      downloadFileName: "contract.md",
+    },
+  };
+}
+
+async function render(element: ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  flushSync(() => root.render(element));
+  // The document is fetched on mount; let the promise land before asserting.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+
+  return {
+    container,
+    unmount: () => {
+      flushSync(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function detailProps(overrides: Record<string, unknown> = {}) {
+  return {
+    owner: "alice",
+    repo: "contract",
+    uploaderSlug: "alice",
+    activeView: "overview" as const,
+    activeChangeNumber: null,
+    activeChangeView: "discussion" as const,
+    activeVersion: null,
+    onTabChange: () => {},
+    onSelectVersion: () => {},
+    onOpenChange: () => {},
+    ...overrides,
+  };
+}
+
+function click(element: Element) {
+  flushSync(() => {
+    element.dispatchEvent(
+      new window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+const threeVersions = [
+  tag(3, "2026-01-12T00:00:00Z"),
+  tag(2, "2025-11-03T00:00:00Z"),
+  tag(1, "2025-09-22T00:00:00Z"),
+];
+
+test("the version pill opens onto every published version", async () => {
+  detail = documentDetail(threeVersions);
+
+  const { container, unmount } = await render(
+    createElement(DocumentDetail, detailProps()),
+  );
+
+  const pill = container.querySelector(
+    ".doc-version-pill--button",
+  ) as HTMLButtonElement;
+  expect(pill.textContent).toContain("v3 · Current");
+  expect(container.querySelector(".doc-version-menu")).toBeNull();
+
+  click(pill);
+
+  expect(
+    [...container.querySelectorAll(".doc-version-menu-label")].map(
+      (label) => label.textContent,
+    ),
+  ).toEqual(["v3", "v2", "v1"]);
+
+  unmount();
+});
+
+test("picking an earlier version asks for its own page", async () => {
+  detail = documentDetail(threeVersions);
+
+  const picked: (number | null)[] = [];
+  const { container, unmount } = await render(
+    createElement(
+      DocumentDetail,
+      detailProps({
+        onSelectVersion: (version: number | null) => picked.push(version),
+      }),
+    ),
+  );
+
+  click(container.querySelector(".doc-version-pill--button")!);
+  const items = container.querySelectorAll(".doc-version-menu-item");
+  click(items[1]!);
+
+  expect(picked).toEqual([2]);
+  // Picking closes the menu; nobody wants it hanging over what they opened.
+  expect(container.querySelector(".doc-version-menu")).toBeNull();
+
+  unmount();
+});
+
+test("an earlier version is unmistakable, and says how to get back", async () => {
+  detail = documentDetail(threeVersions);
+
+  const picked: (number | null)[] = [];
+  const { container, unmount } = await render(
+    createElement(
+      DocumentDetail,
+      detailProps({
+        activeVersion: 2,
+        onSelectVersion: (version: number | null) => picked.push(version),
+      }),
+    ),
+  );
+
+  const pill = container.querySelector(".doc-version-pill--button")!;
+  expect(pill.textContent).toContain("v2 · Earlier version");
+  expect(pill.className).toContain("doc-version-pill--past");
+  expect(container.textContent).toContain("v3 is current");
+
+  const back = container.querySelector(".doc-header-latest")!;
+  click(back);
+  expect(picked).toEqual([null]);
+
+  unmount();
+});
+
+test("the version on record is not dressed up as an earlier one", async () => {
+  detail = documentDetail(threeVersions);
+
+  const { container, unmount } = await render(
+    createElement(DocumentDetail, detailProps({ activeVersion: 3 })),
+  );
+
+  const pill = container.querySelector(".doc-version-pill--button")!;
+  expect(pill.textContent).toContain("v3 · Current");
+  expect(container.querySelector(".doc-header-latest")).toBeNull();
+
+  unmount();
+});
+
+test("a version that does not exist says so instead of lying", async () => {
+  detail = documentDetail(threeVersions);
+
+  const { container, unmount } = await render(
+    createElement(DocumentDetail, detailProps({ activeVersion: 9 })),
+  );
+
+  expect(container.textContent).toContain("This document has no v9");
+
+  unmount();
+});
+
+test("with nothing published the pill is a fact, not a menu", async () => {
+  detail = documentDetail([]);
+
+  const { container, unmount } = await render(
+    createElement(DocumentDetail, detailProps()),
+  );
+
+  expect(container.querySelector(".doc-version-pill--button")).toBeNull();
+  expect(container.querySelector(".doc-version-pill")?.textContent).toBe(
+    "No version yet",
+  );
+
+  unmount();
+});

--- a/apps/app/components/DocumentDetail.tsx
+++ b/apps/app/components/DocumentDetail.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { ChevronDown, Check } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type {
   PullRequestWithApprovalState,
@@ -26,8 +27,10 @@ import {
   buildDocumentHeaderFacts,
   buildPendingDecisionRows,
   buildTeamAvatars,
+  buildVersionMenuOptions,
   buildVersionRailRows,
 } from "../documentWorkspace";
+import type { VersionMenuOption } from "../documentWorkspace";
 import { DocumentAccess } from "./DocumentAccess";
 import { DocumentChangeDetail } from "./DocumentChangeDetail";
 import type { ChangeFilter } from "./DocumentChanges";
@@ -46,19 +49,20 @@ interface DocumentDetailProps {
   activeChangeNumber: number | null;
   /** Which half of that change's page: the discussion or the file. */
   activeChangeView: DocumentChangeView;
+  /**
+   * Which published version the Document tab is showing, from the URL. Null
+   * is the version on record.
+   */
+  activeVersion: number | null;
   onTabChange: (tab: DocumentTab) => void;
+  /** Open a published version, or the record when given null. */
+  onSelectVersion: (version: number | null) => void;
   onOpenChange: (pullNumber: number | null, view?: DocumentChangeView) => void;
 }
 
 interface CanonicalFileInfo {
   storedFileName: string;
   downloadFileName: string;
-}
-
-/** Which version the Document tab is showing. `null` means the latest. */
-interface ViewedVersion {
-  tagName: string;
-  version: number;
 }
 
 function triggerBrowserDownload(blob: Blob, fileName: string): void {
@@ -88,7 +92,9 @@ export function DocumentDetail({
   activeView,
   activeChangeNumber,
   activeChangeView,
+  activeVersion,
   onTabChange,
+  onSelectVersion,
   onOpenChange,
 }: DocumentDetailProps) {
   const [tags, setTags] = useState<DocTag[]>([]);
@@ -105,9 +111,7 @@ export function DocumentDetail({
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showUploadModal, setShowUploadModal] = useState(false);
-  const [viewedVersion, setViewedVersion] = useState<ViewedVersion | null>(
-    null,
-  );
+  const [versionMenuOpen, setVersionMenuOpen] = useState(false);
   const [downloadState, setDownloadState] = useState<{
     ref: string | null;
     error: string | null;
@@ -333,8 +337,17 @@ export function DocumentDetail({
     );
   }
 
-  const viewingRef = viewedVersion?.tagName ?? "main";
-  const isViewingLatest = viewedVersion === null;
+  // The URL carries a version number; the tag list is what turns it into a
+  // git ref. An unknown number resolves to nothing, and the page says so
+  // rather than quietly showing the record under the wrong heading.
+  const viewedTag =
+    activeVersion === null
+      ? null
+      : (tags.find((tag) => tag.version === activeVersion) ?? null);
+  const isViewingLatest =
+    activeVersion === null || latestTag?.version === activeVersion;
+  const viewingRef = isViewingLatest ? "main" : (viewedTag?.name ?? "main");
+  const missingVersion = activeVersion !== null && viewedTag === null;
 
   // History carries no count on purpose: a version count is not a number of
   // things to deal with, and a bubble beside it reads like one.
@@ -350,7 +363,9 @@ export function DocumentDetail({
   const headerFacts = buildDocumentHeaderFacts({
     latestTag,
     fileName: canonicalFileInfo?.downloadFileName ?? null,
+    viewedTag,
   });
+  const versionOptions = buildVersionMenuOptions(tags, activeVersion);
   const pendingRows = buildPendingDecisionRows(openPRs);
   const versionRows = buildVersionRailRows(tags);
   const teamAvatars = buildTeamAvatars(collaborators, owner);
@@ -366,15 +381,38 @@ export function DocumentDetail({
             <div className="doc-header-facts">
               {/* The official version, not a status. A document can have v3
                   published and v4 in review at the same time, so a single
-                  status word here was always going to be a lie. */}
-              <span
-                className={`doc-version-pill doc-version-pill--${headerFacts.tone}`}
-              >
-                {headerFacts.versionLabel}
-              </span>
+                  status word here was always going to be a lie. It is also
+                  the way back to every earlier version — the pill names what
+                  you are reading, so it is where you go to read another. */}
+              <VersionMenu
+                label={headerFacts.versionLabel}
+                tone={headerFacts.tone}
+                options={versionOptions}
+                open={versionMenuOpen}
+                onToggle={() => setVersionMenuOpen((wasOpen) => !wasOpen)}
+                onClose={() => setVersionMenuOpen(false)}
+                onSelect={(version) => {
+                  setVersionMenuOpen(false);
+                  // `onSelectVersion` lands on the Document tab itself, so
+                  // asking for the tab as well would only race it.
+                  onSelectVersion(version);
+                }}
+              />
               <span className="doc-header-fact">
                 {headerFacts.approvedLine}
               </span>
+              {/* The banner this replaces sat on top of the document itself.
+                  The way out of an earlier version belongs beside the pill
+                  that says you are in one. */}
+              {!isViewingLatest ? (
+                <button
+                  className="doc-header-latest"
+                  type="button"
+                  onClick={() => onSelectVersion(null)}
+                >
+                  Back to current
+                </button>
+              ) : null}
               {headerFacts.fileName ? (
                 <span
                   className="doc-header-fact doc-header-file"
@@ -495,15 +533,12 @@ export function DocumentDetail({
           <DocumentHistory
             owner={owner}
             repo={repo}
-            viewingVersion={viewedVersion?.version ?? null}
+            viewingVersion={isViewingLatest ? null : activeVersion}
             hasCanonicalFile={canonicalFileInfo !== null}
             downloadingRef={downloadState.ref}
             onDownloadVersion={(tagName) => void handleDownload(tagName)}
             onViewVersion={(tagName, version) => {
-              setViewedVersion(
-                latestTag?.name === tagName ? null : { tagName, version },
-              );
-              onTabChange("overview");
+              onSelectVersion(latestTag?.name === tagName ? null : version);
             }}
             onOpenChange={(changeNumber) => onOpenChange(changeNumber)}
           />
@@ -511,20 +546,11 @@ export function DocumentDetail({
       ) : (
         <div className="doc-workspace">
           <div className="doc-workspace-main">
-            {!isViewingLatest ? (
-              <div className="doc-version-notice" role="status">
-                <span>
-                  Viewing <strong>v{viewedVersion?.version}</strong>, an earlier
-                  approved version.
-                </span>
-                <button
-                  className="bs-btn bs-btn-secondary doc-history-btn"
-                  type="button"
-                  onClick={() => setViewedVersion(null)}
-                >
-                  Back to latest
-                </button>
-              </div>
+            {missingVersion ? (
+              <p className="vault-pr-notice" role="status">
+                This document has no v{activeVersion}. Showing the version on
+                record instead.
+              </p>
             ) : null}
 
             {/* Nothing has been approved, so there is no official version to
@@ -604,17 +630,16 @@ export function DocumentDetail({
                 <div className="doc-rail-card doc-rail-card--rows">
                   {versionRows.map((row) => (
                     <button
-                      className="doc-rail-row"
+                      className={`doc-rail-row${row.version === activeVersion ? " doc-rail-row--viewing" : ""}`}
                       type="button"
                       key={row.key}
-                      onClick={() => {
-                        setViewedVersion(
-                          row.current
-                            ? null
-                            : { tagName: row.tagName, version: row.version },
-                        );
-                        onTabChange("overview");
-                      }}
+                      // The rail says which version is on screen, not only
+                      // which one is the record — reading v1 beside a row
+                      // marked "Current" is exactly the confusion to avoid.
+                      aria-current={row.version === activeVersion}
+                      onClick={() =>
+                        onSelectVersion(row.current ? null : row.version)
+                      }
                     >
                       <span
                         className={`doc-rail-version${row.current ? " doc-rail-version--current" : ""}`}
@@ -624,6 +649,8 @@ export function DocumentDetail({
                       <span className="doc-rail-row-date">{row.date}</span>
                       {row.current ? (
                         <span className="doc-rail-row-note">Current</span>
+                      ) : row.version === activeVersion ? (
+                        <span className="doc-rail-row-note">Viewing</span>
                       ) : null}
                     </button>
                   ))}
@@ -683,6 +710,100 @@ export function DocumentDetail({
           onClose={() => setShowUploadModal(false)}
           onSuccess={handleUploadSuccess}
         />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The version pill, which is also the way to every earlier version.
+ *
+ * A document's history is the reason the record can be trusted, so reaching
+ * an older version should not mean finding the History tab first. The pill
+ * already names what is on screen; opening it names everything else.
+ */
+function VersionMenu({
+  label,
+  tone,
+  options,
+  open,
+  onToggle,
+  onClose,
+  onSelect,
+}: {
+  label: string;
+  tone: "current" | "past" | "none";
+  options: VersionMenuOption[];
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onSelect: (version: number | null) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const closeOnOutside = (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) onClose();
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    document.addEventListener("mousedown", closeOnOutside);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("mousedown", closeOnOutside);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open, onClose]);
+
+  // Nothing published: the pill is a statement of fact, not a control.
+  if (options.length === 0) {
+    return (
+      <span className={`doc-version-pill doc-version-pill--${tone}`}>
+        {label}
+      </span>
+    );
+  }
+
+  return (
+    <div className="doc-version-picker" ref={ref}>
+      <button
+        className={`doc-version-pill doc-version-pill--${tone} doc-version-pill--button`}
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={`${label}. Choose a version`}
+        onClick={onToggle}
+      >
+        {label}
+        <ChevronDown size={12} strokeWidth={1.8} aria-hidden="true" />
+      </button>
+
+      {open ? (
+        <div className="doc-version-menu" role="menu">
+          {options.map((option) => (
+            <button
+              className={`doc-version-menu-item${option.selected ? " doc-version-menu-item--selected" : ""}`}
+              type="button"
+              role="menuitemradio"
+              aria-checked={option.selected}
+              key={option.key}
+              onClick={() => onSelect(option.current ? null : option.version)}
+            >
+              <span className="doc-version-menu-check" aria-hidden="true">
+                {option.selected ? <Check size={12} strokeWidth={2} /> : null}
+              </span>
+              <span className="doc-version-menu-label">{option.label}</span>
+              <span className="doc-version-menu-date">{option.date}</span>
+              {option.current ? (
+                <span className="doc-version-menu-note">Current</span>
+              ) : null}
+            </button>
+          ))}
+        </div>
       ) : null}
     </div>
   );

--- a/apps/app/documentWorkspace.test.ts
+++ b/apps/app/documentWorkspace.test.ts
@@ -9,6 +9,7 @@ import {
   buildDocumentHeaderFacts,
   buildPendingDecisionRows,
   buildTeamAvatars,
+  buildVersionMenuOptions,
   buildVersionRailRows,
 } from "./documentWorkspace";
 
@@ -102,6 +103,60 @@ test("the newest version is the current one and the rest are history", () => {
   expect(rows.map((row) => row.label)).toEqual(["v3", "v2", "v1"]);
   expect(rows.map((row) => row.current)).toEqual([true, false, false]);
   expect(rows[0]?.date).toBe("Jan 12, 2026");
+});
+
+test("reading an earlier version says so in the header, in coral", () => {
+  expect(
+    buildDocumentHeaderFacts({
+      latestTag: tag(3, "2026-01-12T00:00:00Z"),
+      fileName: "vendor-agreement.docx",
+      viewedTag: tag(1, "2025-09-22T00:00:00Z"),
+    }),
+  ).toEqual({
+    versionLabel: "v1 · Earlier version",
+    tone: "past",
+    approvedLine: "Approved Sep 22, 2025 · v3 is current",
+    fileName: "vendor-agreement.docx",
+  });
+});
+
+test("opening the version on record by number is not an earlier version", () => {
+  const facts = buildDocumentHeaderFacts({
+    latestTag: tag(3, "2026-01-12T00:00:00Z"),
+    fileName: null,
+    viewedTag: tag(3, "2026-01-12T00:00:00Z"),
+  });
+
+  expect(facts.tone).toBe("current");
+  expect(facts.versionLabel).toBe("v3 · Current");
+});
+
+test("the version dropdown lists every version and ticks the record by default", () => {
+  const options = buildVersionMenuOptions(
+    [
+      tag(3, "2026-01-12T00:00:00Z"),
+      tag(2, "2025-11-03T00:00:00Z"),
+      tag(1, "2025-09-22T00:00:00Z"),
+    ],
+    null,
+  );
+
+  expect(options.map((option) => option.label)).toEqual(["v3", "v2", "v1"]);
+  expect(options.map((option) => option.current)).toEqual([true, false, false]);
+  expect(options.map((option) => option.selected)).toEqual([
+    true,
+    false,
+    false,
+  ]);
+});
+
+test("the version dropdown ticks the earlier version being read", () => {
+  const options = buildVersionMenuOptions(
+    [tag(3, "2026-01-12T00:00:00Z"), tag(2, "2025-11-03T00:00:00Z")],
+    2,
+  );
+
+  expect(options.map((option) => option.selected)).toEqual([false, true]);
 });
 
 test("the version rail stops at four rows", () => {

--- a/apps/app/documentWorkspace.ts
+++ b/apps/app/documentWorkspace.ts
@@ -25,8 +25,12 @@ import { formatWhen } from "./homeChanges";
 export interface DocumentHeaderFacts {
   /** "v3 · Current", or "No version yet" before anything is published. */
   versionLabel: string;
-  /** Green only once something is actually on the record. */
-  tone: "current" | "none";
+  /**
+   * Green once something is on the record, coral while an earlier version is
+   * open — reading v2 when v3 exists is the one thing the header must not let
+   * you miss.
+   */
+  tone: "current" | "past" | "none";
   /** "Approved Jan 12, 2026", or why there is no such date. */
   approvedLine: string;
   /** The file the document is, in mono. Null when it cannot be resolved. */
@@ -36,8 +40,13 @@ export interface DocumentHeaderFacts {
 export function buildDocumentHeaderFacts(params: {
   latestTag: Pick<DocTag, "version" | "created"> | null;
   fileName: string | null;
+  /**
+   * The earlier version being read, when one is. Null means the page is
+   * showing the record itself.
+   */
+  viewedTag?: Pick<DocTag, "version" | "created"> | null;
 }): DocumentHeaderFacts {
-  const { latestTag, fileName } = params;
+  const { latestTag, fileName, viewedTag = null } = params;
 
   if (!latestTag) {
     return {
@@ -48,12 +57,60 @@ export function buildDocumentHeaderFacts(params: {
     };
   }
 
+  if (viewedTag && viewedTag.version !== latestTag.version) {
+    return {
+      versionLabel: `v${viewedTag.version} · Earlier version`,
+      tone: "past",
+      approvedLine: `Approved ${formatShortDate(viewedTag.created)} · v${latestTag.version} is current`,
+      fileName,
+    };
+  }
+
   return {
     versionLabel: `v${latestTag.version} · Current`,
     tone: "current",
     approvedLine: `Approved ${formatShortDate(latestTag.created)}`,
     fileName,
   };
+}
+
+/** One line in the header's version dropdown. */
+export interface VersionMenuOption {
+  key: string;
+  tagName: string;
+  version: number;
+  /** "v3". */
+  label: string;
+  /** "Jan 12, 2026". */
+  date: string;
+  /** The version on record. */
+  current: boolean;
+  /** The version the page is showing right now. */
+  selected: boolean;
+}
+
+/**
+ * Every published version, newest first, as the header dropdown lists them.
+ *
+ * Unlike the rail this does not cut the list: the dropdown is how somebody
+ * reaches an old version, so hiding half of them behind another page would
+ * defeat the point. `viewedVersion` is null when the record is open.
+ */
+export function buildVersionMenuOptions(
+  tags: DocTag[],
+  viewedVersion: number | null,
+): VersionMenuOption[] {
+  return tags.map((tag, index) => ({
+    key: tag.name,
+    tagName: tag.name,
+    version: tag.version,
+    label: `v${tag.version}`,
+    date: formatShortDate(tag.created),
+    // The list arrives newest first, so the first row is the record.
+    current: index === 0,
+    selected:
+      viewedVersion === null ? index === 0 : tag.version === viewedVersion,
+  }));
 }
 
 /** One open change, as the rail states it. */

--- a/apps/app/routes.test.ts
+++ b/apps/app/routes.test.ts
@@ -123,6 +123,43 @@ test("the file under review is its own screen within a change", () => {
   ).toBe("/docs/alice/quarterly-report/changes/7/preview");
 });
 
+test("every published version has a page of its own", () => {
+  expect(getRoute("/docs/alice/quarterly-report/version/2")).toEqual({
+    kind: "document",
+    owner: "alice",
+    repo: "quarterly-report",
+    tab: "overview",
+    version: 2,
+  });
+
+  expect(
+    routeToPath({
+      kind: "document",
+      owner: "alice",
+      repo: "quarterly-report",
+      tab: "overview",
+      version: 2,
+    }),
+  ).toBe("/docs/alice/quarterly-report/version/2");
+});
+
+test("the document tab without a version is the version on record", () => {
+  expect(
+    routeToPath({
+      kind: "document",
+      owner: "alice",
+      repo: "quarterly-report",
+      tab: "overview",
+    }),
+  ).toBe("/docs/alice/quarterly-report");
+});
+
+test("a non-numeric version segment is not a version page", () => {
+  expect(getRoute("/docs/alice/quarterly-report/version/latest")).toEqual({
+    kind: "home",
+  });
+});
+
 test("an unknown segment under a change is not a change page", () => {
   expect(getRoute("/docs/alice/quarterly-report/changes/7/nonsense")).toEqual({
     kind: "home",

--- a/apps/app/routes.ts
+++ b/apps/app/routes.ts
@@ -14,6 +14,12 @@ export type AppRoute =
       repo: string;
       tab: DocumentTab;
       /**
+       * Which published version the Document tab is showing, or undefined for
+       * the one on record. Only ever set on the `overview` tab — an earlier
+       * version is a thing you can link to, not a mode the page remembers.
+       */
+      version?: number;
+      /**
        * One change, on its own page. Only ever set on the `changes` tab —
        * reviewing #3 should not mean scrolling past #4 through #10.
        */
@@ -144,6 +150,19 @@ export function getRoute(pathname: string): AppRoute {
     };
   }
 
+  const versionMatch = normalizedPath.match(
+    /^\/docs\/([^/]+)\/([^/]+)\/version\/(\d+)$/,
+  );
+  if (versionMatch) {
+    return {
+      kind: "document",
+      owner: versionMatch[1]!,
+      repo: versionMatch[2]!,
+      tab: "overview",
+      version: Number(versionMatch[3]),
+    };
+  }
+
   const docTabMatch = normalizedPath.match(
     /^\/docs\/([^/]+)\/([^/]+)\/([^/]+)$/,
   );
@@ -188,7 +207,11 @@ export function routeToPath(route: AppRoute): string {
       return "/auth/callback";
     case "document": {
       const base = `/docs/${route.owner}/${route.repo}`;
-      if (route.tab === "overview") return base;
+      if (route.tab === "overview") {
+        return route.version === undefined
+          ? base
+          : `${base}/version/${route.version}`;
+      }
       if (route.tab === "changes" && route.changeNumber !== undefined) {
         const change = `${base}/changes/${route.changeNumber}`;
         return route.changeView === "preview" ? `${change}/preview` : change;


### PR DESCRIPTION
Closes #348.

## What changed

The version pill on `/docs/:owner/:repo` is now the way into the document's
history, and every published version has a page of its own.

- **The pill is a dropdown.** It lists every published version with its date,
  ticks the one on screen, and marks which one is current. Nothing published
  yet? It stays a plain statement of fact, not a menu.
- **Prior versions are linkable:** `/docs/:owner/:repo/version/:number`. Which
  version is open moved out of component state and into the URL, so the header
  dropdown, the rail, the History tab's view button, and the browser's back
  button all move the same thing. A cold load of a version link works.
- **The banner is gone.** Reading an earlier version now shows in the header
  itself: the pill turns coral and reads `v1 · Earlier version`, the fact beside
  it says which version *is* current, `Back to current` sits inline, and the
  rail marks the row being read as "Viewing".
- A version number that does not exist says so and falls back to the record,
  rather than showing the current file under an earlier version's heading.

## Verification

- `bun run test` — 633 tests pass (6 new rendered tests for the header
  dropdown, plus route and header-facts tests).
- Driven by hand against the local stack on a seeded two-version document:
  opening the dropdown, picking v1 (URL becomes `/version/1`, preview swaps to
  the v1 file), cold-loading that link, browser back/forward, `Back to current`,
  and History → View v1. No console or network errors.

## Notes

`packages/editor/` visuals are untouched, so no `bun run sync-demo` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)