### PR TITLE
feat(app): export the audit record as a file an auditor can open

### DIFF
--- a/apps/app/app.css
+++ b/apps/app/app.css
@@ -2644,6 +2644,37 @@ input {
   color: var(--bs-text-muted);
 }
 
+/* ── History tab — exporting the record ────────────────────────────
+   The trail on screen is for the people in the room. The export is for the
+   one person who is not: an auditor with no login, who needs the same facts
+   as a file. It sits above the spline because it is about the whole trail,
+   not about any one version.
+   ------------------------------------------------------------------ */
+.doc-record-export {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--brand-space-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--brand-space-5);
+  padding-bottom: var(--brand-space-4);
+  border-bottom: 1px solid var(--bs-rule);
+}
+
+.doc-record-export-copy {
+  margin: 0;
+  max-width: 48ch;
+  font-size: var(--brand-text-sm);
+  color: var(--bs-text-muted);
+}
+
+.doc-record-export-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--brand-space-2);
+  white-space: nowrap;
+}
+
 /* ── History tab — the audit trail as a spline ─────────────────────
    One line down the page with a knot for every published version. Each knot
    is the change review that produced it, so the title is that review's title

--- a/apps/app/auditRecord.test.ts
+++ b/apps/app/auditRecord.test.ts
@@ -68,29 +68,36 @@ test("the record names the document, the workspace, and the version on record", 
   const { html } = record([version(), version({ version: 2, tagName: "v2" })]);
 
   expect(html).toContain("<title>Quarterly Report — audit record</title>");
-  expect(html).toContain("alice/quarterly-report");
+  expect(html).toContain("<dd>alice</dd>");
   expect(html).toContain("<dd>v3</dd>");
   expect(html).toContain("<dd>2</dd>");
 });
 
-test("a tag that is not just the version number is named alongside it", () => {
-  const { html } = record([version({ tagName: "release-2026-08" })]);
-
-  expect(html).toContain("v3 (release-2026-08)");
-});
-
-test("every version is a section, newest first, with its commit", () => {
+test("nothing in the record is a tag, a commit, or a repository path", () => {
+  // The reader is an auditor, not an engineer. A version number is the whole
+  // identity; how Bindersnap stores it underneath is not their question, and
+  // they have no way to look any of it up.
   const { html } = record([
-    version({ version: 2, tagName: "v2", sha: "1111111111111111" }),
-    version({ version: 3, tagName: "v3", sha: "2222222222222222" }),
+    version({ tagName: "release-2026-08", sha: "abcdef0123456789" }),
   ]);
 
-  const tags = [...html.matchAll(/record-version-tag">(v\d+)</g)].map(
+  expect(html).not.toContain("release-2026-08");
+  expect(html).not.toContain("abcdef0123456789");
+  expect(html).not.toContain("alice/quarterly-report");
+  expect(html).not.toContain("Commit");
+  expect(html).not.toContain("Tag");
+});
+
+test("every version is a section, newest first", () => {
+  const { html } = record([
+    version({ version: 2, tagName: "v2" }),
+    version({ version: 3, tagName: "v3" }),
+  ]);
+
+  const labels = [...html.matchAll(/record-version-label">(v\d+)</g)].map(
     (match) => match[1],
   );
-  expect(tags).toEqual(["v3", "v2"]);
-  expect(html).toContain("2222222222222222");
-  expect(html).toContain("1111111111111111");
+  expect(labels).toEqual(["v3", "v2"]);
 });
 
 test("a review that no longer counts stays on the record, labelled", () => {

--- a/apps/app/auditRecord.test.ts
+++ b/apps/app/auditRecord.test.ts
@@ -69,7 +69,7 @@ test("the record names the document, the workspace, and the version on record", 
 
   expect(html).toContain("<title>Quarterly Report — audit record</title>");
   expect(html).toContain("<dd>alice</dd>");
-  expect(html).toContain("<dd>v3</dd>");
+  expect(html).toContain("<dd>Version 3</dd>");
   expect(html).toContain("<dd>2</dd>");
 });
 
@@ -94,13 +94,13 @@ test("every version is a section, newest first", () => {
     version({ version: 3, tagName: "v3" }),
   ]);
 
-  const labels = [...html.matchAll(/record-version-label">(v\d+)</g)].map(
+  const labels = [...html.matchAll(/record-version-label">([^<]+)</g)].map(
     (match) => match[1],
   );
-  expect(labels).toEqual(["v3", "v2"]);
+  expect(labels).toEqual(["Version 3", "Version 2"]);
 });
 
-test("a review that no longer counts stays on the record, labelled", () => {
+test("an approval that no longer counts stays on the record, labelled", () => {
   const { html } = record([
     version({
       reviews: [
@@ -108,7 +108,6 @@ test("a review that no longer counts stays on the record, labelled", () => {
         review({
           id: 2,
           author: { login: "dana", fullName: "", avatarUrl: "" },
-          state: "changes_requested",
           dismissed: true,
           body: "",
         }),
@@ -117,17 +116,52 @@ test("a review that no longer counts stays on the record, labelled", () => {
   ]);
 
   expect(html).toContain("Kit Alvarez (kit)");
+  expect(html).toContain("Approved");
   expect(html).toContain("superseded by a later upload");
   expect(html).toContain("Dana (dana)");
-  expect(html).toContain("Requested changes");
   expect(html).toContain("dismissed");
   expect(html).toContain("No comment");
 });
 
-test("a version nobody reviewed says so rather than showing an empty table", () => {
+test("the record says approved, never signed off", () => {
+  const { html } = record([version()]);
+
+  expect(html).toContain("<td>Approved</td>");
+  expect(html).not.toContain("Signed off");
+});
+
+test("a request for changes is a step on the way, not part of the record", () => {
+  // It was answered — that is why there is a published version underneath it.
+  const { html } = record([
+    version({
+      reviews: [
+        review({
+          id: 2,
+          state: "changes_requested",
+          body: "The cap needs an IP carve-out.",
+        }),
+        review(),
+      ],
+    }),
+  ]);
+
+  expect(html).not.toContain("Requested changes");
+  expect(html).not.toContain("IP carve-out");
+  expect(html).toContain("Reads correctly against the March policy.");
+});
+
+test("a change whose only review asked for changes reads as unapproved", () => {
+  const { html } = record([
+    version({ reviews: [review({ state: "changes_requested" })] }),
+  ]);
+
+  expect(html).toContain("No approvals were recorded on this change.");
+});
+
+test("a version nobody approved says so rather than showing an empty table", () => {
   const { html } = record([version({ reviews: [] })]);
 
-  expect(html).toContain("No reviews were recorded on this change.");
+  expect(html).toContain("No approvals were recorded on this change.");
 });
 
 test("a version with no surviving change record is still on the record", () => {

--- a/apps/app/auditRecord.test.ts
+++ b/apps/app/auditRecord.test.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "bun:test";
+
+import type { DocumentVersionRecord, VersionReview } from "./api";
+import { buildAuditRecord, buildAuditRecordFileName } from "./auditRecord";
+
+/**
+ * The exported record.
+ *
+ * What has to hold: every published version appears, every review appears —
+ * including the ones that no longer count, labelled as such — and nothing a
+ * person typed can escape into the markup of a file that gets emailed around.
+ */
+
+function review(overrides: Partial<VersionReview> = {}): VersionReview {
+  return {
+    id: 1,
+    author: { login: "kit", fullName: "Kit Alvarez", avatarUrl: "" },
+    state: "approved",
+    body: "Reads correctly against the March policy.",
+    submittedAt: "2026-08-20T10:00:00Z",
+    stale: false,
+    dismissed: false,
+    ...overrides,
+  };
+}
+
+function version(
+  overrides: Partial<DocumentVersionRecord> = {},
+): DocumentVersionRecord {
+  return {
+    version: 3,
+    tagName: "v3",
+    sha: "abcdef0123456789",
+    createdAt: "2026-08-21T09:00:00Z",
+    submission: {
+      number: 12,
+      title: "Updated liability clause",
+      body: "Updated liability clause",
+      submittedBy: "maya",
+      submittedAt: "2026-08-20T08:00:00Z",
+      mergedAt: "2026-08-21T09:00:00Z",
+      mergedBy: "dana",
+    },
+    reviews: [review()],
+    discussionCount: 3,
+    ...overrides,
+  };
+}
+
+const GENERATED_AT = new Date("2026-08-24T12:00:00Z");
+
+function record(versions: DocumentVersionRecord[]) {
+  return buildAuditRecord({
+    owner: "alice",
+    repo: "quarterly-report",
+    versions,
+    generatedAt: GENERATED_AT,
+  });
+}
+
+test("the file is named for the document and the day it was taken", () => {
+  expect(
+    buildAuditRecordFileName("quarterly-report", new Date(2026, 7, 4)),
+  ).toBe("quarterly-report-audit-record-2026-08-04.html");
+});
+
+test("the record names the document, the workspace, and the version on record", () => {
+  const { html } = record([version(), version({ version: 2, tagName: "v2" })]);
+
+  expect(html).toContain("<title>Quarterly Report — audit record</title>");
+  expect(html).toContain("alice/quarterly-report");
+  expect(html).toContain("<dd>v3</dd>");
+  expect(html).toContain("<dd>2</dd>");
+});
+
+test("a tag that is not just the version number is named alongside it", () => {
+  const { html } = record([version({ tagName: "release-2026-08" })]);
+
+  expect(html).toContain("v3 (release-2026-08)");
+});
+
+test("every version is a section, newest first, with its commit", () => {
+  const { html } = record([
+    version({ version: 2, tagName: "v2", sha: "1111111111111111" }),
+    version({ version: 3, tagName: "v3", sha: "2222222222222222" }),
+  ]);
+
+  const tags = [...html.matchAll(/record-version-tag">(v\d+)</g)].map(
+    (match) => match[1],
+  );
+  expect(tags).toEqual(["v3", "v2"]);
+  expect(html).toContain("2222222222222222");
+  expect(html).toContain("1111111111111111");
+});
+
+test("a review that no longer counts stays on the record, labelled", () => {
+  const { html } = record([
+    version({
+      reviews: [
+        review({ stale: true }),
+        review({
+          id: 2,
+          author: { login: "dana", fullName: "", avatarUrl: "" },
+          state: "changes_requested",
+          dismissed: true,
+          body: "",
+        }),
+      ],
+    }),
+  ]);
+
+  expect(html).toContain("Kit Alvarez (kit)");
+  expect(html).toContain("superseded by a later upload");
+  expect(html).toContain("Dana (dana)");
+  expect(html).toContain("Requested changes");
+  expect(html).toContain("dismissed");
+  expect(html).toContain("No comment");
+});
+
+test("a version nobody reviewed says so rather than showing an empty table", () => {
+  const { html } = record([version({ reviews: [] })]);
+
+  expect(html).toContain("No reviews were recorded on this change.");
+});
+
+test("a version with no surviving change record is still on the record", () => {
+  const { html } = record([version({ submission: null })]);
+
+  expect(html).toContain("Version 3");
+  expect(html).toContain("No change record survives for this version");
+});
+
+test("a document with nothing published exports an honest empty record", () => {
+  const { html } = record([]);
+
+  expect(html).toContain("None published");
+  expect(html).toContain("no published versions yet");
+});
+
+test("what a person typed cannot become markup", () => {
+  const { html } = record([
+    version({
+      submission: {
+        number: 12,
+        title: "x",
+        body: "<script>alert(1)</script>",
+        submittedBy: "maya",
+        submittedAt: "2026-08-20T08:00:00Z",
+        mergedAt: "2026-08-21T09:00:00Z",
+        mergedBy: "dana",
+      },
+      reviews: [review({ body: "<img src=x onerror=alert(1)>" })],
+    }),
+  ]);
+
+  expect(html).not.toContain("<script>alert(1)</script>");
+  expect(html).not.toContain("<img src=x");
+  expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+});

--- a/apps/app/auditRecord.ts
+++ b/apps/app/auditRecord.ts
@@ -1,0 +1,359 @@
+/**
+ * The audit record, as a file somebody outside Bindersnap can read.
+ *
+ * The product's claim is that the approval trail is exportable for a regulator.
+ * A regulator does not have a login, so the export cannot be a link into the
+ * app, and it cannot be a screenshot either — it has to state who signed off on
+ * every version, what they said, and when, in a document that opens on its own.
+ *
+ * So this builds one self-contained HTML file out of the history payload the
+ * History tab already loaded. Nothing new is fetched and nothing is stored:
+ * every fact in the file is a fact Gitea already holds, and re-exporting the
+ * same document produces the same record. It prints to PDF straight from the
+ * browser, which is how a record actually gets attached to an audit response.
+ *
+ * Pure on purpose. The component only hands it data and saves the result.
+ */
+
+import type { DocumentVersionRecord, VersionReview } from "./api";
+import {
+  capitalizeFirst,
+  formatDocumentName,
+  formatTimestamp,
+  parseChangeTitle,
+} from "./documentDisplay";
+
+/** What a verdict is called in the record. */
+const REVIEW_VERDICTS: Record<VersionReview["state"], string> = {
+  approved: "Signed off",
+  changes_requested: "Requested changes",
+  commented: "Commented",
+  other: "Reviewed",
+};
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export interface AuditRecordInput {
+  owner: string;
+  repo: string;
+  versions: DocumentVersionRecord[];
+  /** When the export was taken. Passed in so the output is testable. */
+  generatedAt: Date;
+}
+
+export interface AuditRecord {
+  fileName: string;
+  html: string;
+}
+
+/**
+ * "quarterly-report-audit-record-2026-08-24.html".
+ *
+ * Dated because a record is a snapshot — two exports of the same document a
+ * month apart are two different documents, and a regulator's folder should not
+ * silently overwrite one with the other.
+ */
+export function buildAuditRecordFileName(
+  repo: string,
+  generatedAt: Date,
+): string {
+  const stamp = [
+    generatedAt.getFullYear(),
+    String(generatedAt.getMonth() + 1).padStart(2, "0"),
+    String(generatedAt.getDate()).padStart(2, "0"),
+  ].join("-");
+  return `${repo}-audit-record-${stamp}.html`;
+}
+
+/** "Maya" — a login, made presentable, with the login kept alongside it. */
+function personLabel(login: string | null | undefined): string {
+  const trimmed = (login ?? "").trim();
+  if (!trimmed) return "Unknown";
+  return `${capitalizeFirst(trimmed)} (${trimmed})`;
+}
+
+function reviewerLabel(review: VersionReview): string {
+  const login = review.author.login.trim();
+  const fullName = review.author.fullName.trim();
+  if (!login) return "Unknown";
+  return `${fullName || capitalizeFirst(login)} (${login})`;
+}
+
+/**
+ * The qualifiers that decide whether a sign-off still counts.
+ *
+ * A stale or dismissed approval stays in the record — dropping it would be
+ * editing history — but it has to be labelled, or the file reads as though the
+ * version carried more sign-off than it did.
+ */
+function reviewQualifier(review: VersionReview): string {
+  const notes: string[] = [];
+  if (review.stale) notes.push("superseded by a later upload");
+  if (review.dismissed) notes.push("dismissed");
+  return notes.join(", ");
+}
+
+function renderReviewRows(reviews: VersionReview[]): string {
+  if (reviews.length === 0) {
+    return `<tr><td class="record-empty" colspan="4">No reviews were recorded on this change.</td></tr>`;
+  }
+
+  return reviews
+    .map((review) => {
+      const qualifier = reviewQualifier(review);
+      const verdict = REVIEW_VERDICTS[review.state];
+      return [
+        "<tr>",
+        `<td>${escapeHtml(reviewerLabel(review))}</td>`,
+        `<td>${escapeHtml(verdict)}${
+          qualifier
+            ? ` <span class="record-note">(${escapeHtml(qualifier)})</span>`
+            : ""
+        }</td>`,
+        `<td class="record-stamp">${escapeHtml(formatTimestamp(review.submittedAt) || "Unknown")}</td>`,
+        `<td>${review.body.trim() ? escapeHtml(review.body.trim()) : '<span class="record-note">No comment</span>'}</td>`,
+        "</tr>",
+      ].join("");
+    })
+    .join("");
+}
+
+function renderVersion(entry: DocumentVersionRecord): string {
+  const submission = entry.submission;
+  const title = submission
+    ? parseChangeTitle(submission.body, submission.submittedBy)
+    : `Version ${entry.version}`;
+
+  const facts: [string, string][] = [
+    ["Published", formatTimestamp(entry.createdAt) || "Unknown"],
+    ["Tag", entry.tagName],
+    ["Commit", entry.sha],
+  ];
+
+  if (submission) {
+    facts.push(
+      ["Change", `#${submission.number}`],
+      ["Submitted by", personLabel(submission.submittedBy)],
+      ["Submitted", formatTimestamp(submission.submittedAt) || "Unknown"],
+      ["Published by", personLabel(submission.mergedBy)],
+    );
+  } else {
+    // A version with no surviving change record is still on the record. Saying
+    // so is the honest answer; leaving the rows out looks like an omission.
+    facts.push(["Change", "No change record survives for this version"]);
+  }
+
+  facts.push([
+    "Discussion",
+    entry.discussionCount === 1
+      ? "1 comment"
+      : `${entry.discussionCount} comments`,
+  ]);
+
+  const factRows = facts
+    .map(
+      ([label, value]) =>
+        `<div class="record-fact"><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`,
+    )
+    .join("");
+
+  return [
+    '<section class="record-version">',
+    '<header class="record-version-head">',
+    `<span class="record-version-tag">v${entry.version}</span>`,
+    `<h2>${escapeHtml(title)}</h2>`,
+    "</header>",
+    `<dl class="record-facts">${factRows}</dl>`,
+    '<table class="record-reviews">',
+    '<colgroup><col class="record-col-who" /><col class="record-col-verdict" /><col class="record-col-when" /><col /></colgroup>',
+    "<thead><tr><th>Reviewer</th><th>Verdict</th><th>When</th><th>Comment</th></tr></thead>",
+    `<tbody>${renderReviewRows(entry.reviews)}</tbody>`,
+    "</table>",
+    "</section>",
+  ].join("");
+}
+
+/**
+ * The exported record.
+ *
+ * Styles are inlined and the values mirror `bindersnap-tokens.css` by name —
+ * the file has to open with no network and no stylesheet next to it, so the
+ * tokens come along as custom properties rather than as an import.
+ */
+export function buildAuditRecord(input: AuditRecordInput): AuditRecord {
+  const { owner, repo, versions, generatedAt } = input;
+  const documentName = formatDocumentName(repo);
+  const newestFirst = [...versions].sort((a, b) => b.version - a.version);
+  const current = newestFirst[0] ?? null;
+
+  const summary: [string, string][] = [
+    ["Workspace", `${owner}/${repo}`],
+    // The tag is normally just "v3" — printing "v3 (v3)" is the same word
+    // twice, so the tag only earns its parentheses when it differs.
+    [
+      "Version on record",
+      current
+        ? current.tagName === `v${current.version}`
+          ? `v${current.version}`
+          : `v${current.version} (${current.tagName})`
+        : "None published",
+    ],
+    ["Published versions", String(newestFirst.length)],
+    ["Exported", formatTimestamp(generatedAt.toISOString()) || "Unknown"],
+  ];
+
+  const summaryRows = summary
+    .map(
+      ([label, value]) =>
+        `<div class="record-fact"><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`,
+    )
+    .join("");
+
+  const body =
+    newestFirst.length === 0
+      ? '<p class="record-empty-state">This document has no published versions yet, so there is nothing on the record.</p>'
+      : newestFirst.map(renderVersion).join("");
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${escapeHtml(documentName)} — audit record</title>
+<style>
+:root {
+  --color-coral: #E85D26;
+  --color-ink: #1C1917;
+  --color-ink-mid: #44403C;
+  --color-paper: #FAFAF7;
+  --color-paper-warm: #F5F0E8;
+  --color-muted: #78716C;
+  --color-rule: #E7E5E4;
+  --font-serif: 'Lora', Georgia, serif;
+  --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'Geist Mono', ui-monospace, 'SFMono-Regular', Menlo, monospace;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 48px 24px 96px;
+  background: var(--color-paper);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.6;
+}
+main { max-width: 820px; margin: 0 auto; }
+.record-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-coral);
+  margin: 0 0 8px;
+}
+h1 {
+  font-family: var(--font-serif);
+  font-size: 34px;
+  line-height: 1.2;
+  margin: 0 0 8px;
+}
+.record-lede { color: var(--color-muted); margin: 0 0 32px; max-width: 60ch; }
+.record-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px 24px;
+  margin: 0 0 24px;
+}
+.record-fact dt {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+.record-fact dd { margin: 0; word-break: break-word; }
+.record-summary {
+  background: var(--color-paper-warm);
+  border: 1px solid var(--color-rule);
+  border-radius: 16px;
+  padding: 24px;
+  margin: 0 0 48px;
+}
+.record-summary .record-facts { margin: 0; }
+.record-version {
+  border-top: 1px solid var(--color-rule);
+  padding: 32px 0 8px;
+  break-inside: avoid;
+}
+.record-version-head { display: flex; align-items: baseline; gap: 12px; }
+.record-version-tag {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--color-coral);
+  border: 1px solid var(--color-rule);
+  border-radius: 9999px;
+  padding: 2px 10px;
+  background: #FFFFFF;
+}
+h2 { font-family: var(--font-serif); font-size: 22px; margin: 0 0 16px; }
+table.record-reviews { width: 100%; border-collapse: collapse; margin: 0 0 8px; table-layout: fixed; }
+table.record-reviews col.record-col-who { width: 24%; }
+table.record-reviews col.record-col-verdict { width: 20%; }
+table.record-reviews col.record-col-when { width: 22%; }
+table.record-reviews th {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  font-weight: 500;
+  border-bottom: 1px solid var(--color-rule);
+  padding: 6px 12px 6px 0;
+}
+table.record-reviews td {
+  vertical-align: top;
+  padding: 10px 12px 10px 0;
+  border-bottom: 1px solid var(--color-rule);
+  color: var(--color-ink-mid);
+}
+.record-stamp { font-family: var(--font-mono); font-size: 12px; }
+.record-note { color: var(--color-muted); font-style: italic; }
+.record-empty, .record-empty-state { color: var(--color-muted); }
+footer {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--color-rule);
+  color: var(--color-muted);
+  font-size: 13px;
+}
+@media print {
+  body { background: #FFFFFF; padding: 0; font-size: 12px; }
+  .record-summary { background: none; }
+}
+</style>
+</head>
+<body>
+<main>
+<p class="record-eyebrow">Audit record</p>
+<h1>${escapeHtml(documentName)}</h1>
+<p class="record-lede">Every published version of this document, who submitted it, who signed it off, and when. Each version is an immutable tag on the document's repository — the commit named below is the file that was approved.</p>
+<div class="record-summary"><dl class="record-facts">${summaryRows}</dl></div>
+${body}
+<footer>Exported from Bindersnap. This record is generated from the document's version history; it is not editable and re-exporting reproduces it.</footer>
+</main>
+</body>
+</html>
+`;
+
+  return { fileName: buildAuditRecordFileName(repo, generatedAt), html };
+}

--- a/apps/app/auditRecord.ts
+++ b/apps/app/auditRecord.ts
@@ -131,10 +131,12 @@ function renderVersion(entry: DocumentVersionRecord): string {
     ? parseChangeTitle(submission.body, submission.submittedBy)
     : `Version ${entry.version}`;
 
+  // A version number is the whole identity a reader needs. The tag and the
+  // commit underneath it are how Bindersnap stores that version, not what the
+  // version is — and nobody reading this record can look either one up, so
+  // printing them only invites a question the file cannot answer.
   const facts: [string, string][] = [
     ["Published", formatTimestamp(entry.createdAt) || "Unknown"],
-    ["Tag", entry.tagName],
-    ["Commit", entry.sha],
   ];
 
   if (submission) {
@@ -167,7 +169,7 @@ function renderVersion(entry: DocumentVersionRecord): string {
   return [
     '<section class="record-version">',
     '<header class="record-version-head">',
-    `<span class="record-version-tag">v${entry.version}</span>`,
+    `<span class="record-version-label">v${entry.version}</span>`,
     `<h2>${escapeHtml(title)}</h2>`,
     "</header>",
     `<dl class="record-facts">${factRows}</dl>`,
@@ -194,17 +196,10 @@ export function buildAuditRecord(input: AuditRecordInput): AuditRecord {
   const current = newestFirst[0] ?? null;
 
   const summary: [string, string][] = [
-    ["Workspace", `${owner}/${repo}`],
-    // The tag is normally just "v3" — printing "v3 (v3)" is the same word
-    // twice, so the tag only earns its parentheses when it differs.
-    [
-      "Version on record",
-      current
-        ? current.tagName === `v${current.version}`
-          ? `v${current.version}`
-          : `v${current.version} (${current.tagName})`
-        : "None published",
-    ],
+    // The owner, not "owner/repo" — the slug is a storage path, and the
+    // document already has a name at the top of the page.
+    ["Workspace", owner],
+    ["Version on record", current ? `v${current.version}` : "None published"],
     ["Published versions", String(newestFirst.length)],
     ["Exported", formatTimestamp(generatedAt.toISOString()) || "Unknown"],
   ];
@@ -294,7 +289,7 @@ h1 {
   break-inside: avoid;
 }
 .record-version-head { display: flex; align-items: baseline; gap: 12px; }
-.record-version-tag {
+.record-version-label {
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.06em;
@@ -346,7 +341,7 @@ footer {
 <main>
 <p class="record-eyebrow">Audit record</p>
 <h1>${escapeHtml(documentName)}</h1>
-<p class="record-lede">Every published version of this document, who submitted it, who signed it off, and when. Each version is an immutable tag on the document's repository — the commit named below is the file that was approved.</p>
+<p class="record-lede">Every published version of this document, who submitted it, who signed it off, and when. A published version cannot be altered — changing the document means a new version, reviewed again.</p>
 <div class="record-summary"><dl class="record-facts">${summaryRows}</dl></div>
 ${body}
 <footer>Exported from Bindersnap. This record is generated from the document's version history; it is not editable and re-exporting reproduces it.</footer>

--- a/apps/app/auditRecord.ts
+++ b/apps/app/auditRecord.ts
@@ -3,7 +3,7 @@
  *
  * The product's claim is that the approval trail is exportable for a regulator.
  * A regulator does not have a login, so the export cannot be a link into the
- * app, and it cannot be a screenshot either — it has to state who signed off on
+ * app, and it cannot be a screenshot either — it has to state who approved
  * every version, what they said, and when, in a document that opens on its own.
  *
  * So this builds one self-contained HTML file out of the history payload the
@@ -23,13 +23,26 @@ import {
   parseChangeTitle,
 } from "./documentDisplay";
 
-/** What a verdict is called in the record. */
+/** What a verdict is called in the record. Bindersnap says "approved". */
 const REVIEW_VERDICTS: Record<VersionReview["state"], string> = {
-  approved: "Signed off",
+  approved: "Approved",
   changes_requested: "Requested changes",
   commented: "Commented",
   other: "Reviewed",
 };
+
+/**
+ * Whether a review belongs in the record of a *published* version.
+ *
+ * A request for changes is a step on the way, not an outcome: the version
+ * underneath it only exists because that request was answered and the change
+ * was then approved. Printing it invites an auditor to ask what became of it,
+ * and the answer is the version they are already holding. The approvals — and
+ * what the approvers said — are what the record is for.
+ */
+function isRecordedReview(review: VersionReview): boolean {
+  return review.state !== "changes_requested";
+}
 
 export function escapeHtml(value: string): string {
   return value
@@ -87,11 +100,11 @@ function reviewerLabel(review: VersionReview): string {
 }
 
 /**
- * The qualifiers that decide whether a sign-off still counts.
+ * The qualifiers that decide whether an approval still counts.
  *
  * A stale or dismissed approval stays in the record — dropping it would be
  * editing history — but it has to be labelled, or the file reads as though the
- * version carried more sign-off than it did.
+ * version carried more approval than it did.
  */
 function reviewQualifier(review: VersionReview): string {
   const notes: string[] = [];
@@ -100,9 +113,10 @@ function reviewQualifier(review: VersionReview): string {
   return notes.join(", ");
 }
 
-function renderReviewRows(reviews: VersionReview[]): string {
+function renderReviewRows(allReviews: VersionReview[]): string {
+  const reviews = allReviews.filter(isRecordedReview);
   if (reviews.length === 0) {
-    return `<tr><td class="record-empty" colspan="4">No reviews were recorded on this change.</td></tr>`;
+    return `<tr><td class="record-empty" colspan="4">No approvals were recorded on this change.</td></tr>`;
   }
 
   return reviews
@@ -169,7 +183,7 @@ function renderVersion(entry: DocumentVersionRecord): string {
   return [
     '<section class="record-version">',
     '<header class="record-version-head">',
-    `<span class="record-version-label">v${entry.version}</span>`,
+    `<p class="record-version-label">Version ${entry.version}</p>`,
     `<h2>${escapeHtml(title)}</h2>`,
     "</header>",
     `<dl class="record-facts">${factRows}</dl>`,
@@ -199,7 +213,10 @@ export function buildAuditRecord(input: AuditRecordInput): AuditRecord {
     // The owner, not "owner/repo" — the slug is a storage path, and the
     // document already has a name at the top of the page.
     ["Workspace", owner],
-    ["Version on record", current ? `v${current.version}` : "None published"],
+    [
+      "Version on record",
+      current ? `Version ${current.version}` : "None published",
+    ],
     ["Published versions", String(newestFirst.length)],
     ["Exported", formatTimestamp(generatedAt.toISOString()) || "Unknown"],
   ];
@@ -223,117 +240,142 @@ export function buildAuditRecord(input: AuditRecordInput): AuditRecord {
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>${escapeHtml(documentName)} — audit record</title>
 <style>
+/*
+ * A printed document that happens to open in a browser.
+ *
+ * This ends up in an audit binder or attached to a regulator's email as a PDF,
+ * so it is set like paper: black on white, hairline rules, no fills, nothing
+ * that costs toner or reads as a web page. The brand lives in the typography —
+ * the serif for headings, the sans for everything else — not in colour.
+ */
 :root {
-  --color-coral: #E85D26;
-  --color-ink: #1C1917;
-  --color-ink-mid: #44403C;
-  --color-paper: #FAFAF7;
-  --color-paper-warm: #F5F0E8;
-  --color-muted: #78716C;
-  --color-rule: #E7E5E4;
-  --font-serif: 'Lora', Georgia, serif;
-  --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-mono: 'Geist Mono', ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  --ink: #000000;
+  --ink-soft: #222222;
+  --label: #444444;
+  --rule: #000000;
+  --hairline: #BBBBBB;
+  --font-serif: 'Lora', Georgia, 'Times New Roman', serif;
+  --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
 }
+@page { margin: 18mm; }
 * { box-sizing: border-box; }
 body {
   margin: 0;
-  padding: 48px 24px 96px;
-  background: var(--color-paper);
-  color: var(--color-ink);
+  padding: 32pt 24pt 48pt;
+  background: #FFFFFF;
+  color: var(--ink);
   font-family: var(--font-sans);
-  font-size: 15px;
-  line-height: 1.6;
+  font-size: 10.5pt;
+  line-height: 1.5;
+  -webkit-print-color-adjust: exact;
 }
-main { max-width: 820px; margin: 0 auto; }
+main { max-width: 46em; margin: 0 auto; }
 .record-eyebrow {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.12em;
+  margin: 0 0 6pt;
+  font-size: 8pt;
+  font-weight: 500;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--color-coral);
-  margin: 0 0 8px;
+  color: var(--label);
 }
 h1 {
   font-family: var(--font-serif);
-  font-size: 34px;
-  line-height: 1.2;
-  margin: 0 0 8px;
+  font-size: 22pt;
+  line-height: 1.15;
+  font-weight: 700;
+  margin: 0 0 8pt;
 }
-.record-lede { color: var(--color-muted); margin: 0 0 32px; max-width: 60ch; }
+.record-lede {
+  margin: 0 0 20pt;
+  max-width: 62ch;
+  color: var(--ink-soft);
+}
+/* The summary is the cover block: ruled off, not boxed in. */
+.record-summary {
+  border-top: 1.25pt solid var(--rule);
+  border-bottom: 0.5pt solid var(--hairline);
+  padding: 12pt 0;
+  margin: 0 0 8pt;
+}
 .record-facts {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 8px 24px;
-  margin: 0 0 24px;
+  grid-template-columns: repeat(auto-fit, minmax(150pt, 1fr));
+  gap: 10pt 24pt;
+  margin: 0 0 16pt;
 }
 .record-fact dt {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: 7.5pt;
+  font-weight: 500;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--color-muted);
+  color: var(--label);
+  margin-bottom: 1pt;
 }
 .record-fact dd { margin: 0; word-break: break-word; }
-.record-summary {
-  background: var(--color-paper-warm);
-  border: 1px solid var(--color-rule);
-  border-radius: 16px;
-  padding: 24px;
-  margin: 0 0 48px;
-}
 .record-summary .record-facts { margin: 0; }
 .record-version {
-  border-top: 1px solid var(--color-rule);
-  padding: 32px 0 8px;
+  border-top: 0.5pt solid var(--hairline);
+  padding-top: 18pt;
+  margin-top: 18pt;
   break-inside: avoid;
+  page-break-inside: avoid;
 }
-.record-version-head { display: flex; align-items: baseline; gap: 12px; }
 .record-version-label {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  letter-spacing: 0.06em;
-  color: var(--color-coral);
-  border: 1px solid var(--color-rule);
-  border-radius: 9999px;
-  padding: 2px 10px;
-  background: #FFFFFF;
+  margin: 0 0 2pt;
+  font-size: 8pt;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--label);
 }
-h2 { font-family: var(--font-serif); font-size: 22px; margin: 0 0 16px; }
-table.record-reviews { width: 100%; border-collapse: collapse; margin: 0 0 8px; table-layout: fixed; }
+h2 {
+  font-family: var(--font-serif);
+  font-size: 15pt;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0 0 14pt;
+}
+table.record-reviews {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  margin: 0;
+}
 table.record-reviews col.record-col-who { width: 24%; }
-table.record-reviews col.record-col-verdict { width: 20%; }
+table.record-reviews col.record-col-verdict { width: 18%; }
 table.record-reviews col.record-col-when { width: 22%; }
+/* Repeat the column headings when a long trail runs onto a second page. */
+table.record-reviews thead { display: table-header-group; }
+table.record-reviews tr { break-inside: avoid; page-break-inside: avoid; }
 table.record-reviews th {
   text-align: left;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-muted);
+  font-size: 7.5pt;
   font-weight: 500;
-  border-bottom: 1px solid var(--color-rule);
-  padding: 6px 12px 6px 0;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--label);
+  border-bottom: 1pt solid var(--rule);
+  padding: 0 10pt 4pt 0;
 }
 table.record-reviews td {
   vertical-align: top;
-  padding: 10px 12px 10px 0;
-  border-bottom: 1px solid var(--color-rule);
-  color: var(--color-ink-mid);
+  padding: 7pt 10pt 7pt 0;
+  border-bottom: 0.5pt solid var(--hairline);
+  color: var(--ink-soft);
 }
-.record-stamp { font-family: var(--font-mono); font-size: 12px; }
-.record-note { color: var(--color-muted); font-style: italic; }
-.record-empty, .record-empty-state { color: var(--color-muted); }
+.record-stamp { white-space: normal; }
+.record-note { color: var(--label); font-style: italic; }
+.record-empty, .record-empty-state { color: var(--label); font-style: italic; }
 footer {
-  margin-top: 48px;
-  padding-top: 24px;
-  border-top: 1px solid var(--color-rule);
-  color: var(--color-muted);
-  font-size: 13px;
+  margin-top: 24pt;
+  padding-top: 8pt;
+  border-top: 0.5pt solid var(--hairline);
+  color: var(--label);
+  font-size: 8.5pt;
 }
 @media print {
-  body { background: #FFFFFF; padding: 0; font-size: 12px; }
-  .record-summary { background: none; }
+  body { padding: 0; }
+  h1, h2 { page-break-after: avoid; }
 }
 </style>
 </head>
@@ -341,7 +383,7 @@ footer {
 <main>
 <p class="record-eyebrow">Audit record</p>
 <h1>${escapeHtml(documentName)}</h1>
-<p class="record-lede">Every published version of this document, who submitted it, who signed it off, and when. A published version cannot be altered — changing the document means a new version, reviewed again.</p>
+<p class="record-lede">Every published version of this document, who submitted it, who approved it, and when. A published version cannot be altered — changing the document means a new version, reviewed again.</p>
 <div class="record-summary"><dl class="record-facts">${summaryRows}</dl></div>
 ${body}
 <footer>Exported from Bindersnap. This record is generated from the document's version history; it is not editable and re-exporting reproduces it.</footer>

--- a/apps/app/components/DocumentHistory.test.ts
+++ b/apps/app/components/DocumentHistory.test.ts
@@ -358,3 +358,40 @@ test("nothing published yet says so instead of drawing an empty line", async () 
 
   unmount();
 });
+
+test("the whole trail can leave as one file", async () => {
+  payload = { versions: [version()], canonicalFile: null };
+
+  const downloads: { name: string; href: string }[] = [];
+  const anchorProto = (
+    window as unknown as { HTMLAnchorElement: { prototype: HTMLAnchorElement } }
+  ).HTMLAnchorElement.prototype;
+  const realClick = anchorProto.click;
+  anchorProto.click = function capture(this: HTMLAnchorElement) {
+    downloads.push({ name: this.download, href: this.href });
+  };
+  const realCreate = URL.createObjectURL;
+  URL.createObjectURL = () => "blob:record";
+
+  const { container, unmount } = await render(
+    createElement(DocumentHistory, historyProps()),
+  );
+
+  const button = container.querySelector(
+    ".doc-record-export-btn",
+  ) as HTMLButtonElement;
+  expect(button.textContent).toContain("Export record");
+
+  flushSync(() => {
+    button.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+
+  expect(downloads.length).toBe(1);
+  expect(downloads[0]!.name).toMatch(
+    /^contract-audit-record-\d{4}-\d{2}-\d{2}\.html$/,
+  );
+
+  anchorProto.click = realClick;
+  URL.createObjectURL = realCreate;
+  unmount();
+});

--- a/apps/app/components/DocumentHistory.tsx
+++ b/apps/app/components/DocumentHistory.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
-import { Download, Eye } from "lucide-react";
+import { Download, Eye, FileDown } from "lucide-react";
 
 import type { DocumentVersionRecord } from "../api";
 import { getDocumentHistory } from "../api";
+import { buildAuditRecord } from "../auditRecord";
 import type { HistoryEntry, HistoryPerson } from "../documentHistory";
 import { buildHistoryEntries } from "../documentHistory";
 import { PersonAvatar } from "./PersonAvatar";
@@ -19,6 +20,36 @@ interface DocumentHistoryProps {
   onViewVersion: (tagName: string, version: number) => void;
   /** Opens the change review a version came from, in the Changes tab. */
   onOpenChange: (changeNumber: number) => void;
+}
+
+/**
+ * Hand the built record to the browser as a file.
+ *
+ * A blob and an anchor, because the record is assembled here — there is no URL
+ * to link to, and there should not be: the export is a view of history the app
+ * already loaded, not a new thing the server has to keep.
+ */
+function saveAuditRecord(
+  owner: string,
+  repo: string,
+  versions: DocumentVersionRecord[],
+): void {
+  const { fileName, html } = buildAuditRecord({
+    owner,
+    repo,
+    versions,
+    generatedAt: new Date(),
+  });
+  const blob = new Blob([html], { type: "text/html;charset=utf-8" });
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = fileName;
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(objectUrl);
 }
 
 /** One name on the spline: a face, who they are, and what they did. */
@@ -143,114 +174,134 @@ export function DocumentHistory({
   const entries: HistoryEntry[] = buildHistoryEntries(versions, owner, repo);
 
   return (
-    <ol className="doc-spline">
-      {entries.map((entry) => {
-        const isViewing = viewingVersion === entry.version;
+    <>
+      {/* The record, on its way out of the building. The spline is the trail
+          on screen; this is the same trail as a file an auditor can open. */}
+      <div className="doc-record-export">
+        <p className="doc-record-export-copy">
+          Every version, every sign-off, in one file you can send to an auditor.
+        </p>
+        <button
+          className="bs-btn bs-btn-secondary doc-record-export-btn"
+          type="button"
+          onClick={() => saveAuditRecord(owner, repo, versions)}
+        >
+          <FileDown size={15} strokeWidth={1.5} aria-hidden="true" />
+          Export record
+        </button>
+      </div>
 
-        return (
-          <li
-            className={`doc-spline-entry${
-              isViewing ? " doc-spline-entry--viewing" : ""
-            }`}
-            key={entry.key}
-          >
-            <span className="doc-spline-knot" aria-hidden="true">
-              {entry.label}
-            </span>
+      <ol className="doc-spline">
+        {entries.map((entry) => {
+          const isViewing = viewingVersion === entry.version;
 
-            <div className="doc-spline-body">
-              <div className="doc-spline-head">
-                <h3 className="doc-spline-title">
-                  {entry.changeHref && entry.changeNumber !== null ? (
-                    <a
-                      className="doc-spline-link"
-                      href={entry.changeHref}
-                      onClick={(event) => {
-                        // Let a modifier click open the review in a new tab;
-                        // a plain click is a route change, not a page load.
-                        if (
-                          event.defaultPrevented ||
-                          event.metaKey ||
-                          event.ctrlKey ||
-                          event.shiftKey ||
-                          event.altKey ||
-                          event.button !== 0
-                        ) {
-                          return;
-                        }
-                        event.preventDefault();
-                        onOpenChange(entry.changeNumber!);
-                      }}
-                    >
-                      {entry.title}
-                    </a>
-                  ) : (
-                    entry.title
-                  )}
-                  {/* The knot carries the version visually; a reader who
+          return (
+            <li
+              className={`doc-spline-entry${
+                isViewing ? " doc-spline-entry--viewing" : ""
+              }`}
+              key={entry.key}
+            >
+              <span className="doc-spline-knot" aria-hidden="true">
+                {entry.label}
+              </span>
+
+              <div className="doc-spline-body">
+                <div className="doc-spline-head">
+                  <h3 className="doc-spline-title">
+                    {entry.changeHref && entry.changeNumber !== null ? (
+                      <a
+                        className="doc-spline-link"
+                        href={entry.changeHref}
+                        onClick={(event) => {
+                          // Let a modifier click open the review in a new tab;
+                          // a plain click is a route change, not a page load.
+                          if (
+                            event.defaultPrevented ||
+                            event.metaKey ||
+                            event.ctrlKey ||
+                            event.shiftKey ||
+                            event.altKey ||
+                            event.button !== 0
+                          ) {
+                            return;
+                          }
+                          event.preventDefault();
+                          onOpenChange(entry.changeNumber!);
+                        }}
+                      >
+                        {entry.title}
+                      </a>
+                    ) : (
+                      entry.title
+                    )}
+                    {/* The knot carries the version visually; a reader who
                       cannot see the rail still needs to hear it. */}
-                  <span className="sr-only">{entry.label}</span>
-                </h3>
+                    <span className="sr-only">{entry.label}</span>
+                  </h3>
 
-                <div className="doc-spline-actions">
-                  <button
-                    className="bs-btn bs-btn-secondary doc-spline-icon-btn"
-                    type="button"
-                    title={`View ${entry.label}`}
-                    aria-label={`View ${entry.label}`}
-                    onClick={() => onViewVersion(entry.tagName, entry.version)}
-                  >
-                    <Eye size={15} strokeWidth={1.5} aria-hidden="true" />
-                  </button>
-                  {hasCanonicalFile ? (
+                  <div className="doc-spline-actions">
                     <button
-                      className="bs-btn bs-btn-secondary doc-spline-icon-btn vault-version-download"
+                      className="bs-btn bs-btn-secondary doc-spline-icon-btn"
                       type="button"
-                      disabled={downloadingRef === entry.tagName}
-                      title={
-                        downloadingRef === entry.tagName
-                          ? `Downloading ${entry.label}…`
-                          : `Download ${entry.label}`
-                      }
-                      aria-label={
-                        downloadingRef === entry.tagName
-                          ? `Downloading ${entry.label}…`
-                          : `Download ${entry.label}`
-                      }
+                      title={`View ${entry.label}`}
+                      aria-label={`View ${entry.label}`}
                       onClick={() =>
-                        onDownloadVersion(entry.tagName, entry.version)
+                        onViewVersion(entry.tagName, entry.version)
                       }
                     >
-                      <Download
-                        size={15}
-                        strokeWidth={1.5}
-                        aria-hidden="true"
-                      />
+                      <Eye size={15} strokeWidth={1.5} aria-hidden="true" />
                     </button>
+                    {hasCanonicalFile ? (
+                      <button
+                        className="bs-btn bs-btn-secondary doc-spline-icon-btn vault-version-download"
+                        type="button"
+                        disabled={downloadingRef === entry.tagName}
+                        title={
+                          downloadingRef === entry.tagName
+                            ? `Downloading ${entry.label}…`
+                            : `Download ${entry.label}`
+                        }
+                        aria-label={
+                          downloadingRef === entry.tagName
+                            ? `Downloading ${entry.label}…`
+                            : `Download ${entry.label}`
+                        }
+                        onClick={() =>
+                          onDownloadVersion(entry.tagName, entry.version)
+                        }
+                      >
+                        <Download
+                          size={15}
+                          strokeWidth={1.5}
+                          aria-hidden="true"
+                        />
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+
+                {/* The two people the record is about, on the line itself. */}
+                <div className="doc-spline-people">
+                  {entry.author ? (
+                    <SplinePerson person={entry.author} role="wrote" />
+                  ) : null}
+                  {entry.publisher ? (
+                    <SplinePerson person={entry.publisher} role="published" />
                   ) : null}
                 </div>
-              </div>
 
-              {/* The two people the record is about, on the line itself. */}
-              <div className="doc-spline-people">
-                {entry.author ? (
-                  <SplinePerson person={entry.author} role="wrote" />
-                ) : null}
-                {entry.publisher ? (
-                  <SplinePerson person={entry.publisher} role="published" />
-                ) : null}
+                <p className="doc-spline-meta">
+                  <time dateTime={entry.createdAt} title={entry.publishedAt}>
+                    {entry.publishedOn}
+                  </time>
+                  {entry.comments ? ` · ${entry.comments}` : ""}
+                </p>
               </div>
-
-              <p className="doc-spline-meta">
-                <time dateTime={entry.createdAt} title={entry.publishedAt}>
-                  {entry.publishedOn}
-                </time>
-                {entry.comments ? ` · ${entry.comments}` : ""}
-              </p>
-            </div>
-          </li>
-        );
-      })}
-    </ol>
+            </li>
+          );
+        })}
+      </ol>
+    </>
   );
 }


### PR DESCRIPTION
## The problem

The pitch is that the approval trail is exportable for a regulator. It wasn't. The trail lived inside the app, behind a login the auditor doesn't have — so "send us the record" ended in a screenshot or a screen share.

## What this does

The History tab gets an **Export record** button. It builds one self-contained HTML file from the version history and hands it to the browser as a download, named `<document>-audit-record-<date>.html`.

The file states, for every published version:

- the version, and when it was published
- who submitted the change, when, and who published it
- the approvals — approver, verdict, timestamp, comment

Approvals that no longer count stay in the record, labelled *superseded by a later upload* or *dismissed*. Dropping them would be editing history; leaving them unlabelled would read as more approval than the version actually carried.

Requests for changes are **not** in the record. A request for changes is a step on the way, not an outcome — the published version underneath it exists precisely because that request was answered and the change was then approved. Printing it invites a question whose answer is the version already in the reader's hand.

It speaks Bindersnap's own vocabulary and nothing else — "approved", "version", "change". No tags, no commit hashes, no `owner/repo` paths: those are how a version is stored, not what it is, and the reader has no way to look any of them up. The lede makes the guarantee in plain words instead: a published version cannot be altered, and changing the document means a new version, reviewed again.

## It is a printed document

This ends up in an audit binder or attached to an email as a PDF, so it is set like paper, not like a web page:

- black on white, hairline rules, no fills, no coral
- sizes in points, `@page` margins, `break-inside: avoid` on each version
- headings that don't strand themselves at the bottom of a page, and table column headers that repeat when a long trail runs over
- opens with no network and no stylesheet beside it, so ⌘P → Save as PDF is the whole workflow

The brand is carried by the typography — the serif for headings, the sans for everything else — not by colour.

## How it fits the architecture

- **No new state.** Built client-side from the payload the History tab already loaded. Nothing is fetched, nothing is stored, and re-exporting the same document reproduces the same record — every fact in it is a fact Gitea already holds.
- **No new endpoint.** No BFF change, no Gitea change.
- **Self-contained.** A standalone export can't import `bindersnap-tokens.css`, so its (now monochrome) values are inlined as custom properties.

No `packages/editor/` visuals changed, so no `sync-demo` needed.

## Tests

- `apps/app/auditRecord.test.ts` — 12 tests over the pure builder: naming, ordering, the empty-record case, a version whose change record didn't survive, stale/dismissed labelling, that it says *approved* and never *signed off*, that a request for changes never reaches the page (and that a change with nothing but one reads as unapproved), that no tag or commit or repo path appears, and that nothing a person typed can become markup in a file that gets emailed around.
- `apps/app/components/DocumentHistory.test.ts` — the button renders and downloads a correctly named file.

`bun run test` is green (274 app + 360 ops + 12), `bun run build` succeeds, and the rendered export was checked in a browser.

Refs #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)